### PR TITLE
feat: implement OpenAI Vision KYC document extraction

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",
     "mongodb": "^6.3.0",
+    "openai": "^6.32.0",
     "otplib": "^12.0.1",
     "qrcode": "^1.5.4",
     "stellar-sdk": "^11.2.2",

--- a/src/services/kyc/machineLayer.ts
+++ b/src/services/kyc/machineLayer.ts
@@ -2,10 +2,12 @@
  * Machine automation: ingest docs, extract (AI/OCR), redact, confidence, route.
  * When KYC_MACHINE_PROVIDER=none, skips extraction and routes to human review.
  */
+import OpenAI from "openai";
 import { prisma } from "../../config/database";
 import { config } from "../../config/env";
 import { logger } from "../../config/logger";
 import { afterMachineProcessing } from "./applicationService";
+import { getDocumentBuffer } from "./storage";
 import type { MachineExtractedPayload, MachineRedactedPayload } from "./types";
 
 const PROVIDER = config.kyc.machineProvider;
@@ -48,7 +50,9 @@ export async function processApplication(applicationId: string): Promise<void> {
 }
 
 /**
- * OpenAI-based extraction (placeholder: real impl would call Vision API and redact).
+ * OpenAI Vision-based extraction: fetches document images from storage,
+ * sends them to GPT-4o for structured data extraction, then computes a
+ * confidence score based on how many fields were successfully extracted.
  */
 async function extractWithOpenAI(
   documents: { kind: string; storageRef: string }[],
@@ -57,12 +61,124 @@ async function extractWithOpenAI(
   redacted: MachineRedactedPayload;
   confidence: number;
 }> {
-  // Placeholder: no doc bytes fetched here. Real impl would use storage.get() and call OpenAI.
-  const extracted: MachineExtractedPayload = {};
+  const openai = new OpenAI({ apiKey: config.kyc.openaiApiKey });
+
+  // Fetch document images from object storage
+  const imageContents: OpenAI.Chat.Completions.ChatCompletionContentPart[] = [];
+  const hints: string[] = [];
+
+  for (const doc of documents) {
+    try {
+      const buffer = await getDocumentBuffer(doc.storageRef);
+      const base64 = buffer.toString("base64");
+      const mimeType = doc.kind === "selfie" ? "image/jpeg" : "image/png";
+
+      imageContents.push({
+        type: "image_url",
+        image_url: {
+          url: `data:${mimeType};base64,${base64}`,
+          detail: "high",
+        },
+      });
+      hints.push(`${doc.kind}_uploaded`);
+    } catch (err) {
+      logger.warn(`Failed to fetch document ${doc.kind} from storage`, { err });
+      hints.push(`${doc.kind}_fetch_failed`);
+    }
+  }
+
+  if (imageContents.length === 0) {
+    logger.warn("No documents could be fetched from storage for extraction");
+    return {
+      extracted: {},
+      redacted: { hints, unreadableRegions: ["all"] },
+      confidence: 0,
+    };
+  }
+
+  // Call OpenAI Vision to extract structured data
+  let extracted: MachineExtractedPayload = {};
+  const unreadableRegions: string[] = [];
+
+  try {
+    const response = await openai.chat.completions.create({
+      model: "gpt-4o",
+      max_tokens: 1000,
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a KYC document extraction assistant. Extract structured identity data from the provided document images. " +
+            "Return ONLY valid JSON with these fields (omit any field you cannot read): " +
+            '{"documentType": "passport|national_id|drivers_license", "name": "full legal name", ' +
+            '"dateOfBirth": "YYYY-MM-DD", "documentNumber": "the ID number", "nationality": "country name"}. ' +
+            "If a field is unreadable or obscured, do not include it. Do not hallucinate data.",
+        },
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: "Extract the identity information from these KYC documents:",
+            },
+            ...imageContents,
+          ],
+        },
+      ],
+    });
+
+    const content = response.choices[0]?.message?.content?.trim() ?? "";
+
+    // Parse the JSON response, stripping markdown code fences if present
+    const jsonStr = content.replace(/^```json?\s*/i, "").replace(/\s*```$/i, "");
+    const parsed = JSON.parse(jsonStr);
+
+    extracted = {
+      documentType: parsed.documentType ?? undefined,
+      name: parsed.name ?? undefined,
+      dateOfBirth: parsed.dateOfBirth ?? undefined,
+      documentNumber: parsed.documentNumber ?? undefined,
+      nationality: parsed.nationality ?? undefined,
+    };
+
+    // Track which fields were extracted for hint reporting
+    if (extracted.name) hints.push("name_extracted");
+    if (extracted.dateOfBirth) hints.push("dob_extracted");
+    if (extracted.documentNumber) hints.push("doc_number_extracted");
+    if (extracted.documentType) hints.push("doc_type_extracted");
+    if (extracted.nationality) hints.push("nationality_extracted");
+  } catch (err) {
+    logger.error("OpenAI Vision extraction failed", { err });
+    unreadableRegions.push("all");
+    hints.push("extraction_error");
+  }
+
+  // Compute confidence based on number of fields extracted (5 possible fields)
+  const fieldCount = [
+    extracted.documentType,
+    extracted.name,
+    extracted.dateOfBirth,
+    extracted.documentNumber,
+    extracted.nationality,
+  ].filter(Boolean).length;
+
+  const hasIdDoc = documents.some((d) => d.kind === "id_front" || d.kind === "id_back");
+  const hasSelfie = documents.some((d) => d.kind === "selfie");
+  const docBonus = hasIdDoc && hasSelfie ? 0.05 : 0;
+
+  // Base: 0.2 per field (max 1.0) + bonus for complete doc set
+  const confidence = Math.min(1, fieldCount * 0.2 + docBonus);
+
   const redacted: MachineRedactedPayload = {
-    hints: documents.length >= 2 ? ["documents_uploaded"] : [],
-    unreadableRegions: [],
+    hints,
+    unreadableRegions,
   };
