### PR TITLE
added max retry limit "No max retry limit for webhook consumer

### DIFF
--- a/src/config/rabbitmq.ts
+++ b/src/config/rabbitmq.ts
@@ -61,6 +61,7 @@ export const QUEUES = {
   NOTIFICATIONS: "notifications",
   OTP_SEND: "otp_send", // OTP delivery (email/SMS) via worker
   WEBHOOKS: "webhooks",
+  WEBHOOKS_DLQ: "webhooks_dlq", // failed webhook deliveries for retry
   KYC_PROCESSING: "kyc_processing",
   WALLET_ACTIVATION: "wallet_activation", // send XLM to user wallet when KYC fee paid
   ACBU_SAVINGS_VAULT_EVENTS: "acbu_savings_vault_events",

--- a/src/jobs/webhookConsumer.ts
+++ b/src/jobs/webhookConsumer.ts
@@ -10,33 +10,104 @@ interface WebhookJobPayload {
   webhookId: string;
 }
 
+const MAX_RETRIES = 5;
+
 export async function startWebhookConsumer(): Promise<void> {
   const ch = await connectRabbitMQ();
-  await ch.assertQueue(QUEUES.WEBHOOKS, { durable: true });
+
+  // Main queue with DLQ configuration
+  await ch.assertQueue(QUEUES.WEBHOOKS, {
+    durable: true,
+    arguments: {
+      "x-dead-letter-exchange": "",
+      "x-dead-letter-routing-key": QUEUES.WEBHOOKS_DLQ,
+    },
+  });
+
+  // Dead-letter queue
+  await ch.assertQueue(QUEUES.WEBHOOKS_DLQ, {
+    durable: true,
+  });
+
   ch.prefetch(1);
+
   ch.consume(
     QUEUES.WEBHOOKS,
     async (msg: ConsumeMessage | null) => {
       if (!msg) return;
+
+      const headers = msg.properties.headers ?? {};
+      const retries =
+        typeof headers["x-retries"] === "number"
+          ? headers["x-retries"]
+          : 0;
+
       try {
-        const body = JSON.parse(msg.content.toString()) as WebhookJobPayload;
+        const body = JSON.parse(
+          msg.content.toString()
+        ) as WebhookJobPayload;
+
         const { webhookId } = body;
+
         if (!webhookId) {
           ch.ack(msg);
           return;
         }
+
         const ok = await deliverWebhook(webhookId);
+
         if (ok) {
           ch.ack(msg);
-        } else {
-          ch.nack(msg, false, true);
+          return;
         }
-      } catch (e) {
-        logger.error("Webhook consumer error", { error: e });
-        ch.nack(msg, false, true);
+
+        //  Failed delivery
+        if (retries >= MAX_RETRIES) {
+          logger.error("Webhook failed permanently", {
+            webhookId,
+            retries,
+          });
+
+          // send to DLQ
+          ch.nack(msg, false, false);
+          return;
+        }
+
+        // Retry with incremented header
+        ch.sendToQueue(QUEUES.WEBHOOKS, msg.content, {
+          persistent: true,
+          headers: {
+            ...headers,
+            "x-retries": retries + 1,
+          },
+        });
+
+        ch.ack(msg);
+      } catch (error) {
+        logger.error("Webhook consumer error", { error });
+
+        if (retries >= MAX_RETRIES) {
+          // send to DLQ
+          ch.nack(msg, false, false);
+          return;
+        }
+
+        // retry on processing error
+        ch.sendToQueue(QUEUES.WEBHOOKS, msg.content, {
+          persistent: true,
+          headers: {
+            ...headers,
+            "x-retries": retries + 1,
+          },
+        });
+
+        ch.ack(msg);
       }
     },
-    { noAck: false },
+    { noAck: false }
   );
-  logger.info("Webhook consumer started", { queue: QUEUES.WEBHOOKS });
+
+  logger.info("Webhook consumer started", {
+    queue: QUEUES.WEBHOOKS,
+  });
 }


### PR DESCRIPTION
Fixes #36"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved webhook delivery reliability with automatic retry logic: failed webhooks are automatically retried up to 5 times instead of being immediately requeued.
  * Added dead-letter queue support to track and store webhook messages that fail after all retry attempts, enabling better monitoring and troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->