### PR TITLE
fix: reject webhooks when Flutterwave secret is not configured

### DIFF
--- a/src/controllers/webhookController.ts
+++ b/src/controllers/webhookController.ts
@@ -15,8 +15,13 @@ export function verifyFlutterwaveSignature(
 ): void {
   const secret = config.flutterwave.webhookSecret;
   if (!secret) {
-    logger.warn("Flutterwave webhook secret not set; skipping verification");
-    next();
+    logger.error(
+      "FLUTTERWAVE_WEBHOOK_SECRET is not configured — rejecting webhook. " +
+        "Set the environment variable to accept Flutterwave webhooks.",
+    );
+    res.status(503).json({
+      error: "Webhook verification unavailable: secret not configured",
+    });
     return;
   }
   const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;


### PR DESCRIPTION
Closes #48

## Summary
Fixes a security vulnerability where `verifyFlutterwaveSignature` called `next()` and skipped verification when `FLUTTERWAVE_WEBHOOK_SECRET` was unset, allowing forged webhooks to be processed.

## Changes
- Changed the missing-secret path in `verifyFlutterwaveSignature` from `next()` (skip verification) to `res.status(503)` (reject request)
- Logs at `error` level instead of `warn` to ensure visibility in monitoring
- Error message instructs operators to set the environment variable

## Before
```
secret not set → logger.warn() → next() → webhook processed without verification
```

## After
```
secret not set → logger.error() → 503 response → webhook rejected
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced webhook handling to reject incoming webhooks when verification cannot be completed, ensuring only properly verified webhook events are processed by the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->