### PR TITLE
Fix: move env validation before config object construction

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -2,6 +2,27 @@ import dotenv from "dotenv";
 
 dotenv.config();
 
+// ── Validate required env vars BEFORE building config ────────────────────────
+// This ensures the app fails fast with a clear message instead of starting
+// with empty strings and failing later in an unpredictable way.
+const requiredEnvVars = [
+  "DATABASE_URL",
+  "MONGODB_URI",
+  "RABBITMQ_URL",
+  "JWT_SECRET",
+];
+
+if (process.env.NODE_ENV === "production") {
+  requiredEnvVars.push("PRISMA_ACCELERATE_URL");
+}
+
+const missing = requiredEnvVars.filter((v) => !process.env[v]);
+if (missing.length > 0) {
+  throw new Error(
+    `Missing required environment variable(s): ${missing.join(", ")}`,
+  );
+}
+
 export const config = {
   // Server
   nodeEnv: process.env.NODE_ENV || "development",
@@ -304,21 +325,3 @@ export const config = {
   // CORS
   corsOrigin: process.env.CORS_ORIGIN?.split(",") || ["http://localhost:3000"],
 };
-
-// Validate required environment variables
-const requiredEnvVars = [
-  "DATABASE_URL",
-  "MONGODB_URI",
-  "RABBITMQ_URL",
-  "JWT_SECRET",
-];
-
-if (config.nodeEnv === "production") {
-  requiredEnvVars.push("PRISMA_ACCELERATE_URL");
-}
-
-for (const envVar of requiredEnvVars) {
-  if (!process.env[envVar]) {
-    throw new Error(`Missing required environment variable: ${envVar}`);
-  }
-}


### PR DESCRIPTION
## Description

Environment variable validation ran after the config object was already built with empty-string fallbacks. If DATABASE_URL was missing, the app could start and fail later with a cryptic database connection error instead of a clear "missing env var" message.

## Changes

- Move validation to run immediately after `dotenv.config()`, before the config object is constructed
- Report all missing variables at once (instead of failing on the first one)
- Remove the duplicate validation block that was at the bottom of the file

## How to test

- Unset `DATABASE_URL` and start the app: should fail immediately with a clear error message listing all missing vars
- Set all required vars: app should start normally

Closes #28

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error reporting for missing environment variables—all missing variables are now displayed together in a single message rather than reported one at a time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->