### PR TITLE
feat: #147 B-032 Add /health/ready endpoint for K8s readiness probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,52 @@ docker-compose down
 docker-compose logs -f
 ```
 
+## Health Check Endpoints
+
+The API provides three health check endpoints with different purposes:
+
+### `/health` - Shallow Liveness Check
+- **Path:** `GET /api/v1/health`
+- **Status:** Always returns `200 OK`
+- **Purpose:** For load balancers to verify the process is alive
+- **Response:** `{ status: "ok", timestamp, uptime, version }`
+- **Note:** Does not probe dependencies; fast and reliable
+
+### `/health/ready` - Kubernetes Readiness Probe
+- **Path:** `GET /api/v1/health/ready`
+- **Status:** Returns `200` if all dependencies up, `503` if any down
+- **Purpose:** For Kubernetes readinessProbe configurations
+- **Probes:** PostgreSQL, MongoDB, RabbitMQ
+- **Recommendation:** Use this endpoint in K8s deployment readinessProbe
+
+### `/health/deep` - Deep Health Check
+- **Path:** `GET /api/v1/health/deep`
+- **Status:** Returns `200` if all dependencies up, `503` if any down
+- **Purpose:** Detailed dependency status for monitoring dashboards
+- **Response:** Full report with status of each dependency
+
+### Kubernetes Configuration Example
+
+```yaml
+readinessProbe:
+  httpGet:
+    path: /api/v1/health/ready
+    port: 5000
+  initialDelaySeconds: 5
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+
+livenessProbe:
+  httpGet:
+    path: /api/v1/health
+    port: 5000
+  initialDelaySeconds: 30
+  periodSeconds: 10
+  timeoutSeconds: 5
+  failureThreshold: 3
+```
+
 ## CI/CD
 
 GitHub Actions CI pipeline runs on:

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -41,6 +41,10 @@ router.get("/health", (_req, res) => {
   });
 });
 
+// Kubernetes readiness check — probes all critical dependencies; returns 503 if any are down
+// Use this endpoint for K8s readinessProbe configurations
+router.get("/health/ready", deepHealthCheck);
+
 // Deep health check — probes PostgreSQL, MongoDB, RabbitMQ; returns 503 if any are down
 router.get("/health/deep", deepHealthCheck);
 


### PR DESCRIPTION
## Fix: Add `/health/ready` endpoint for Kubernetes readiness probes

Closes #147

### Problem
The shallow `/health` endpoint always returns `200 OK` regardless of dependency status, causing load balancers to mark instances as ready even when PostgreSQL, MongoDB, or RabbitMQ are down.

### Solution
- Added dedicated `/health/ready` endpoint that probes all critical dependencies
- Returns `503 Service Unavailable` if any dependency is down
- Returns `200 OK` only when all dependencies are healthy
- Documented the split between three health check endpoints in README

### Endpoints
- `/health` - Shallow liveness check (always 200) for load balancers
- `/health/ready` - K8s readiness probe (checks dependencies, returns 503 if down)
- `/health/deep` - Deep health check for monitoring dashboards

### Changes
- Added `/health/ready` route in `src/routes/index.ts`
- Updated README with comprehensive health check documentation and K8s configuration example

### Testing
The `/health/ready` endpoint uses the existing `deepHealthCheck` function which validates PostgreSQL, MongoDB, and RabbitMQ with 2-second timeouts.

**Acceptance Check:** K8s readinessProbe now properly uses `/health/ready` when configured.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/health/ready` endpoint for Kubernetes readiness probes that monitors critical service dependencies.

* **Documentation**
  * Updated with health check endpoint guidance, including shallow liveness, readiness, and deep monitoring endpoints, plus Kubernetes probe configuration examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->