### PR TITLE
feat:Client-supplied mint recipient vs user wallet

### DIFF
--- a/src/controllers/mintController.test.ts
+++ b/src/controllers/mintController.test.ts
@@ -1,0 +1,77 @@
+import { depositFromBasketCurrency } from "./mintController";
+import { prisma } from "../config/database";
+import { AppError } from "../middleware/errorHandler";
+import type { AuthRequest } from "../middleware/auth";
+import type { Response, NextFunction } from "express";
+
+jest.mock("../config/database", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+    transaction: {
+      create: jest.fn(),
+    },
+  },
+}));
+
+const makeRes = () => {
+  const res = { status: jest.fn(), json: jest.fn() } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  (res.json as jest.Mock).mockReturnValue(res);
+  return res;
+};
+
+const makeNext = () => jest.fn() as jest.MockedFunction<NextFunction>;
+
+const mockedUserFindUnique = prisma.user.findUnique as jest.Mock;
+
+describe("mintController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("rejects /mint/deposit when API key has no user context", async () => {
+    const res = makeRes();
+    const next = makeNext();
+    await depositFromBasketCurrency(
+      {
+        body: {
+          currency: "NGN",
+          amount: "100",
+          wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        },
+      } as AuthRequest,
+      res,
+      next,
+    );
+
+    const err = (next as jest.Mock).mock.calls[0][0] as AppError;
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(401);
+    expect(err.message).toBe("User context required for deposit");
+  });
+
+  it("rejects /mint/deposit when wallet_address does not match the user's stored wallet", async () => {
+    mockedUserFindUnique.mockResolvedValue({ stellarAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" });
+    const res = makeRes();
+    const next = makeNext();
+    await depositFromBasketCurrency(
+      {
+        apiKey: { id: "key-1", userId: "user-1", organizationId: null, permissions: [], rateLimit: 100 },
+        body: {
+          currency: "NGN",
+          amount: "100",
+          wallet_address: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+        },
+      } as AuthRequest,
+      res,
+      next,
+    );
+
+    const err = (next as jest.Mock).mock.calls[0][0] as AppError;
+    expect(err).toBeInstanceOf(AppError);
+    expect(err.statusCode).toBe(403);
+    expect(err.message).toBe("Wallet address does not match user");
+  });
+});

--- a/src/controllers/mintController.ts
+++ b/src/controllers/mintController.ts
@@ -22,6 +22,7 @@ import {
 } from "../services/limits/limitsService";
 import { enqueueUsdcConvertAndMint } from "../jobs/usdcConvertAndMintJob";
 import { AppError } from "../middleware/errorHandler";
+import { assertUserWalletAddress } from "../services/wallet/walletService";
 
 const MINT_FEE_BPS = 30; // 0.3%
 const DECIMALS_7 = 1e7;
@@ -37,26 +38,6 @@ const usdcBodySchema = z.object({
   wallet_address: z.string().length(56).regex(/^G/),
   currency_preference: z.enum(["auto"]).optional(),
 });
