### PR TITLE
fix: enforce financial limits and circuit breakers on direct burn/mint routes

### DIFF
--- a/src/controllers/burnController.ts
+++ b/src/controllers/burnController.ts
@@ -56,24 +56,28 @@ export async function burnAcbu(
     const feeAcbu = (acbuNum * burnFeeBps) / 10000;
     const acbuAmount7 = Math.round(acbuNum * DECIMALS_7).toString();
 
-    if (req.audience) {
-      const paused = await isCurrencyWithdrawalPaused(currency);
-      if (paused) {
-        res.status(503).json({
-          error: "Withdrawal paused for currency",
-          code: "CIRCUIT_BREAKER",
-          message: `Single-currency withdrawals for ${currency} are temporarily paused (reserve below threshold). Basket withdrawals continue.`,
-        });
-        return;
-      }
-      await checkWithdrawalLimits(
-        req.audience,
-        acbuNum,
-        currency,
-        req.apiKey?.userId ?? null,
-        req.apiKey?.organizationId ?? null,
-      );
+    // SECURITY: Always enforce circuit breaker and withdrawal limits
+    // Previously these checks were skipped when req.audience was undefined,
+    // allowing bypass of critical financial controls via direct /burn/acbu route
+    const paused = await isCurrencyWithdrawalPaused(currency);
+    if (paused) {
+      res.status(503).json({
+        error: "Withdrawal paused for currency",
+        code: "CIRCUIT_BREAKER",
+        message: `Single-currency withdrawals for ${currency} are temporarily paused (reserve below threshold). Basket withdrawals continue.`,
+      });
+      return;
     }
+
+    // Apply withdrawal limits - use retail as default if no audience is set
+    const audience = req.audience || "retail";
+    await checkWithdrawalLimits(
+      audience,
+      acbuNum,
+      currency,
+      req.apiKey?.userId ?? null,
+      req.apiKey?.organizationId ?? null,
+    );
 
     const tx = await prisma.transaction.create({
       data: {

--- a/src/controllers/mintController.ts
+++ b/src/controllers/mintController.ts
@@ -59,24 +59,28 @@ export async function mintFromUsdc(
     }
     const { usdc_amount, wallet_address } = parsed.data;
     const usdcNum = Number(usdc_amount);
-    if (req.audience) {
-      const paused = await isMintingPaused();
-      if (paused) {
-        res.status(503).json({
-          error: "Minting paused",
-          code: "CIRCUIT_BREAKER",
-          message:
-            "New minting is temporarily paused (reserve ratio below 102%).",
-        });
-        return;
-      }
-      await checkDepositLimits(
-        req.audience,
-        usdcNum,
-        userId,
-        req.apiKey?.organizationId ?? null,
-      );
+    // SECURITY: Always enforce circuit breaker and deposit limits
+    // Previously these checks were skipped when req.audience was undefined,
+    // allowing bypass of critical financial controls via direct /mint/usdc route
+    const paused = await isMintingPaused();
+    if (paused) {
+      res.status(503).json({
+        error: "Minting paused",
+        code: "CIRCUIT_BREAKER",
+        message:
+          "New minting is temporarily paused (reserve ratio below 102%).",
+      });
+      return;
     }
+
+    // Apply deposit limits - use retail as default if no audience is set
+    const audience = req.audience || "retail";
+    await checkDepositLimits(
+      audience,
+      usdcNum,
+      userId,
+      req.apiKey?.organizationId ?? null,
+    );
     const swap = await prisma.onRampSwap.create({
       data: {
         userId,
@@ -191,25 +195,29 @@ export async function depositFromBasketCurrency(
       return;
     }
     const amountNum = Number(amount);
-    if (req.audience) {
-      const paused = await isMintingPaused();
-      if (paused) {
-        res.status(503).json({
-          error: "Minting paused",
-          code: "CIRCUIT_BREAKER",
-          message:
-            "New minting is temporarily paused (reserve ratio below 102%).",
-        });
-        return;
-      }
-      const amountUsdPlaceholder = amountNum; // TODO: convert via rate to USD for accurate limit
-      await checkDepositLimits(
-        req.audience,
-        amountUsdPlaceholder,
-        req.apiKey?.userId ?? null,
-        req.apiKey?.organizationId ?? null,
-      );
+    // SECURITY: Always enforce circuit breaker and deposit limits
+    // Previously these checks were skipped when req.audience was undefined,
+    // allowing bypass of critical financial controls via direct /mint/deposit route
+    const paused = await isMintingPaused();
+    if (paused) {
+      res.status(503).json({
+        error: "Minting paused",
+        code: "CIRCUIT_BREAKER",
+        message:
+          "New minting is temporarily paused (reserve ratio below 102%).",
+      });
+      return;
     }
+
+    // Apply deposit limits - use retail as default if no audience is set
+    const audience = req.audience || "retail";
+    const amountUsdPlaceholder = amountNum; // TODO: convert via rate to USD for accurate limit
+    await checkDepositLimits(
+      audience,
+      amountUsdPlaceholder,
+      req.apiKey?.userId ?? null,
+      req.apiKey?.organizationId ?? null,
+    );
     const tx = await prisma.transaction.create({
       data: {
         userId: req.apiKey?.userId ?? undefined,


### PR DESCRIPTION
Fixed issue where checkWithdrawalLimits and isCurrencyWithdrawalPaused only 
run when req.audience is set. The /burn/acbu route via burnRoutes does not 
set audience, allowing limits and circuit breakers to be skipped.

Also fixed similar issue in mintController where deposit limits and minting 
circuit breakers could be bypassed on direct /mint/* routes.

- Remove conditional req.audience checks in burn and mint controllers
- Always enforce withdrawal/deposit limits using retail as default audience
- Always run circuit breaker checks regardless of audience context

closes #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved consistency of withdrawal safety checks for burn operations across all request types.
  * Improved consistency of deposit safety checks for mint operations across all request types.
  * Enhanced circuit-breaker protections now apply uniformly to all transactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->