### PR TITLE
feat: load limits from environment variables (Fixes #10)

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -101,6 +101,25 @@ Or per network: `CONTRACT_ORACLE_TESTNET`, `CONTRACT_ORACLE_MAINNET`, etc.
 |----------|---------|-------------|
 | `BASKET_METRICS_INTERVAL_DAYS` | `30` | Days between metrics ingestion and proposed basket weight creation |
 
+## Limits (Deposit/Withdrawal & Circuit Breakers)
+
+| Variable | Default (USD) | Description |
+|----------|---------|-------------|
+| `LIMIT_RETAIL_DEPOSIT_DAILY_USD` | `5000` | Daily deposit limit for retail users |
+| `LIMIT_RETAIL_DEPOSIT_MONTHLY_USD` | `50000` | Monthly deposit limit for retail users |
+| `LIMIT_RETAIL_WITHDRAWAL_DAILY_USD` | `10000` | Daily withdrawal limit for retail users |
+| `LIMIT_RETAIL_WITHDRAWAL_MONTHLY_USD` | `80000` | Monthly withdrawal limit for retail users |
+| `LIMIT_BUSINESS_DEPOSIT_DAILY_USD` | `50000` | Daily deposit limit for business users |
+| `LIMIT_BUSINESS_DEPOSIT_MONTHLY_USD` | `500000` | Monthly deposit limit for business users |
+| `LIMIT_BUSINESS_WITHDRAWAL_DAILY_USD` | `100000` | Daily withdrawal limit for business users |
+| `LIMIT_BUSINESS_WITHDRAWAL_MONTHLY_USD` | `800000` | Monthly withdrawal limit for business users |
+| `LIMIT_GOV_DEPOSIT_DAILY_USD` | `500000` | Daily deposit limit for government users |
+| `LIMIT_GOV_DEPOSIT_MONTHLY_USD` | `5000000` | Monthly deposit limit for government users |
+| `LIMIT_GOV_WITHDRAWAL_DAILY_USD` | `500000` | Daily withdrawal limit for government users |
+| `LIMIT_GOV_WITHDRAWAL_MONTHLY_USD` | `4000000` | Monthly withdrawal limit for government users |
+| `LIMIT_CIRCUIT_BREAKER_RESERVE_WEIGHT_PCT`| `10` | Reserve % weight threshold circuit breaker |
+| `LIMIT_CIRCUIT_BREAKER_MIN_RATIO` | `1.02` | Minimum reserve ratio threshold circuit breaker |
+
 ## Reserve
 
 | Variable | Default | Description |

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -167,6 +167,32 @@ export const config = {
     secret: process.env.WEBHOOK_SECRET || '',
   },
 
+  // Limits
+  limits: {
+    retail: {
+      depositDailyUsd: parseInt(process.env.LIMIT_RETAIL_DEPOSIT_DAILY_USD || '5000', 10),
+      depositMonthlyUsd: parseInt(process.env.LIMIT_RETAIL_DEPOSIT_MONTHLY_USD || '50000', 10),
+      withdrawalSingleCurrencyDailyUsd: parseInt(process.env.LIMIT_RETAIL_WITHDRAWAL_DAILY_USD || '10000', 10),
+      withdrawalSingleCurrencyMonthlyUsd: parseInt(process.env.LIMIT_RETAIL_WITHDRAWAL_MONTHLY_USD || '80000', 10),
+    },
+    business: {
+      depositDailyUsd: parseInt(process.env.LIMIT_BUSINESS_DEPOSIT_DAILY_USD || '50000', 10),
+      depositMonthlyUsd: parseInt(process.env.LIMIT_BUSINESS_DEPOSIT_MONTHLY_USD || '500000', 10),
+      withdrawalSingleCurrencyDailyUsd: parseInt(process.env.LIMIT_BUSINESS_WITHDRAWAL_DAILY_USD || '100000', 10),
+      withdrawalSingleCurrencyMonthlyUsd: parseInt(process.env.LIMIT_BUSINESS_WITHDRAWAL_MONTHLY_USD || '800000', 10),
+    },
+    government: {
+      depositDailyUsd: parseInt(process.env.LIMIT_GOV_DEPOSIT_DAILY_USD || '500000', 10),
+      depositMonthlyUsd: parseInt(process.env.LIMIT_GOV_DEPOSIT_MONTHLY_USD || '5000000', 10),
+      withdrawalSingleCurrencyDailyUsd: parseInt(process.env.LIMIT_GOV_WITHDRAWAL_DAILY_USD || '500000', 10),
+      withdrawalSingleCurrencyMonthlyUsd: parseInt(process.env.LIMIT_GOV_WITHDRAWAL_MONTHLY_USD || '4000000', 10),
+    },
+    circuitBreaker: {
+      reserveWeightThresholdPct: parseFloat(process.env.LIMIT_CIRCUIT_BREAKER_RESERVE_WEIGHT_PCT || '10'),
+      minReserveRatio: parseFloat(process.env.LIMIT_CIRCUIT_BREAKER_MIN_RATIO || '1.02')
+    }
+  },
+
   // CORS
   corsOrigin: process.env.CORS_ORIGIN?.split(',') || ['http://localhost:3000'],
 };

