### PR TITLE
fix(validators): remove unused exported validator helpers (closes #303)

### DIFF
--- a/src/validators/bulkTransferValidator.ts
+++ b/src/validators/bulkTransferValidator.ts
@@ -16,10 +16,6 @@ export const bulkTransferRowSchema = z.object({
 
 export type BulkTransferRowInput = z.infer<typeof bulkTransferRowSchema>;
 
-export function validateBulkTransferRow(row: unknown): BulkTransferRowInput {
-  return bulkTransferRowSchema.parse(row);
-}
-
-export function validateBulkTransferRowSafe(row: unknown) {
-  return bulkTransferRowSchema.safeParse(row);
-}
+// Helper types and schema are exposed; parsing helpers are unused in the
+// codebase and were removed to avoid exporting dead code. Use
+// `bulkTransferRowSchema.parse()` / `safeParse()` where needed.


### PR DESCRIPTION
Title:
fix(validators): remove unused exported validator helpers (closes #303)

Body:
## Summary
This PR removes unused exported helper functions from `src/validators/bulkTransferValidator.ts`.

## Why
Issue #303 reported unused Zod schemas in the validators directory. After reviewing the repo, the Zod schemas currently defined in `src/validators` are already wired into services, controllers, and routes. The only dead code found in this area was the unused parsing helper exports in `bulkTransferValidator.ts`.

## Changes
- Removed `validateBulkTransferRow`
- Removed `validateBulkTransferRowSafe`
- Kept the shared `bulkTransferRowSchema` export for existing validation usage

## Notes
- No runtime behavior change.
- No route/controller wiring was modified.

Closes #303

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Breaking Changes**
  * Updated bulk transfer validation API. Use schema validation methods directly instead of wrapper functions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/328?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->