### PR TITLE
fix: convert acbuAmount to Decimal type in transferService

### DIFF
--- a/src/services/transfer/transferService.ts
+++ b/src/services/transfer/transferService.ts
@@ -3,6 +3,7 @@
  * Uses direct wallets (G...). When getSenderSigningKey is provided, signs and submits; otherwise leaves pending.
  */
 import { Operation, Asset, Keypair, TransactionBuilder } from "stellar-sdk";
+import { Decimal } from "@prisma/client/runtime/library";
 import { prisma } from "../../config/database";
 import { stellarClient } from "../stellar/client";
 import { getBaseFee } from "../stellar/feeManager";
@@ -101,7 +102,7 @@ export async function createTransfer(
       type: "transfer",
       status: "pending",
       recipientAddress,
-      acbuAmount: amount,
+      acbuAmount: new Decimal(amount),
     },
   });
 


### PR DESCRIPTION
acbuAmount was being passed as a string to prisma.transaction.create(), but the schema expects a Decimal type. This can cause type or precision issues. Convert the string amount to Decimal using new Decimal() before passing to Prisma, consistent with the pattern used in mintController.ts and rewardService.ts.

The amount string is already validated to ensure it's a positive number with up to 7 decimal places before conversion.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved precision handling for transfer amounts to ensure accurate storage and calculation of transaction values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
CLOSE #34 