### PR TITLE
fix(B-047): enforce requireMinTier on premium routes, fix undefined-t…

### DIFF
--- a/src/middleware/segmentGuard.ts
+++ b/src/middleware/segmentGuard.ts
@@ -70,7 +70,7 @@ export function requireMinTier(minTier: UserTier) {
   return (req: AuthRequest, _res: Response, next: NextFunction): void => {
     const tier = req.userTier;
     if (tier === undefined) {
-      next();
+      next(new AppError("Insufficient tier. Required at least: " + minTier, 403));
       return;
     }
     const tierIdx = TIER_ORDER.indexOf(tier);

--- a/src/routes/gatewayRoutes.ts
+++ b/src/routes/gatewayRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import {
   postGatewayCharge,
@@ -10,6 +10,7 @@ import {
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("sme"));
 router.use(requireSegmentScope("gateway:read", "gateway:write"));
 router.use(apiKeyRateLimiter);
 

--- a/src/routes/internationalRoutes.ts
+++ b/src/routes/internationalRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import { getRates } from "../controllers/ratesController";
 import mintRoutes from "./mintRoutes";
@@ -9,6 +9,7 @@ import burnRoutes from "./burnRoutes";
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("verified"));
 router.use(requireSegmentScope("international:read", "international:write"));
 router.use(apiKeyRateLimiter);
 

--- a/src/routes/investmentRoutes.ts
+++ b/src/routes/investmentRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import {
   postInvestmentWithdrawRequest,
@@ -10,6 +10,7 @@ import {
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("verified"));
 router.use(requireSegmentScope("investment:read", "investment:write"));
 router.use(apiKeyRateLimiter);
 

--- a/src/routes/lendingRoutes.ts
+++ b/src/routes/lendingRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import {
   postLendingDeposit,
@@ -11,6 +11,7 @@ import {
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("verified"));
 router.use(requireSegmentScope("lending:read", "lending:write"));
 router.use(apiKeyRateLimiter);
 

--- a/src/routes/p2pRoutes.ts
+++ b/src/routes/p2pRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import {
   postTransfers,
@@ -11,6 +11,7 @@ import {
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("verified"));
 router.use(requireSegmentScope("p2p:read", "p2p:write"));
 router.use(apiKeyRateLimiter);
 

--- a/src/routes/salaryRoutes.ts
+++ b/src/routes/salaryRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import {
   postSalaryDisburse,
@@ -12,6 +12,7 @@ import {
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("sme"));
 router.use(requireSegmentScope("salary:read", "salary:write"));
 router.use(apiKeyRateLimiter);
 

--- a/src/routes/savingsRoutes.ts
+++ b/src/routes/savingsRoutes.ts
@@ -1,6 +1,6 @@
 import { Router, type IRouter } from "express";
 import { validateApiKey } from "../middleware/auth";
-import { requireSegmentScope } from "../middleware/segmentGuard";
+import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import { validate } from "../middleware/validator";
 import {
@@ -18,6 +18,7 @@ import {
 const router: IRouter = Router();
 
 router.use(validateApiKey);
+router.use(requireMinTier("verified"));
 router.use(requireSegmentScope("savings:read", "savings:write"));
 router.use(apiKeyRateLimiter);
 

--- a/tests/segmentGuard.test.ts
+++ b/tests/segmentGuard.test.ts
@@ -1,0 +1,80 @@
+// Tests for requireMinTier (B-047)
+import { Response } from "express";
+import { requireMinTier, TIER_ORDER } from "../src/middleware/segmentGuard";
+import type { AuthRequest, UserTier } from "../src/middleware/auth";
+
+function makeReq(tier?: UserTier): AuthRequest {
+  return { userTier: tier } as AuthRequest;
+}
+
+function makeNext(): jest.Mock {
+  return jest.fn();
+}
+
+describe("requireMinTier", () => {
+  it("blocks when userTier is undefined (no tier set)", () => {
+    const next = makeNext();
+    requireMinTier("free")(makeReq(undefined), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it("allows exact tier match", () => {
+    const next = makeNext();
+    requireMinTier("verified")(makeReq("verified"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(); // called with no args = pass
+  });
+
+  it("allows higher tier than required", () => {
+    const next = makeNext();
+    requireMinTier("verified")(makeReq("sme"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("blocks free tier from verified+ endpoint", () => {
+    const next = makeNext();
+    requireMinTier("verified")(makeReq("free"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it("blocks free tier from sme+ endpoint", () => {
+    const next = makeNext();
+    requireMinTier("sme")(makeReq("free"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it("blocks verified tier from sme+ endpoint", () => {
+    const next = makeNext();
+    requireMinTier("sme")(makeReq("verified"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it("allows sme tier on sme+ endpoint", () => {
+    const next = makeNext();
+    requireMinTier("sme")(makeReq("sme"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("allows enterprise tier on sme+ endpoint", () => {
+    const next = makeNext();
+    requireMinTier("sme")(makeReq("enterprise"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("blocks non-enterprise tier from enterprise+ endpoint", () => {
+    for (const tier of ["free", "verified", "sme"] as UserTier[]) {
+      const next = makeNext();
+      requireMinTier("enterprise")(makeReq(tier), {} as Response, next);
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+    }
+  });
+
+  it("allows enterprise tier on enterprise+ endpoint", () => {
+    const next = makeNext();
+    requireMinTier("enterprise")(makeReq("enterprise"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it("TIER_ORDER is correctly ordered", () => {
+    expect(TIER_ORDER).toEqual(["free", "verified", "sme", "enterprise"]);
+  });
+});


### PR DESCRIPTION
Problem                                                                        
                                                                                 
  requireMinTier existed in segmentGuard.ts but had two issues:                  
                                                                                 
  - When req.userTier was undefined, it silently passed the request through      
  instead of blocking — meaning API keys with no user tier could access any      
  segment endpoint                                                               
  - Several premium routes (savings, lending, investment, gateway, salary,       
  international, p2p) had no tier guard at all                                   
                                                                                 
  Changes                                                                        
                                                                                 
  Bug fix — requireMinTier now returns 403 when userTier is undefined.           
                                                                                 
  Tier guards applied:                                                           
                                                                                 
  ┌────────────────────────────────────────────────────────────┬────────────┐    
  │ Routes                                                     │ Min tier   │    
  ├────────────────────────────────────────────────────────────┼────────────┤    
  │ `p2p`, `savings`, `lending`, `investment`, `international` │ `verified` │    
  │ `salary`, `gateway`                                        │ `sme`      │    
  └────────────────────────────────────────────────────────────┴────────────┘    
                                                                                 
  Tests — 11 unit tests covering: undefined tier blocks, tier hierarchy          
  enforcement, exact match, higher-tier passthrough, enterprise-only gating.     
                                                                                 
  Acceptance                                                                     
                                                                                 
  - Free tier → 403 on SME-only endpoints (/v1/sme, /v1/salary, /v1/gateway)     
  - Unverified (no tier) → 403 on all segment endpoints                          
  - sme/enterprise tier → passes tier check as expected  

Closes #162

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  - Fixed authorization middleware to properly reject requests with missing tier information

* **New Features**
  - Gateway and salary endpoints now require business-level account access
  - International, investment, lending, P2P, and savings endpoints now require verified account status

<!-- end of auto-generated comment: release notes by coderabbit.ai -->