### PR TITLE
fix: aggregate byCurrency from transactions and reserve exposure (#55)

### DIFF
--- a/src/controllers/governmentController.ts
+++ b/src/controllers/governmentController.ts
@@ -3,6 +3,7 @@
  * For government actors (actorType === 'government'); reuse enterprise-style aggregates.
  */
 import { Response, NextFunction } from "express";
+import { Prisma, Reserve } from "@prisma/client";
 import { prisma } from "../config/database";
 import { AuthRequest } from "../middleware/auth";
 
@@ -35,33 +36,42 @@ export async function getGovernmentTreasury(
       (minted._sum.acbuAmount?.toNumber() ?? 0) -
       (burned._sum.acbuAmountBurned?.toNumber() ?? 0);
 
-    const burnsByCurrency = await prisma.transaction.groupBy({
-      by: ["localCurrency"],
-      where: {
-        type: "burn",
-        status: { in: ["completed", "processing"] },
-        localCurrency: { not: null },
-        ...(userId ? { userId } : { user: { organizationId } }),
-      },
-      _sum: { localAmount: true, acbuAmountBurned: true },
-    });
+    const burnsByCurrency: Prisma.TransactionGroupByOutputType[] =
+      await prisma.transaction.groupBy({
+        by: ["localCurrency"],
+        where: {
+          type: "burn",
+          status: { in: ["completed", "processing"] },
+          localCurrency: { not: null },
+          ...(userId ? { userId } : { user: { organizationId } }),
+        },
+        _sum: { localAmount: true, acbuAmountBurned: true },
+      });
 
-    const latestReserves = await prisma.reserve.findMany({
+    const latestReserves = (await prisma.reserve.findMany({
       where: { segment: "transactions" },
       orderBy: { timestamp: "desc" },
       distinct: ["currency"],
-    });
+    })) as Reserve[];
 
-    const reserveMap = new Map(latestReserves.map((r) => [r.currency, r]));
+    const reserveMap = new Map<string, Reserve>(
+      latestReserves.map((r) => [r.currency, r]),
+    );
 
     const byCurrency = burnsByCurrency
-      .filter((b) => b.localCurrency !== null)
+      .filter(
+        (
+          b,
+        ): b is Prisma.TransactionGroupByOutputType & {
+          localCurrency: string;
+        } => b.localCurrency !== null,
+      )
       .map((b) => {
-        const reserve = reserveMap.get(b.localCurrency!);
+        const reserve = reserveMap.get(b.localCurrency);
         return {
-          currency: b.localCurrency!,
-          burnedLocalAmount: b._sum.localAmount?.toNumber() ?? 0,
-          acbuBurned: b._sum.acbuAmountBurned?.toNumber() ?? 0,
+          currency: b.localCurrency,
+          burnedLocalAmount: b._sum?.localAmount?.toNumber() ?? 0,
+          acbuBurned: b._sum?.acbuAmountBurned?.toNumber() ?? 0,
           reserveExposure: reserve?.reserveAmount.toNumber() ?? 0,
           reserveValueUsd: reserve?.reserveValueUsd.toNumber() ?? 0,
         };


### PR DESCRIPTION
## Summary

- Replaced hardcoded `byCurrency: []` with actual per-currency aggregation from burn transactions scoped to the requesting org/user
- Added reserve exposure per currency by fetching the latest snapshot from the `reserves` table (segment: `transactions`)
- Each entry in `byCurrency` now includes: `currency`, `burnedLocalAmount`, `acbuBurned`, `reserveExposure`, and `reserveValueUsd`

## Changes

- `src/controllers/governmentController.ts`: implemented `groupBy` on burn transactions by `localCurrency`, cross-referenced with latest reserve snapshots to populate `byCurrency`

## Test plan

- [ ] Call `GET /v1/government/treasury` with a government API key that has burn transactions — verify `byCurrency` is non-empty and grouped correctly by currency
- [ ] Call with an API key that has no burn transactions — verify `byCurrency` returns `[]`
- [ ] Verify `reserveExposure` and `reserveValueUsd` reflect current reserve snapshots
- [ ] Verify `totalBalanceAcbu` is unaffected

Closes #55


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Treasury view now shows a per-currency breakdown including burned totals and ACBU burned.
  * Each currency row includes reserve exposure and reserve value in USD, with totals reflecting net minted minus burned ACBU.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->