--- a/src/config/limits.ts
+++ b/src/config/limits.ts
@@ -3,6 +3,7 @@
  * Aligned with LIMITS_AND_TIERS.MD.
  */
 import type { Audience } from '../middleware/auth';
+import { config } from './env';
 
 export interface LimitConfig {
   depositDailyUsd: number;
@@ -12,24 +13,9 @@ export interface LimitConfig {
 }
 
 const LIMITS: Record<Audience, LimitConfig> = {
-  retail: {
-    depositDailyUsd: 5_000,
-    depositMonthlyUsd: 50_000,
-    withdrawalSingleCurrencyDailyUsd: 10_000,
-    withdrawalSingleCurrencyMonthlyUsd: 80_000,
-  },
-  business: {
-    depositDailyUsd: 50_000,
-    depositMonthlyUsd: 500_000,
-    withdrawalSingleCurrencyDailyUsd: 100_000,
-    withdrawalSingleCurrencyMonthlyUsd: 800_000,
-  },
-  government: {
-    depositDailyUsd: 500_000,
-    depositMonthlyUsd: 5_000_000,
-    withdrawalSingleCurrencyDailyUsd: 500_000,
-    withdrawalSingleCurrencyMonthlyUsd: 4_000_000,
-  },
+  retail: config.limits.retail,
+  business: config.limits.business,
+  government: config.limits.government,
 };
 
 export function getLimitConfig(audience: Audience): LimitConfig {
@@ -37,7 +23,7 @@ export function getLimitConfig(audience: Audience): LimitConfig {
 }
 
 /** Circuit breaker: pause single-currency withdrawal if reserve below this % of target weight. */
-export const CIRCUIT_BREAKER_RESERVE_WEIGHT_THRESHOLD_PCT = 10;
+export const CIRCUIT_BREAKER_RESERVE_WEIGHT_THRESHOLD_PCT = config.limits.circuitBreaker.reserveWeightThresholdPct;
 
 /** Pause new minting if total reserve ratio below this (e.g. 1.02 = 102%). */
-export const CIRCUIT_BREAKER_MIN_RESERVE_RATIO = 1.02;
+export const CIRCUIT_BREAKER_MIN_RESERVE_RATIO = config.limits.circuitBreaker.minReserveRatio;


### PR DESCRIPTION
# Description
This PR addresses the hardcoded logic in [src/config/limits.ts](cci:7://file:///Users/arowolokehinde/Stellar-wave3/acbu-backend/src/config/limits.ts:0:0-0:0) by introducing fully configurable environment variables. Deposit, withdrawal, and circuit breaker limits are now driven safely via `.env` configuration while preserving the original fallback defaults.

Closes #10 


## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature / Enhancement (non-breaking change which adds configurable limits)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

## How to Test
1. Pull the branch locally.
2. In your `.env` file, try overriding one of the limit variables (e.g., `LIMIT_RETAIL_DEPOSIT_DAILY_USD=9999`).
3. Start the dev server and verify that [getLimitConfig('retail').depositDailyUsd](cci:1://file:///Users/arowolokehinde/Stellar-wave3/acbu-backend/src/config/limits.ts:20:0-22:1) evaluates to `9999`.
4. Without the variables in `.env`, verify it smoothly acts on the default hardcoded fallbacks without crashing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added environment-based configuration for deposit and withdrawal limits across retail, business, and government account types.
  * Introduced configurable circuit breaker thresholds for reserve protection.

* **Documentation**
  * Updated configuration documentation with new environment variable specifications for deposit/withdrawal daily and monthly caps and circuit breaker settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->