-
-async function assertUserWalletAddress(
-  userId: string,
-  providedAddress: string,
-): Promise<string> {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { stellarAddress: true },
-  });
-
-  if (!user?.stellarAddress) {
-    throw new AppError("User wallet address not set", 400);
-  }
-
-  if (user.stellarAddress !== providedAddress) {
-    throw new AppError("Wallet address does not match user", 403);
-  }
-
-  return user.stellarAddress;
-}
 
 /**
  * POST /v1/mint/usdc - Accept USDC deposit. We convert USDC→XLM in backend (pools/swaps independent); once conversion succeeds, mint is approved. User does not wait for LPs.
@@ -257,9 +238,11 @@ export async function depositFromBasketCurrency(
       return;
     }
     const amountNum = Number(amount);
-    if (req.apiKey?.userId) {
-      await assertUserWalletAddress(req.apiKey.userId, wallet_address);
+    const userId = req.apiKey?.userId;
+    if (!userId) {
+      throw new AppError("User context required for deposit", 401);
     }
+    await assertUserWalletAddress(userId, wallet_address);
     // SECURITY: Always enforce circuit breaker and deposit limits
     // Previously these checks were skipped when req.audience was undefined,
     // allowing bypass of critical financial controls via direct /mint/deposit route
@@ -280,12 +263,12 @@ export async function depositFromBasketCurrency(
     await checkDepositLimits(
       audience,
       amountUsdPlaceholder,
-      req.apiKey?.userId ?? null,
+      userId,
       req.apiKey?.organizationId ?? null,
     );
     const tx = await prisma.transaction.create({
       data: {
-        userId: req.apiKey?.userId ?? undefined,
+        userId,
         type: "mint",
         status: "pending",
         localCurrency: currency,

--- a/src/controllers/onrampController.ts
+++ b/src/controllers/onrampController.ts
@@ -10,26 +10,7 @@ import { Decimal } from "@prisma/client/runtime/library";
 import { enqueueXlmToAcbu } from "../jobs/xlmToAcbuJob";
 import { AppError } from "../middleware/errorHandler";
 import { isValidStellarAddress } from "../utils/stellar";
-
-async function assertUserWalletAddress(
-  userId: string,
-  providedAddress: string,
-): Promise<string> {
-  const user = await prisma.user.findUnique({
-    where: { id: userId },
-    select: { stellarAddress: true },
-  });
-
-  if (!user?.stellarAddress) {
-    throw new AppError("User wallet address not set", 400);
-  }
-
-  if (user.stellarAddress !== providedAddress) {
-    throw new AppError("Wallet address does not match user", 403);
-  }
-
-  return user.stellarAddress;
-}
+import { assertUserWalletAddress } from "../services/wallet/walletService";
 
 const bodySchema = z.object({
   stellar_address: z

--- a/src/services/wallet/walletService.test.ts
+++ b/src/services/wallet/walletService.test.ts
@@ -1,0 +1,46 @@
+import { assertUserWalletAddress } from "./walletService";
+import { prisma } from "../../config/database";
+import { AppError } from "../../middleware/errorHandler";
+
+jest.mock("../../config/database", () => ({
+  prisma: {
+    user: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+const mockedFindUnique = prisma.user.findUnique as jest.Mock;
+
+describe("walletService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns the user wallet address when it matches the provided address", async () => {
+    mockedFindUnique.mockResolvedValue({ stellarAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" });
+    const result = await assertUserWalletAddress(
+      "user-1",
+      "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+    );
+    expect(result).toBe("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF");
+    expect(mockedFindUnique).toHaveBeenCalledWith({
+      where: { id: "user-1" },
+      select: { stellarAddress: true },
+    });
+  });
+
+  it("throws 400 when the user has no wallet address", async () => {
+    mockedFindUnique.mockResolvedValue({ stellarAddress: null });
+    await expect(
+      assertUserWalletAddress("user-2", "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"),
+    ).rejects.toMatchObject({ statusCode: 400, message: "User wallet address not set" });
+  });
+
+  it("throws 403 when the provided address does not match the user's wallet", async () => {
+    mockedFindUnique.mockResolvedValue({ stellarAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" });
+    await expect(
+      assertUserWalletAddress("user-3", "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"),
+    ).rejects.toMatchObject({ statusCode: 403, message: "Wallet address does not match user" });
+  });
+});

--- a/src/services/wallet/walletService.ts
+++ b/src/services/wallet/walletService.ts
@@ -5,10 +5,31 @@ import { Keypair } from "@stellar/stellar-sdk";
 import { prisma } from "../../config/database";
 import { logger } from "../../config/logger";
 import { assertValidStellarAddress } from "../../utils/stellar";
+import { AppError } from "../../middleware/errorHandler";
 
 export interface EnsureWalletResult {
   wallet_created: boolean;
   passphrase?: string;
+}
+
+export async function assertUserWalletAddress(
+  userId: string,
+  providedAddress: string,
+): Promise<string> {
+  const user = await prisma.user.findUnique({
+    where: { id: userId },
+    select: { stellarAddress: true },
+  });
+
+  if (!user?.stellarAddress) {
+    throw new AppError("User wallet address not set", 400);
+  }
+
+  if (user.stellarAddress !== providedAddress) {
+    throw new AppError("Wallet address does not match user", 403);
+  }
+
+  return user.stellarAddress;
 }
 
 /**

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,7 @@
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
     "resolveJsonModule": true,
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,


### PR DESCRIPTION
Close #122 

# PR: Secure mint/on-ramp wallet binding + tsconfig warning fix

## Summary

This PR closes the security issue around client-supplied mint recipients by centralizing wallet ownership verification and enforcing it across mint and on-ramp endpoints. It also resolves a TypeScript diagnostic in `tsconfig.json` related to deprecated `moduleResolution`.

## Changes

- Added shared `assertUserWalletAddress` helper in `src/services/wallet/walletService.ts`
- Updated:
  - `src/controllers/mintController.ts`
  - `src/controllers/onrampController.ts`
- Enforced user-owned wallet address checks for:
  - `/v1/mint/usdc`
  - `/v1/mint/deposit`
  - `/v1/onramp/register`
- Added focused tests:
  - `src/services/wallet/walletService.test.ts`
  - `src/controllers/mintController.test.ts`
- Updated `tsconfig.json`:
  - changed `moduleResolution` from `node` to `bundler` to remove TypeScript diagnostics

## Testing

- Verified editor diagnostics on changed files report no errors
- Ensured no remaining `task07` references in the repository

## Notes

- This PR is scoped to the security fix and local TS config cleanup only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved wallet address validation with consistent error messaging across the platform.

* **Bug Fixes**
  * Strengthened authentication enforcement; requests lacking valid user credentials now return proper error responses.
  * Enhanced wallet address verification with clearer validation messages.

* **Tests**
  * Added comprehensive test coverage for wallet address validation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->