### PR TITLE
fix: optimize MongoDB indexes for cache hot keys (B-057)

### DIFF
--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -6,15 +6,30 @@ let client: MongoClient | null = null;
 let db: Db | null = null;
 
 export async function connectMongoDB(): Promise<Db> {
-  if (db) {
-    return db;
-  }
+  if (db) return db;
 
   try {
     client = new MongoClient(config.mongodbUri);
     await client.connect();
     db = client.db();
+
     logger.info("MongoDB connected successfully");
+
+    const collection = db.collection("cache");
+
+    await Promise.all([
+      collection.createIndex(
+        { key: 1, expiresAt: 1 },
+        { name: "idx_key_expiresAt" }
+      ),
+      collection.createIndex(
+        { expiresAt: 1 },
+        { name: "idx_expiresAt_ttl", expireAfterSeconds: 0 }
+      ),
+    ]).catch((error) => {
+      logger.warn("Index creation warning", error);
+    });
+
     return db;
   } catch (error) {
     logger.error("Failed to connect to MongoDB", error);

--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -17,22 +17,46 @@ export async function connectMongoDB(): Promise<Db> {
 
     const collection = db.collection("cache");
 
-    await Promise.all([
-      collection.createIndex(
-        { key: 1, expiresAt: 1 },
-        { name: "idx_key_expiresAt" }
-      ),
-      collection.createIndex(
-        { expiresAt: 1 },
-        { name: "idx_expiresAt_ttl", expireAfterSeconds: 0 }
-      ),
-    ]).catch((error) => {
-      logger.warn("Index creation warning", error);
+    // Define index configurations
+    const indexConfigs = [
+      {
+        spec: { key: 1, expiresAt: 1 },
+        options: { name: "idx_key_expiresAt" },
+        critical: false,
+      },
+      {
+        spec: { expiresAt: 1 },
+        options: { name: "idx_expiresAt_ttl", expireAfterSeconds: 0 },
+        critical: true, // TTL failure impacts security logic
+      },
+    ];
+
+    // Execute all index creations regardless of individual failures
+    const results = await Promise.allSettled(
+      indexConfigs.map((idx) => collection.createIndex(idx.spec, idx.options))
+    );
+
+    // Evaluate results
+    results.forEach((result, i) => {
+      if (result.status === "rejected") {
+        const config = indexConfigs[i];
+        const logData = { 
+          indexName: config.options.name, 
+          error: result.reason 
+        };
+
+        if (config.critical) {
+          // TTL failures are logged as errors because they break brute-force protection
+          logger.error("Critical index creation failed", logData);
+        } else {
+          logger.warn("Index creation warning", logData);
+        }
+      }
     });
 
     return db;
   } catch (error) {
-    logger.error("Failed to connect to MongoDB", error);
+    logger.error("Failed to connect to MongoDB", { error });
     throw error;
   }
 }


### PR DESCRIPTION
## Issue
#172 B-057 — Mongo index strategy for hot keys

Hot keys in the cache collection caused slower lookups under load due to suboptimal indexing.

---

## Changes
- Added index for fast key-based lookups:
  - `{ key: 1 }` OR `{ key: 1, expiresAt: 1 }` (depending on your final choice)
- Added TTL index for automatic expiration:
  - `{ expiresAt: 1 }` with `expireAfterSeconds: 0`
- Indexes are created on MongoDB connection startup

---

## Why this works
- Ensures O(log n) lookup for hot keys instead of collection scans
- Reduces latency on high-frequency cache/rate-limit queries
- TTL index removes expired documents automatically (no manual cleanup)

---

## Impact
- Improved performance for hot key access paths
- Lower p95 latency under load (expected)

---

## Validation
- Verified indexes are created on startup
- Confirmed query uses index via `.explain()` (IXSCAN)
- Ready for load testing to validate p95 improvement

---

## Notes
- No schema changes
- No new dependencies
- Safe, backward-compatible change

- Closes: #172 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database connections are more reliable: index creation errors no longer block establishing a connection; critical index failures are surfaced as errors while non-critical failures emit warnings.

* **Chores**
  * Cache performance optimized by creating necessary database indexes automatically during connection setup, improving query efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->