### PR TITLE
fix(B-039): add status filter to investment withdrawal list (#154)

### DIFF
--- a/src/controllers/investmentController.ts
+++ b/src/controllers/investmentController.ts
@@ -105,18 +105,21 @@ export async function postInvestmentWithdrawRequest(
   }
 }
 
+const WITHDRAWAL_STATUSES = ["requested", "available", "completed", "cancelled"] as const;
+
 const getWithdrawRequestsQuerySchema = z.object({
   limit: z
     .string()
     .optional()
     .transform((v) => (v ? parseInt(v, 10) : 20))
     .pipe(z.number().int().min(1).max(100)),
-  cursor: z.string().optional(), // last request id from previous page
+  cursor: z.string().optional(),
+  status: z.enum(WITHDRAWAL_STATUSES).optional(),
 });
 
 /**
- * GET /v1/investment/withdraw/requests?limit=20&cursor=<last_id>
- * List user's investment withdrawal requests with cursor-based pagination.
+ * GET /v1/investment/withdraw/requests?limit=20&cursor=<last_id>&status=<status>
+ * List user's investment withdrawal requests with cursor-based pagination and optional status filter.
  * Returns { requests, next_cursor } — pass next_cursor as cursor on the next request.
  */
 export async function getInvestmentWithdrawRequests(
@@ -133,10 +136,15 @@ export async function getInvestmentWithdrawRequests(
       const msg = query.error.errors.map((x) => x.message).join("; ");
       throw new AppError(msg, 400);
     }
-    const { limit, cursor } = query.data;
+    const { limit, cursor, status } = query.data;
+
+    const where = {
+      ...(userId ? { userId } : { organizationId }),
+      ...(status ? { status } : {}),
+    };
 
     const list = await prisma.investmentWithdrawalRequest.findMany({
-      where: userId ? { userId } : { organizationId },
+      where,
       orderBy: { createdAt: "desc" },
       take: limit + 1,
       ...(cursor ? { cursor: { id: cursor }, skip: 1 } : {}),


### PR DESCRIPTION
## Problem

Closes #154 (B-039)

`GET /v1/investment/withdraw/requests` had a hard-coded `take: 50` cap with no pagination and no way to filter by lifecycle status, making it unusable for large org histories.

## What changed

- **Cursor-based pagination** was already added in PR #72; this PR completes the acceptance criteria by adding the missing **`?status`** filter.
- Added `WITHDRAWAL_STATUSES` tuple (`requested | available | completed | cancelled`) validated via Zod.
- The `where` clause now merges the owner predicate with the optional status filter.
- No schema changes required — `idx_inv_withdrawal_status` index already exists.

## API

```
GET /v1/investment/withdraw/requests?limit=20&cursor=<id>&status=available
```

| Param | Type | Default | Notes |
|-------|------|---------|-------|
| `limit` | int 1–100 | 20 | Page size |
| `cursor` | string | — | Last `id` from previous page |
| `status` | enum | — | `requested` \| `available` \| `completed` \| `cancelled` |

Response includes `next_cursor: string | null` for progressive loading.

## Acceptance check

Large org history loads progressively via cursor; callers can scope to a single status bucket (e.g. `available`) without fetching the full history.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The `GET /v1/investment/withdraw/requests` endpoint now accepts an optional `status` query parameter, enabling filtering of withdrawal requests by their current status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->