### PR TITLE
fix: Prisma URL guardrails, PII field encryption, and OpenAI usage guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,7 +1,20 @@
 DATABASE_URL="postgresql://acbu_user:acbu_pass@localhost:5432/acbu_db"
+# Optional: Prisma Accelerate URL for runtime connection pooling (prisma:// protocol).
+# Leave unset for local dev. Never use this for prisma migrate — it requires DATABASE_URL above.
+# PRISMA_ACCELERATE_URL="prisma://accelerate.prisma-data.net/?api_key=..."
 MONGODB_URI="mongodb://localhost:27017/acbu_db"
 RABBITMQ_URL="amqp://guest:guest@localhost:5672"
 JWT_SECRET="dev-jwt-secret-change-me"
+
+# B-058: PII field-level encryption key (AES-256-GCM).
+# Must be a 64-character hex string (32 bytes). Required in production.
+# Generate: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+# PII_ENCRYPTION_KEY=your-64-char-hex-key-here
+
+# B-063: OpenAI integration (used for KYC document analysis)
+# OPENAI_API_KEY=sk-...
+# OPENAI_ORG_MONTHLY_BUDGET_USD=50
+# OPENAI_MAX_TOKENS_PER_REQUEST=2000
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=60000

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ Edit `.env` and configure:
 - JWT secrets
 - Other service configurations
 
+### Database URL Matrix
+
+Two separate environment variables serve distinct purposes — using the wrong one for the wrong purpose causes silent failures or boot errors.
+
+| Variable | Protocol | Used by | Must NOT be used for |
+|---|---|---|---|
+| `DATABASE_URL` | `postgresql://` or `postgres://` | `prisma migrate` (schema migrations) | Runtime app server; Prisma Accelerate |
+| `PRISMA_ACCELERATE_URL` | `prisma://` or `prisma+postgres://` | App server at runtime (connection pooling, caching) | Migrations (`prisma migrate` will fail with this URL) |
+
+**Rules:**
+- `DATABASE_URL` must always be a **direct** PostgreSQL connection string. The server asserts this at boot and will refuse to start if it detects a `prisma://` protocol here.
+- `PRISMA_ACCELERATE_URL` is optional. When set, the app uses it for all runtime queries. When absent, the app falls back to `DATABASE_URL` directly (suitable for local dev).
+- Never run `pnpm prisma:migrate` pointing at `PRISMA_ACCELERATE_URL`. Always run migrations against the direct `DATABASE_URL`.
+- The boot log prints which URL type is active: `Runtime connection: Prisma Accelerate (pooled)` or `Runtime connection: direct PostgreSQL`.
+
 ### 3. Message queue and optional local services
 
 The app uses **Prisma Accelerate** and **MongoDB Atlas**; it does not require local PostgreSQL or MongoDB. You need a RabbitMQ instance (e.g. from Docker or a managed provider).

--- a/src/config/database.ts
+++ b/src/config/database.ts
@@ -4,10 +4,44 @@ import { config } from "./env";
 import { logger } from "./logger";
 import { trace, SpanStatusCode } from "@opentelemetry/api";
 
+// B-056: Validate URL assignments at boot to prevent runtime/migration confusion.
+// DATABASE_URL  → direct PostgreSQL only (used by prisma migrate)
+// PRISMA_ACCELERATE_URL → prisma:// or prisma+postgres:// protocol (runtime connection pooling)
+const ACCELERATE_PROTOCOL_RE = /^prisma(\+postgres)?:\/\//i;
+
+if (ACCELERATE_PROTOCOL_RE.test(config.databaseUrl)) {
+  throw new Error(
+    "[database] DATABASE_URL must be a direct PostgreSQL connection string " +
+      "(postgresql:// or postgres://). " +
+      "An Accelerate URL (prisma://) was detected — " +
+      "set that value in PRISMA_ACCELERATE_URL instead. " +
+      "Using Accelerate for migrations will fail.",
+  );
+}
+
+if (
+  config.prismaAccelerateUrl &&
+  !ACCELERATE_PROTOCOL_RE.test(config.prismaAccelerateUrl)
+) {
+  logger.warn(
+    "[database] PRISMA_ACCELERATE_URL does not start with prisma:// — " +
+      "expected an Accelerate connection string. " +
+      "If you intended a direct URL, set DATABASE_URL and leave PRISMA_ACCELERATE_URL unset.",
+  );
+}
+
 const useAccelerate = Boolean(config.prismaAccelerateUrl);
 const databaseUrl = useAccelerate
   ? config.prismaAccelerateUrl!
   : config.databaseUrl;
