### PR TITLE
fix: replace manual env validation with Zod schema for fail-fast startup

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,57 +1,56 @@
 import dotenv from "dotenv";
+import { z } from "zod";
 
 dotenv.config();
 
-// ── Validate required env vars BEFORE building config ────────────────────────
-// This ensures the app fails fast with a clear message instead of starting
-// with empty strings and failing later in an unpredictable way.
-const requiredEnvVars = [
-  "DATABASE_URL",
-  "MONGODB_URI",
-  "RABBITMQ_URL",
-  "JWT_SECRET",
-];
+const envSchema = z.object({
+  NODE_ENV: z.string().default("development"),
+  PORT: z.coerce.number().default(5000),
+  API_VERSION: z.string().default("v1"),
+  DATABASE_URL: z.string().min(1),
+  MONGODB_URI: z.string().min(1),
+  RABBITMQ_URL: z.string().min(1),
+  JWT_SECRET: z.string().min(1),
+  PRISMA_ACCELERATE_URL: z.string().optional(),
+  JWT_EXPIRES_IN: z.string().default("7d"),
+  API_KEY_SALT: z.string().default(""),
+  RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60000),
+  RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(100),
+});
 
-if (process.env.NODE_ENV === "production") {
-  requiredEnvVars.push("PRISMA_ACCELERATE_URL");
+const parsed = envSchema.safeParse(process.env);
+
+if (!parsed.success) {
+  const messages = parsed.error.issues
+    .map((i) => `${i.path.join(".")}: ${i.message}`)
+    .join("\n");
+  throw new Error(`Invalid environment variables:\n${messages}`);
 }
 
-const missing = requiredEnvVars.filter((v) => !process.env[v]);
-if (missing.length > 0) {
+if (
+  parsed.data.NODE_ENV === "production" &&
+  !parsed.data.PRISMA_ACCELERATE_URL
+) {
   throw new Error(
-    `Missing required environment variable(s): ${missing.join(", ")}`,
+    "Missing required environment variable: PRISMA_ACCELERATE_URL",
   );
 }
 
+const env = parsed.data;
+
 export const config = {
-  // Server
-  nodeEnv: process.env.NODE_ENV || "development",
-  port: parseInt(process.env.PORT || "5000", 10),
-  apiVersion: process.env.API_VERSION || "v1",
-
-  // Database
-  databaseUrl: process.env.DATABASE_URL || "",
-  prismaAccelerateUrl: process.env.PRISMA_ACCELERATE_URL || "",
-
-  // MongoDB
-  mongodbUri: process.env.MONGODB_URI || "",
-
-  // RabbitMQ
-  rabbitmqUrl: process.env.RABBITMQ_URL || "",
-
-  // JWT
-  jwtSecret: process.env.JWT_SECRET || "",
-  jwtExpiresIn: process.env.JWT_EXPIRES_IN || "7d",
-
-  // API Security
-  apiKeySalt: process.env.API_KEY_SALT || "",
-
-  // Rate Limiting
-  rateLimitWindowMs: parseInt(process.env.RATE_LIMIT_WINDOW_MS || "60000", 10),
-  rateLimitMaxRequests: parseInt(
-    process.env.RATE_LIMIT_MAX_REQUESTS || "100",
-    10,
-  ),
+  nodeEnv: env.NODE_ENV,
+  port: env.PORT,
+  apiVersion: env.API_VERSION,
+  databaseUrl: env.DATABASE_URL,
+  prismaAccelerateUrl: env.PRISMA_ACCELERATE_URL,
+  mongodbUri: env.MONGODB_URI,
+  rabbitmqUrl: env.RABBITMQ_URL,
+  jwtSecret: env.JWT_SECRET,
+  jwtExpiresIn: env.JWT_EXPIRES_IN,
+  apiKeySalt: env.API_KEY_SALT,
+  rateLimitWindowMs: env.RATE_LIMIT_WINDOW_MS,
+  rateLimitMaxRequests: env.RATE_LIMIT_MAX_REQUESTS,
 
   // Logging
   logLevel: process.env.LOG_LEVEL || "info",

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -1,0 +1,38 @@
+describe("env validation", () => {
+  const ORIGINAL = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...ORIGINAL };
+  });
+
+  afterAll(() => {
+    process.env = ORIGINAL;
+  });
+
+  it("throws when JWT_SECRET is missing", () => {
+    delete process.env.JWT_SECRET;
+    expect(() => require("../src/config/env")).toThrow(/JWT_SECRET/);
+  });
+
+  it("throws when DATABASE_URL is missing", () => {
+    delete process.env.DATABASE_URL;
+    expect(() => require("../src/config/env")).toThrow(/DATABASE_URL/);
+  });
+
+  it("throws when MONGODB_URI is missing", () => {
+    delete process.env.MONGODB_URI;
+    expect(() => require("../src/config/env")).toThrow(/MONGODB_URI/);
+  });
+
+  it("loads successfully with all required vars set", () => {
+    expect(() => require("../src/config/env")).not.toThrow();
+  });
+
+  it("coerces PORT to a number", () => {
+    process.env.PORT = "3000";
+    const { config } = require("../src/config/env");
+    expect(typeof config.port).toBe("number");
+    expect(config.port).toBe(3000);
+  });
+});


### PR DESCRIPTION
Closes #176

The previous env validation was a manually maintained array that only 
checked for presence. Secrets like JWT_SECRET could still resolve to 
empty strings via the || "" fallbacks in the config object, meaning the 
app could start in a broken state without any clear error.

This replaces the manual check with a Zod schema that validates and 
coerces all required vars at startup. If anything critical is missing, 
the process throws before the server binds to a port.

Also restored prismaAccelerateUrl in the exported config to fix a 
compile regression introduced during the refactor.

**Changes**
- src/config/env.ts — Zod schema replaces manual requiredEnvVars check
- tests/env.test.ts — new tests covering missing secrets and type coercion

**Verified**
- npm run build passes with no TS errors
- All 5 env tests pass
- Removing JWT_SECRET blocks startup with: "Invalid environment variables: JWT_SECRET: Required"
- Acceptance check: missing JWT_SECRET prevents listen 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Upgraded environment configuration validation with stricter enforcement of required variables, improved error messages for missing configuration, and automatic type conversion for configuration values.

* **Tests**
  * Added test suite for environment configuration validation, verifying proper error handling for missing variables and correct value type conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->