-  const confidence = 0.5; // Conservative when we don't actually call OpenAI yet
+
+  logger.info("OpenAI extraction complete", {
+    fieldCount,
+    confidence,
+    hints,
+  });
+
   return { extracted, redacted, confidence };
 }

--- a/src/services/kyc/storage.ts
+++ b/src/services/kyc/storage.ts
@@ -106,6 +106,22 @@ export async function put(
 }
 
 /**
+ * Download a document from object storage and return it as a Buffer.
+ */
+export async function getDocumentBuffer(key: string): Promise<Buffer> {
+  const client = getClient();
+  const command = new GetObjectCommand({ Bucket: BUCKET, Key: key });
+  const response = await client.send(command);
+  const stream = response.Body;
+  if (!stream) throw new Error(`Empty body for key ${key}`);
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of stream as AsyncIterable<Uint8Array>) {
+    chunks.push(chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+/**
  * Check if object store is configured (bucket + client). Does not validate credentials.
  */
 export function isConfigured(): boolean {


### PR DESCRIPTION
Closes #42

## Summary
Replaces the placeholder `extractWithOpenAI()` function with a real implementation that fetches documents from S3/MinIO, sends them to GPT-4o Vision for structured data extraction, and computes a confidence score.

## Changes
- **`src/services/kyc/machineLayer.ts`** — Full OpenAI Vision implementation:
  - Fetches document images from object storage via `getDocumentBuffer()`
  - Sends base64-encoded images to GPT-4o with a structured extraction prompt
  - Parses JSON response for: documentType, name, dateOfBirth, documentNumber, nationality
  - Computes confidence score: 0.2 per extracted field + 0.05 bonus for complete doc set (ID + selfie)
  - Graceful error handling for storage fetch failures and API errors
- **`src/services/kyc/storage.ts`** — Added `getDocumentBuffer(key)` to download documents as Buffer from S3
- **`package.json`** — Added `openai` dependency

## Confidence Scoring
| Fields Extracted | ID + Selfie | Confidence |
|---|---|---|
| 0 | - | 0.0 |
| 3 | No | 0.6 |
| 4 | Yes | 0.85 |
| 5 | Yes | 1.0 |

Auto-approval threshold is `KYC_MACHINE_CONFIDENCE_THRESHOLD` (default 0.95), so 5/5 fields + complete docs = auto-approve.