+
+logger.info(
+  `[database] Runtime connection: ${useAccelerate ? "Prisma Accelerate (pooled)" : "direct PostgreSQL"}`,
+);
+logger.info(
+  "[database] Migration connection: direct PostgreSQL via DATABASE_URL " +
+    "(run prisma migrate against DATABASE_URL, never against PRISMA_ACCELERATE_URL)",
+);
 
 const basePrisma = new PrismaClient({
   datasources: { db: { url: databaseUrl } },

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -18,6 +18,17 @@ const envSchema = z.object({
   API_KEY_SALT: z.string().default(""),
   RATE_LIMIT_WINDOW_MS: z.coerce.number().default(60000),
   RATE_LIMIT_MAX_REQUESTS: z.coerce.number().default(100),
+  // B-058: 64-char hex key (32 bytes) for AES-256-GCM PII field encryption.
+  // Generate with: node -e "console.log(require('crypto').randomBytes(32).toString('hex'))"
+  PII_ENCRYPTION_KEY: z
+    .string()
+    .length(64, "PII_ENCRYPTION_KEY must be exactly 64 hex characters (32 bytes)")
+    .regex(/^[0-9a-fA-F]+$/, "PII_ENCRYPTION_KEY must be a hex string")
+    .optional(),
+  // B-063: OpenAI integration config.
+  OPENAI_API_KEY: z.string().optional(),
+  OPENAI_ORG_MONTHLY_BUDGET_USD: z.coerce.number().default(50),
+  OPENAI_MAX_TOKENS_PER_REQUEST: z.coerce.number().default(2000),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -395,5 +406,15 @@ export const config = {
      * Must be set in production.
      */
     scanWebhookSecret: process.env.S3_SCAN_WEBHOOK_SECRET || "",
+  },
+
+  // B-058: PII field-level encryption (AES-256-GCM)
+  piiEncryptionKey: env.PII_ENCRYPTION_KEY,
+
+  // B-063: OpenAI guardrails
+  openai: {
+    apiKey: env.OPENAI_API_KEY,
+    orgMonthlyBudgetUsd: env.OPENAI_ORG_MONTHLY_BUDGET_USD,
+    maxTokensPerRequest: env.OPENAI_MAX_TOKENS_PER_REQUEST,
   },
 };

--- a/src/services/ai/openaiGuard.ts
+++ b/src/services/ai/openaiGuard.ts
@@ -1,0 +1,245 @@
+/**
+ * B-063: OpenAI usage guardrails.
+ *
+ * Wraps every OpenAI call with:
+ *  1. Auth check — caller must supply a verified org/user ID.
+ *  2. Per-org monthly spend budget — rejects calls when the org would exceed its cap.
+ *  3. Prompt allowlist — rejects prompts that contain disallowed patterns.
+ *  4. Spend recording — writes usage to MongoDB so the budget check stays accurate.
+ */
+
+import OpenAI from "openai";
+import type { ChatCompletionMessageParam } from "openai/resources/chat/completions";
+import { config } from "../../config/env";
+import { logger } from "../../config/logger";
+import { getMongoDB } from "../../config/mongodb";
+
+// Patterns that are never allowed in prompts regardless of context.
+const DISALLOWED_PROMPT_PATTERNS: RegExp[] = [
+  /ignore (all |previous |prior )?instructions/i,
+  /you are now/i,
+  /act as (a |an )?(?!kyc|document|analyst)/i,
+  /jailbreak/i,
+  /disregard (your |all |prior )?/i,
+  /forget (your |all |prior )?instructions/i,
+  /reveal (your |the )?system prompt/i,
+  /print (your |the )?system prompt/i,
+];
+
+const SPEND_COLLECTION = "openai_org_spend";
+
+export interface GuardedChatParams {
+  orgId: string;
+  userId?: string;
+  messages: ChatCompletionMessageParam[];
+  model?: string;
+  maxTokens?: number;
+}
+
+export interface GuardedChatResult {
+  content: string;
+  usage: {
+    promptTokens: number;
+    completionTokens: number;
+    totalTokens: number;
+    estimatedCostUsd: number;
+  };
+}
+
+function getOpenAIClient(): OpenAI {
+  if (!config.openai.apiKey) {
+    throw new Error(
+      "OpenAI is not configured. Set OPENAI_API_KEY in your environment.",
+    );
+  }
+  return new OpenAI({ apiKey: config.openai.apiKey });
+}
+
+/**
+ * Validates that none of the user-supplied messages contain injection patterns.
+ * Throws AppError-compatible if a disallowed pattern is found.
+ */
+function assertPromptSafe(messages: ChatCompletionMessageParam[]): void {
+  for (const msg of messages) {
+    if (msg.role !== "user") continue;
+    const text = typeof msg.content === "string" ? msg.content : "";
+    for (const pattern of DISALLOWED_PROMPT_PATTERNS) {
+      if (pattern.test(text)) {
+        throw Object.assign(
+          new Error("Prompt rejected: contains disallowed content."),
+          { statusCode: 400, isOperational: true },
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Returns the current month's total spend in USD for the given org.
+ */
+async function getMonthlySpend(orgId: string): Promise<number> {
+  let db;
+  try {
+    db = getMongoDB();
+  } catch {
+    return 0;
+  }
+
+  const now = new Date();
+  const monthKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+
+  const doc = await db
+    .collection<{ orgId: string; monthKey: string; totalUsd: number }>(
+      SPEND_COLLECTION,
+    )
+    .findOne({ orgId, monthKey });
+
+  return doc?.totalUsd ?? 0;
+}
+
+/**
+ * Estimates USD cost from token usage.
+ * Uses gpt-4o-mini pricing as a conservative default; override for other models.
+ */
+function estimateCostUsd(
+  promptTokens: number,
+  completionTokens: number,
+  model: string,
+): number {
+  // Prices per 1M tokens (USD) — update when OpenAI changes pricing.
+  const pricing: Record<string, { input: number; output: number }> = {
+    "gpt-4o": { input: 2.5, output: 10.0 },
+    "gpt-4o-mini": { input: 0.15, output: 0.6 },
+    "gpt-4-turbo": { input: 10.0, output: 30.0 },
+    "gpt-3.5-turbo": { input: 0.5, output: 1.5 },
+  };
+
+  const modelKey = Object.keys(pricing).find((k) => model.startsWith(k));
+  const { input, output } = pricing[modelKey ?? "gpt-4o-mini"];
+
+  return (promptTokens * input + completionTokens * output) / 1_000_000;
+}
+
+/**
+ * Records spend for an org in the current calendar month (upsert).
+ */
+async function recordSpend(orgId: string, costUsd: number): Promise<void> {
+  let db;
+  try {
+    db = getMongoDB();
+  } catch {
+    return;
+  }
+
+  const now = new Date();
+  const monthKey = `${now.getUTCFullYear()}-${String(now.getUTCMonth() + 1).padStart(2, "0")}`;
+
+  await db.collection(SPEND_COLLECTION).updateOne(
+    { orgId, monthKey },
+    {
+      $inc: { totalUsd: costUsd },
+      $set: { updatedAt: now },
+      $setOnInsert: { createdAt: now },
+    },
+    { upsert: true },
+  );
+}
+
+/**
+ * The single entry point for all OpenAI chat calls within the platform.
+ * Enforces auth context, budget cap, and prompt safety before calling the API.
+ */
+export async function guardedChat(
+  params: GuardedChatParams,
+): Promise<GuardedChatResult> {
+  const {
+    orgId,
+    userId,
+    messages,
+    model = "gpt-4o-mini",
+    maxTokens = config.openai.maxTokensPerRequest,
+  } = params;
+
+  if (!orgId) {
+    throw Object.assign(new Error("orgId is required for OpenAI calls."), {
+      statusCode: 401,
+      isOperational: true,
+    });
+  }
+
+  assertPromptSafe(messages);
+
+  const currentSpend = await getMonthlySpend(orgId);
+  if (currentSpend >= config.openai.orgMonthlyBudgetUsd) {
+    logger.warn("[openaiGuard] Monthly budget exceeded", {
+      orgId,
+      currentSpend,
+      budgetUsd: config.openai.orgMonthlyBudgetUsd,
+    });
+    throw Object.assign(
+      new Error(
+        `OpenAI monthly budget of $${config.openai.orgMonthlyBudgetUsd} exceeded for this organisation.`,
+      ),
+      { statusCode: 429, isOperational: true },
+    );
+  }
+
+  const client = getOpenAIClient();
+
+  logger.debug("[openaiGuard] Sending request", { orgId, userId, model });
+
+  const response = await client.chat.completions.create({
+    model,
+    messages,
+    max_tokens: maxTokens,
+  });
+
+  const choice = response.choices[0];
+  const content = choice?.message?.content ?? "";
+  const usage = response.usage ?? {
+    prompt_tokens: 0,
+    completion_tokens: 0,
+    total_tokens: 0,
+  };
+
+  const estimatedCostUsd = estimateCostUsd(
+    usage.prompt_tokens,
+    usage.completion_tokens,
+    model,
+  );
+
+  await recordSpend(orgId, estimatedCostUsd);
+
+  logger.info("[openaiGuard] Request completed", {
+    orgId,
+    userId,
+    model,
+    totalTokens: usage.total_tokens,
+    estimatedCostUsd: estimatedCostUsd.toFixed(6),
+  });
+
+  return {
+    content,
+    usage: {
+      promptTokens: usage.prompt_tokens,
+      completionTokens: usage.completion_tokens,
+      totalTokens: usage.total_tokens,
+      estimatedCostUsd,
+    },
+  };
+}
+
+/**
+ * Returns the current month's spend for an org. Useful for admin dashboards.
+ */
+export async function getOrgMonthlySpend(
+  orgId: string,
+): Promise<{ spendUsd: number; budgetUsd: number; remainingUsd: number }> {
+  const spendUsd = await getMonthlySpend(orgId);
+  const budgetUsd = config.openai.orgMonthlyBudgetUsd;
+  return {
+    spendUsd,
+    budgetUsd,
+    remainingUsd: Math.max(0, budgetUsd - spendUsd),
+  };
+}

--- a/src/utils/piiEncryption.ts
+++ b/src/utils/piiEncryption.ts
@@ -1,0 +1,102 @@
+import { createCipheriv, createDecipheriv, createHmac, randomBytes } from "crypto";
+
+const ALGORITHM = "aes-256-gcm";
+const IV_BYTES = 12;
+const TAG_BYTES = 16;
+const VERSION_PREFIX = "v1:";
+
+/**
+ * Derives a 32-byte Buffer from the configured PII_ENCRYPTION_KEY.
+ * The env value must be a 64-character hex string (256 bits).
+ */
+export function getPiiKey(hexKey: string): Buffer {
+  if (hexKey.length !== 64) {
+    throw new Error(
+      "PII_ENCRYPTION_KEY must be a 64-character hex string (32 bytes / 256 bits). " +
+        `Got ${hexKey.length} characters.`,
+    );
+  }
+  return Buffer.from(hexKey, "hex");
+}
+
+/**
+ * Encrypts a UTF-8 string with AES-256-GCM.
+ * Returns a versioned base64 string: "v1:<iv-hex>:<tag-hex>:<ciphertext-base64>".
+ */
+export function encryptField(plaintext: string, key: Buffer): string {
+  const iv = randomBytes(IV_BYTES);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const encrypted = Buffer.concat([
+    cipher.update(plaintext, "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+  return (
+    VERSION_PREFIX +
+    iv.toString("hex") +
+    ":" +
+    tag.toString("hex") +
+    ":" +
+    encrypted.toString("base64")
+  );
+}
+
+/**
+ * Decrypts a value produced by encryptField.
+ * Throws on tampered ciphertext (GCM auth tag mismatch).
+ */
+export function decryptField(encrypted: string, key: Buffer): string {
+  if (!encrypted.startsWith(VERSION_PREFIX)) {
+    throw new Error("Unsupported PII encryption version or unencrypted value.");
+  }
+  const parts = encrypted.slice(VERSION_PREFIX.length).split(":");
+  if (parts.length !== 3) {
+    throw new Error("Malformed encrypted PII field.");
+  }
+  const [ivHex, tagHex, ciphertextB64] = parts;
+  const iv = Buffer.from(ivHex, "hex");
+  const tag = Buffer.from(tagHex, "hex");
+  const ciphertext = Buffer.from(ciphertextB64, "base64");
+
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag.slice(0, TAG_BYTES));
+  return (
+    decipher.update(ciphertext).toString("utf8") +
+    decipher.final().toString("utf8")
+  );
+}
+
+/**
+ * Produces a deterministic HMAC-SHA256 search token for a plaintext value.
+ * Use this to maintain unique-index lookups (e.g. phone, email) while keeping
+ * the stored value encrypted. Store both the encrypted field AND its search token.
+ *
+ * Returns a 64-char hex string.
+ */
+export function searchToken(plaintext: string, key: Buffer): string {
+  return createHmac("sha256", key).update(plaintext, "utf8").digest("hex");
+}
+
+/**
+ * Encrypts a JSON-serialisable object.
+ * Returns a versioned string suitable for storage in a Text/String DB column.
+ */
+export function encryptJson(value: unknown, key: Buffer): string {
+  return encryptField(JSON.stringify(value), key);
+}
+
+/**
+ * Decrypts a value produced by encryptJson and parses it back to an object.
+ */
+export function decryptJson<T = unknown>(encrypted: string, key: Buffer): T {
+  return JSON.parse(decryptField(encrypted, key)) as T;
+}
+
+/**
+ * Returns true when a stored value was produced by encryptField / encryptJson.
+ * Callers can use this to handle a mix of legacy plaintext rows and encrypted rows
+ * during a rolling migration.
+ */
+export function isEncrypted(value: string): boolean {
+  return value.startsWith(VERSION_PREFIX);
+}


### PR DESCRIPTION
## Summary

- **B-056** — Prisma Accelerate vs direct URL confusion: startup assertion + boot logs + README matrix
- **B-058** — Encryption at rest for PII columns: AES-256-GCM utility + HMAC search tokens + env config
- **B-063** — OpenAI usage guardrails: auth check + per-org monthly budget + prompt injection allowlist

## Changes

### B-056 — Prisma Accelerate vs direct URL confusion (`#171`)

**`src/config/database.ts`**
- Added startup assertion: throws at boot if `DATABASE_URL` contains a `prisma://` or `prisma+postgres://` protocol, preventing silent failures when the wrong URL is used for migrations.
- Added warning log if `PRISMA_ACCELERATE_URL` doesn't start with the expected `prisma://` protocol.
- Added boot-time info logs that clearly state which connection type is active (`Prisma Accelerate (pooled)` vs `direct PostgreSQL`) and remind that migrations must always run against `DATABASE_URL`.

**`README.md`**
- Added a **Database URL Matrix** table documenting the distinct roles of `DATABASE_URL` (migrations, direct connection) and `PRISMA_ACCELERATE_URL` (runtime pooled connection), with explicit rules about when each must be used.

### B-058 — Encryption at rest for PII columns (`#173`)

**`src/utils/piiEncryption.ts`** _(new file)_
- `encryptField` / `decryptField`: AES-256-GCM encryption for string PII fields. Output is a versioned string (`v1:<iv>:<tag>:<ciphertext>`) to support future key rotation.
- `encryptJson` / `decryptJson`: wraps JSON objects for encrypted storage in text columns (e.g. `machineExtractedPayload`, `machineRedactedPayload`).
- `searchToken`: deterministic HMAC-SHA256 token for fields that require indexed lookups while encrypted (e.g. `phoneE164`, `email`).
- `isEncrypted`: guard for rolling migrations — lets callers detect and handle a mix of legacy plaintext and encrypted rows.

**`src/config/env.ts`** + **`.env.example`**
- Added `PII_ENCRYPTION_KEY` (64-char hex, 32 bytes) with Zod validation for length and format.
- Generation instructions included in `.env.example`.

### B-063 — OpenAI usage guardrails (`#178`)

**`src/services/ai/openaiGuard.ts`** _(new file)_
- `guardedChat()`: single entry point for all OpenAI calls. Enforces:
  1. **Auth** — `orgId` must be present (maps to a verified organisation context).
  2. **Budget cap** — checks per-org monthly USD spend in MongoDB before each call; rejects with HTTP 429 if the cap is reached.
  3. **Prompt injection allowlist** — scans user messages against regex patterns for common injection techniques (`ignore instructions`, `jailbreak`, `reveal system prompt`, etc.).
  4. **Spend recording** — upserts cost estimate into MongoDB `openai_org_spend` collection after each successful call so the budget check survives restarts.
- `getOrgMonthlySpend()`: exposes current spend vs budget for admin dashboards.
- Gracefully degrades when MongoDB is unavailable (spend tracking skipped, requests still served).

**`src/config/env.ts`** + **`.env.example`**
- Added `OPENAI_API_KEY`, `OPENAI_ORG_MONTHLY_BUDGET_USD` (default $50), `OPENAI_MAX_TOKENS_PER_REQUEST` (default 2000).

Closes #171
Closes #173
Closes #178