### PR TITLE
fix(B-031): protect /health/deep and /health/metrics with admin API key

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -14,6 +14,7 @@ const envSchema = z.object({
   PRISMA_ACCELERATE_URL: z.string().optional(),
   JWT_EXPIRES_IN: z.string().default("7d"),
   API_KEY_SALT: z.string().default(""),
+  ADMIN_API_KEY: z.string().optional(),
   RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60000),
   RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(100),
 });
@@ -49,6 +50,7 @@ export const config = {
   jwtSecret: env.JWT_SECRET,
   jwtExpiresIn: env.JWT_EXPIRES_IN,
   apiKeySalt: env.API_KEY_SALT,
+  adminApiKey: env.ADMIN_API_KEY,
   rateLimitWindowMs: env.RATE_LIMIT_WINDOW_MS,
   rateLimitMaxRequests: env.RATE_LIMIT_MAX_REQUESTS,
 

--- a/src/middleware/adminAuth.ts
+++ b/src/middleware/adminAuth.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction } from "express";
+import { config } from "../config/env";
+import { AppError } from "./errorHandler";
+
+/**
+ * Guard for admin-only endpoints (e.g. /health/deep, /health/metrics).
+ * Requires the `x-admin-key` header to match ADMIN_API_KEY env var.
+ * If ADMIN_API_KEY is not configured, the endpoint is blocked entirely.
+ */
+export function requireAdminApiKey(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const { adminApiKey } = config;
+  if (!adminApiKey) {
+    next(new AppError("Admin endpoint not available", 503));
+    return;
+  }
+  const provided = req.headers["x-admin-key"];
+  if (!provided || provided !== adminApiKey) {
+    next(new AppError("Unauthorized", 401));
+    return;
+  }
+  next();
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { config } from "../config/env";
 import { deepHealthCheck } from "../controllers/healthController";
+import { requireAdminApiKey } from "../middleware/adminAuth";
 import reserveRoutes from "./reserveRoutes";
 import recipientRoutes from "./recipientRoutes";
 import transferRoutes from "./transferRoutes";
@@ -42,10 +43,10 @@ router.get("/health", (_req, res) => {
 });
 
 // Deep health check — probes PostgreSQL, MongoDB, RabbitMQ; returns 503 if any are down
-router.get("/health/deep", deepHealthCheck);
+router.get("/health/deep", requireAdminApiKey, deepHealthCheck);
 
 // Extended health / metrics (reserve ratio when available; for monitoring dashboards)
-router.get("/health/metrics", deepHealthCheck);
+router.get("/health/metrics", requireAdminApiKey, deepHealthCheck);
 
 // API routes
 router.use("/auth", authRoutes);

--- a/tests/adminAuth.test.ts
+++ b/tests/adminAuth.test.ts
@@ -1,0 +1,49 @@
+// Tests for requireAdminApiKey middleware (B-031)
+import { Request, Response } from "express";
+
+const mockConfig = { adminApiKey: undefined as string | undefined };
+
+jest.mock("../src/config/env", () => ({ config: mockConfig }));
+jest.mock("../src/config/logger", () => ({ logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() } }));
+
+import { requireAdminApiKey } from "../src/middleware/adminAuth";
+
+function makeReq(adminKey?: string): Request {
+  return { headers: adminKey ? { "x-admin-key": adminKey } : {} } as Request;
+}
+
+function makeNext() {
+  return jest.fn();
+}
+
+describe("requireAdminApiKey", () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  it("returns 503 when ADMIN_API_KEY is not configured", () => {
+    mockConfig.adminApiKey = undefined;
+    const next = makeNext();
+    requireAdminApiKey(makeReq("anything"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 503 }));
+  });
+
+  it("returns 401 when no x-admin-key header is provided", () => {
+    mockConfig.adminApiKey = "secret-key";
+    const next = makeNext();
+    requireAdminApiKey(makeReq(), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
+  });
+
+  it("returns 401 when x-admin-key header is wrong", () => {
+    mockConfig.adminApiKey = "secret-key";
+    const next = makeNext();
+    requireAdminApiKey(makeReq("wrong-key"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 401 }));
+  });
+
+  it("calls next() with no error when key matches", () => {
+    mockConfig.adminApiKey = "secret-key";
+    const next = makeNext();
+    requireAdminApiKey(makeReq("secret-key"), {} as Response, next);
+    expect(next).toHaveBeenCalledWith();
+  });
+});


### PR DESCRIPTION
Problem                                                                        
                                                                                 
  /health/deep and /health/metrics were fully public — any unauthenticated caller
  could probe dependency health (PostgreSQL, MongoDB, RabbitMQ status, error     
  messages) and use it for reconnaissance. /health (shallow) is intentionally    
  public for load balancers.                                                     
                                                                                 
  Changes                                                                        
                                                                                 
  - src/config/env.ts — add optional ADMIN_API_KEY env var                       
  - src/middleware/adminAuth.ts (new) — requireAdminApiKey middleware: checks    
  x-admin-key request header; returns 503 if key is unconfigured, 401 on missing 
  or wrong key                                                                   
  - src/routes/index.ts — apply requireAdminApiKey to /health/deep and           
  /health/metrics; /health remains public                                        
  - tests/adminAuth.test.ts — 4 unit tests covering all auth paths               
                                                                                 
  Deployment                                                                     
                                                                                 
  Set ADMIN_API_KEY=<strong-random-value> in your environment. Pass x-admin-key: 
  <value> from monitoring dashboards and alerting tools.                         
                                                                                 
  Acceptance                                                                     
                                                                                 
  - Unauthenticated GET /health/deep → 401                                       
  - GET /health/deep with correct x-admin-key → 200/503 (dependency status)      
  - GET /health (shallow) → 200 with no auth (load balancer path unaffected)     
  - ADMIN_API_KEY unset → 503 (endpoint unavailable, not leaking data)

Closes #146