### PR TITLE
Fix: sanitize error logs to prevent stack trace and PII leakage

### DIFF
--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -13,6 +13,22 @@ export class AppError extends Error {
   }
 }
 
+/**
+ * Sanitize an error for logging: strip stack traces in production
+ * and ensure no PII or secrets leak into log output.
+ */
+function sanitizeForLog(err: Error, req: Request) {
+  const isProduction = process.env.NODE_ENV === "production";
+
+  return {
+    message: err.message,
+    name: err.name,
+    path: req.path,
+    method: req.method,
+    ...(isProduction ? {} : { stack: err.stack }),
+  };
+}
+
 export const errorHandler = (
   err: Error | AppError,
   req: Request,
@@ -36,14 +52,8 @@ export const errorHandler = (
     return;
   }
 
-  // Unexpected errors
-  logger.error("Unexpected error", {
-    error: err,
-    message: err.message,
-    stack: err.stack,
-    path: req.path,
-    method: req.method,
-  });
+  // Unexpected errors: log sanitized details, never expose internals to client
+  logger.error("Unexpected error", sanitizeForLog(err, req));
 
   res.status(500).json({
     error: {


### PR DESCRIPTION
## Description

The error handler was logging the full error object (including stack traces, nested request data, and potentially sensitive information) to the logger. This could expose PII or secrets in log aggregation systems.

## Changes

- Add `sanitizeForLog()` helper that extracts only safe fields: message, name, path, method
- Include stack traces only in non-production environments
- Never pass the raw error object to the logger
- Client-facing response remains unchanged (generic "Internal server error")

## How to test

- Trigger a 500 error and verify logs contain only sanitized fields
- In production mode (`NODE_ENV=production`), verify stack traces are omitted

Closes #14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved error logging to use structured information (message, name, path, method) with selective stack trace inclusion based on environment settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->