### PR TITLE
feat: implement createTransfer service with validation, KYC checks, a…

### DIFF
--- a/src/services/transfer/transferService.ts
+++ b/src/services/transfer/transferService.ts
@@ -14,7 +14,7 @@ import { stellarClient } from "../stellar/client";
 import { getBaseFee } from "../stellar/feeManager";
 import { resolveRecipientToStellarAddress } from "../recipient/recipientResolver";
 
-import { logger } from "../../config/logger";
+import { logger, logFinancialEvent } from "../../config/logger";
 import type {
   CreateTransferParams,
   CreateTransferOptions,
@@ -111,7 +111,12 @@ export async function createTransfer(
   });
 
   const correlationId = options?.correlationId ?? crypto.randomUUID();
-  const amountInSmallestUnit = Math.round(Number(amount) * 100);
+  // Avoid float arithmetic: parse integer and fractional parts separately to
+  // prevent precision loss when amount has up to 7 decimal places.
+  const [wholePart, fracPart = ""] = amount.split(".");
+  const amountInSmallestUnit =
+    parseInt(wholePart, 10) * 100 +
+    parseInt(fracPart.slice(0, 2).padEnd(2, "0"), 10);
 
   // Emit transfer.initiated immediately after the Transaction row is created
   logFinancialEvent({

--- a/tests/transfer.test.ts
+++ b/tests/transfer.test.ts
@@ -291,6 +291,61 @@ describe("createTransfer", () => {
     expect(mockTx.update).not.toHaveBeenCalled();
   });
 
+  // ── max precision Decimal construction ──────────────────────────────────────
+
+  it("stores Decimal with full 7-decimal precision (no float rounding)", async () => {
+    (mockUser.findUnique as jest.Mock)
+      .mockResolvedValueOnce(verifiedSender)
+      .mockResolvedValueOnce({ stellarAddress: RECIPIENT_STELLAR });
+    (mockUser.findFirst as jest.Mock).mockResolvedValue(bobUser);
+    (mockTx.create as jest.Mock).mockResolvedValue({ id: "tx-prec" });
+
+    await createTransfer({
+      senderUserId: SENDER_ID,
+      to: "@bob",
+      amountAcbu: "9999999.9999999",
+    });
+
+    const createCall = (mockTx.create as jest.Mock).mock.calls[0][0];
+    const stored = createCall.data.acbuAmount;
+    // Prisma Decimal.toString() must round-trip the original string exactly
+    expect(stored.toString()).toBe("9999999.9999999");
+  });
+
+  it("stores Decimal for minimum positive amount with 7 decimals", async () => {
+    (mockUser.findUnique as jest.Mock)
+      .mockResolvedValueOnce(verifiedSender)
+      .mockResolvedValueOnce({ stellarAddress: RECIPIENT_STELLAR });
+    (mockUser.findFirst as jest.Mock).mockResolvedValue(bobUser);
+    (mockTx.create as jest.Mock).mockResolvedValue({ id: "tx-min-prec" });
+
+    await createTransfer({
+      senderUserId: SENDER_ID,
+      to: "@bob",
+      amountAcbu: "0.0000001",
+    });
+
+    const createCall = (mockTx.create as jest.Mock).mock.calls[0][0];
+    expect(createCall.data.acbuAmount.toString()).toBe("0.0000001");
+  });
+
+  it("stores Decimal for whole number amount without decimal point", async () => {
+    (mockUser.findUnique as jest.Mock)
+      .mockResolvedValueOnce(verifiedSender)
+      .mockResolvedValueOnce({ stellarAddress: RECIPIENT_STELLAR });
+    (mockUser.findFirst as jest.Mock).mockResolvedValue(bobUser);
+    (mockTx.create as jest.Mock).mockResolvedValue({ id: "tx-whole" });
+
+    await createTransfer({
+      senderUserId: SENDER_ID,
+      to: "@bob",
+      amountAcbu: "1000000",
+    });
+
+    const createCall = (mockTx.create as jest.Mock).mock.calls[0][0];
+    expect(createCall.data.acbuAmount.toString()).toBe("1000000");
+  });
+
   // ── raw Stellar address as recipient ─────────────────────────────────────────
 
   it("accepts raw Stellar address as recipient", async () => {


### PR DESCRIPTION
Three changes made across two files:
Closes #123 

[transferService.ts:17](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/src/services/transfer/transferService.ts#L17) — missing import (critical runtime bug)
logFinancialEvent was called on lines 117, 145, 191, 224 but never imported. At runtime this would throw ReferenceError: logFinancialEvent is not defined on every transfer attempt.

[transferService.ts:114–119](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/src/services/transfer/transferService.ts#L114) — float precision fix
Replaced Math.round(Number(amount) * 100) with integer string arithmetic. For an amount like 9999999.9999999, the float path can produce 999999999.9999900 before rounding, which is indeterminate at the boundary. The new path splits on ., parses each part as an integer, and combines — no floating point involved.

[tests/transfer.test.ts](vscode-webview://0p0da59vnjm99bn1u149ca2prqmbgrtprcd5hq9qss0vupachqfs/tests/transfer.test.ts) — acceptance tests
Added three tests under createTransfer that verify prisma.transaction.create receives a Decimal whose .toString() round-trips the original string exactly: max-precision 9999999.9999999, minimum unit 0.0000001, and a whole number 1000000. These would fail if a plain string were passed to Prisma instead of new Decimal(amount), or if float coercion mangled the value before construction.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added financial event logging for transfer lifecycle states (initiated, completed, failed)

* **Bug Fixes**
  * Improved decimal precision handling in transfer amount calculations to eliminate rounding errors

* **Tests**
  * Expanded test coverage to validate transfer amount precision across various decimal values

<!-- end of auto-generated comment: release notes by coderabbit.ai -->