### PR TITLE
fix: implement supply reconciliation and drift alerts in ReserveTracker #125

### DIFF
--- a/src/services/reserve/ReserveTracker.ts
+++ b/src/services/reserve/ReserveTracker.ts
@@ -410,14 +410,48 @@ export class ReserveTracker {
    * Get total ACBU supply from blockchain.
    * Queries Horizon to get the actual amount in circulation, preventing divergence from internal tracking.
    */
+  
+  /**
+   * Get total ACBU supply with reconciliation between DB Ledger and Blockchain.
+   */
   private async getTotalAcbuSupply(): Promise<number> {
+    const ledgerSupply = await this.getTotalAcbuSupplyFromLedger();
+    
     const issuer = process.env.STELLAR_ACBU_ASSET_ISSUER;
-    const assetCode = process.env.STELLAR_ACBU_ASSET_CODE || "ACBU";
+    const assetCode = process.env.STELLAR_ACBU_ASSET_CODE || 'ACBU';
 
     if (!issuer) {
-      logger.warn(
-        "ACBU issuer not configured. Falling back to internal transaction aggregates for supply calculation.",
-        { assetCode },
+      logger.warn('ACBU issuer not configured. Using ledger supply.');
+      return ledgerSupply;
+    }
+
+    try {
+      const server = stellarClient.getServer();
+      const assets = await server.assets().forCode(assetCode).forIssuer(issuer).call();
+
+      if (assets.records.length === 0) {
+        return ledgerSupply;
+      }
+
+      const onChainSupply = parseFloat((assets.records[0] as any).amount);
+      const delta = Math.abs(onChainSupply - ledgerSupply);
+      const driftThreshold = 0.01;
+
+      if (delta > driftThreshold) {
+        logger.warn('RESERVE DRIFT DETECTED: DB Ledger and On-Chain supply diverge', {
+          ledgerSupply,
+          onChainSupply,
+          delta,
+        });
+      }
+
+      return onChainSupply;
+    } catch (e) {
+      logger.error('Failed to query Stellar for ACBU total supply, falling back to ledger', { error: e });
+      return ledgerSupply;
+    }
+  }
+,
       );
 
       return this.getTotalAcbuSupplyFromLedger();


### PR DESCRIPTION
### Description
This PR addresses the divergence between indexed database supply and on-chain truth. 

### Changes
- Updated `getTotalAcbuSupply` to fetch the authoritative total supply directly from Stellar Horizon.
- Implemented reconciliation logic to compare DB ledger totals against on-chain data.
- Added a warning alert that triggers if the drift (delta) exceeds the safety threshold (0.01).
- Added fallback logic to return the ledger supply if the blockchain query fails, ensuring system continuity.

### Acceptance Check
- [x] Reconciliation logic implemented.
- [x] Drift alerts configured for logger output.
- [x] On-chain truth prioritized over DB aggregates.

Closes #125

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced ACBU supply verification by comparing database records against on-chain data sources. The system now detects and logs supply discrepancies when identified, with automatic fallback to database records if on-chain data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->