### PR TITLE
fix(limits): use UTC start-of-day for daily limit windows

### DIFF
--- a/src/services/limits/limitsService.ts
+++ b/src/services/limits/limitsService.ts
@@ -43,19 +43,16 @@ export async function checkDepositLimits(
   organizationId: string | null,
 ): Promise<void> {
   const config = await getLimitConfig(audience);
-  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
-  const startOfMonth = new Date(
-    new Date().getFullYear(),
-    new Date().getMonth(),
-    1,
-  );
+  const now = new Date();
+  const startOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 
   const whereActor = buildActorWhere(userId, organizationId);
   const mintedDaily = await prisma.transaction.aggregate({
     where: {
       type: "mint",
       status: { in: ["pending", "processing", "completed"] },
-      createdAt: { gte: since24h },
+      createdAt: { gte: startOfDay },
       ...whereActor,
     },
     _sum: { usdcAmount: true },
@@ -103,12 +100,9 @@ export async function checkWithdrawalLimits(
   organizationId: string | null,
 ): Promise<void> {
   const config = await getLimitConfig(audience);
-  const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000);
-  const startOfMonth = new Date(
-    new Date().getFullYear(),
-    new Date().getMonth(),
-    1,
-  );
+  const now = new Date();
+  const startOfDay = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  const startOfMonth = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1));
 
   const whereActor = buildActorWhere(userId, organizationId);
   const burnedDaily = await prisma.transaction.aggregate({
@@ -116,7 +110,7 @@ export async function checkWithdrawalLimits(
       type: { in: ["burn", "bill_payment"] },
       localCurrency: currency,
       status: { in: ["pending", "processing", "completed"] },
-      createdAt: { gte: since24h },
+      createdAt: { gte: startOfDay },
       ...whereActor,
     },
     _sum: { acbuAmountBurned: true },


### PR DESCRIPTION
## Summary

Fixes #297

The daily limit windows in `checkDepositLimits` and `checkWithdrawalLimits` used a rolling 24-hour window (`Date.now() - 24h`). This allowed a user to straddle midnight UTC — transacting near the end of one UTC day and again at the start of the next — effectively doubling their daily allowance within a single user-perceived day.

## Changes

- Replace `since24h = new Date(Date.now() - 24 * 60 * 60 * 1000)` with `startOfDay = new Date(Date.UTC(...))` anchored to 00:00:00 UTC in both functions.
- Also fix `startOfMonth` to use `Date.UTC` instead of local-time `new Date().getMonth()`, ensuring consistent UTC-based month boundaries regardless of server timezone.

## Testing

- Build passes (pre-existing unrelated TS errors on `dev` are unchanged).
- Logic: at any point in the day, the window now starts at 00:00:00 UTC, so all users share the same reset boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated deposit and withdrawal limit calculations to use UTC-aligned daily and monthly boundaries instead of rolling 24-hour windows and local timezone boundaries. This ensures consistent and predictable limit reset times across all users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/326?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->