### PR TITLE
fix: add .dockerignore to prevent build context bloat and secret leakage

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ node_modules/
 dist/
 build/
 
-# Logs
+#Logs
 logs/
 *.log
 npm-debug.log*
@@ -14,27 +14,27 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-# Environment variables & Secrets
+#Environment variables & Secrets
 .env
 .env.*
 !.env.example
 !.env.test
 
-# Git and IDE configurations
+#Git and IDE configurations
 .git
 .gitignore
 .idea/
 .vscode/
 
-# Testing and Coverage
+#Testing and Coverage
 coverage/
 .nyc_output/
 
-# OS generated files
+#OS generated files
 .DS_Store
 Thumbs.db
 
-# Misc project directories not needed in production container
+#Misc project directories not needed in production container
 scratch/
 docs/
 tests/

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,40 @@
+# Dependency directories
+node_modules/
+.pnpm-store/
+
+# Build outputs
+dist/
+build/
+
+# Logs
+logs/
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Environment variables & Secrets
+.env
+.env.*
+!.env.example
+!.env.test
+
+# Git and IDE configurations
+.git
+.gitignore
+.idea/
+.vscode/
+
+# Testing and Coverage
+coverage/
+.nyc_output/
+
+# OS generated files
+.DS_Store
+Thumbs.db
+
+# Misc project directories not needed in production container
+scratch/
+docs/
+tests/

--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ Thumbs.db
 # Temporary files
 tmp/
 temp/
+.idea


### PR DESCRIPTION
## Description
This PR introduces a `.dockerignore` file to the project root to optimize the Docker build process and enhance security. 

Previously, the absence of this file meant that the entire working directory—including heavy dependencies and sensitive environment variables—was sent to the Docker daemon during builds. 

## Changes Made
- Excluded dependency directories (`node_modules/`, `.pnpm-store/`) to significantly reduce the build context size.
- Excluded sensitive files (`.env`, `.env.*`) to prevent accidental secret leakage in the resulting images.
- Excluded build artifacts (`dist/`, `build/`), logs, and development-specific directories (`tests/`, `docs/`, `scratch/`) that are not required for the production runtime environment.
- Excluded Git and IDE configurations (`.git/`, `.idea/`, `.vscode/`).

## Related Issues
Closes #306 

## Checklist
- [x] Tested locally to ensure the build context is minimized.
- [x] Verified that `.env.example` and `.env.test` remain accessible if needed for CI/CD pipelines.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build configuration to exclude unnecessary files and directories (dependencies, logs, environment files, metadata, test artifacts, OS files) from the build context.
  * Enhanced Git configuration to exclude IDE-related directories.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/327?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->