### PR TITLE
Fix investment withdrawal delays to use trusted database clock

### DIFF
--- a/src/config/investment.ts
+++ b/src/config/investment.ts
@@ -16,9 +16,10 @@ export const INVESTMENT_FORCED_REMOVAL_FEE_PERCENT = Number(
   process.env.INVESTMENT_FORCED_REMOVAL_FEE_PERCENT || "1",
 );
 
-export function isBusinessWithdrawalAllowedDate(
-  date: Date = new Date(),
-): boolean {
-  const day = date.getDate();
-  return INVESTMENT_BUSINESS_ALLOWED_DAYS.includes(day);
+export function isBusinessWithdrawalAllowedDay(dayOfMonth: number): boolean {
+  return INVESTMENT_BUSINESS_ALLOWED_DAYS.includes(dayOfMonth);
+}
+
+export function isBusinessWithdrawalAllowedDate(date: Date): boolean {
+  return isBusinessWithdrawalAllowedDay(date.getUTCDate());
 }

--- a/src/controllers/investmentController.test.ts
+++ b/src/controllers/investmentController.test.ts
@@ -1,0 +1,106 @@
+/// <reference types="jest" />
+import type { NextFunction, Response } from "express";
+import { postInvestmentWithdrawRequest } from "./investmentController";
+import { prisma } from "../config/database";
+import type { AuthRequest } from "../middleware/auth";
+import type { AppError } from "../middleware/errorHandler";
+import { getInvestmentWithdrawalTiming } from "../services/investment/withdrawalTimingService";
+
+jest.mock("../config/database", () => ({
+  prisma: {
+    investmentWithdrawalRequest: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../services/investment/withdrawalTimingService", () => ({
+  getInvestmentWithdrawalTiming: jest.fn(),
+}));
+
+const mockCreate = prisma.investmentWithdrawalRequest.create as jest.Mock;
+const mockGetInvestmentWithdrawalTiming =
+  getInvestmentWithdrawalTiming as jest.Mock;
+
+const trustedRequestedAt = new Date("2026-05-27T12:00:00.000Z");
+const trustedAvailableAt = new Date("2026-05-28T12:00:00.000Z");
+
+const makeRes = () => {
+  const res = { status: jest.fn(), json: jest.fn() } as unknown as Response;
+  (res.status as jest.Mock).mockReturnValue(res);
+  return res;
+};
+
+const makeNext = () => jest.fn() as jest.MockedFunction<NextFunction>;
+
+function makeRequest(body: unknown): AuthRequest {
+  return {
+    body,
+    apiKey: { userId: "user-123", organizationId: null },
+  } as AuthRequest;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockGetInvestmentWithdrawalTiming.mockResolvedValue({
+    requestedAt: trustedRequestedAt,
+    availableAt: trustedAvailableAt,
+    businessCalendarDay: 27,
+    isBusinessWithdrawalAllowedDate: true,
+  });
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+describe("postInvestmentWithdrawRequest", () => {
+  it("creates retail withdrawal timing from trusted database time", async () => {
+    jest.useFakeTimers().setSystemTime(new Date("2035-01-01T00:00:00.000Z"));
+    mockCreate.mockResolvedValue({ id: "withdrawal-1" });
+    const res = makeRes();
+    const next = makeNext();
+
+    await postInvestmentWithdrawRequest(
+      makeRequest({ amount_acbu: "100.00", audience: "retail" }),
+      res,
+      next,
+    );
+
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: expect.objectContaining({
+        createdAt: trustedRequestedAt,
+        availableAt: trustedAvailableAt,
+      }),
+    });
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        available_at: trustedAvailableAt.toISOString(),
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("rejects non-forced business withdrawals using the trusted calendar day", async () => {
+    mockGetInvestmentWithdrawalTiming.mockResolvedValue({
+      requestedAt: trustedRequestedAt,
+      availableAt: trustedAvailableAt,
+      businessCalendarDay: 27,
+      isBusinessWithdrawalAllowedDate: false,
+    });
+    const next = makeNext();
+
+    await postInvestmentWithdrawRequest(
+      makeRequest({ amount_acbu: "100.00", audience: "business" }),
+      makeRes(),
+      next,
+    );
+
+    expect(mockCreate).not.toHaveBeenCalled();
+    const err = next.mock.calls[0][0] as unknown as AppError;
+    expect(err.statusCode).toBe(403);
+    expect(err.code).toBe("INVESTMENT_BUSINESS_CALENDAR");
+  });
+});

--- a/src/controllers/investmentController.ts
+++ b/src/controllers/investmentController.ts
@@ -155,9 +155,10 @@ export async function getInvestmentWithdrawRequests(
     const hasMore = list.length > limit;
     const page = hasMore ? list.slice(0, limit) : list;
     const nextCursor = hasMore ? page[page.length - 1].id : null;
+    type WithdrawalRequestRow = (typeof list)[number];
 
     res.status(200).json({
-      requests: page.map((r: typeof list[number]) => ({
+      requests: page.map((r: WithdrawalRequestRow) => ({
         id: r.id,
         amount_acbu: r.amountAcbu.toString(),
         status: r.status,

--- a/src/controllers/investmentController.ts
+++ b/src/controllers/investmentController.ts
@@ -6,14 +6,12 @@ import { z } from "zod";
 import { prisma } from "../config/database";
 import { AuthRequest } from "../middleware/auth";
 import { Decimal } from "@prisma/client/runtime/library";
-import { InvestmentWithdrawalRequest } from "@prisma/client";
 import { AppError } from "../middleware/errorHandler";
 import {
-  isBusinessWithdrawalAllowedDate,
+  INVESTMENT_BUSINESS_ALLOWED_DAYS,
   INVESTMENT_FORCED_REMOVAL_FEE_PERCENT,
 } from "../config/investment";
-import { getRabbitMQChannel } from "../config/rabbitmq";
-import { QUEUES } from "../config/rabbitmq";
+import { getInvestmentWithdrawalTiming } from "../services/investment/withdrawalTimingService";
 
 export const requestSchema = z.object({
   amount_acbu: z
@@ -26,8 +24,6 @@ export const requestSchema = z.object({
   audience: z.enum(["retail", "business"]),
   forced_removal: z.boolean().optional(),
 });
-
-const TWENTY_FOUR_HOURS_MS = 24 * 60 * 60 * 1000;
 
 /**
  * POST /v1/investment/withdraw/request - Request investment withdrawal. Funds available in 24h; notification when ready.
@@ -54,20 +50,20 @@ export async function postInvestmentWithdrawRequest(
     }
     const { amount_acbu, audience, forced_removal } = parsed.data;
     const amountNum = Number(amount_acbu);
+    const timing = await getInvestmentWithdrawalTiming();
 
     if (audience === "business") {
-      const onAllowedDate = isBusinessWithdrawalAllowedDate();
-      if (!onAllowedDate && !forced_removal) {
+      if (!timing.isBusinessWithdrawalAllowedDate && !forced_removal) {
         throw new AppError(
           "Business investment withdrawals are only allowed on specific dates. Use forced_removal: true to withdraw with 1% fee (funds in 24h).",
           403,
           "INVESTMENT_BUSINESS_CALENDAR",
-          { allowed_days: process.env.INVESTMENT_BUSINESS_ALLOWED_DAYS || "1,15" },
+          { allowed_days: INVESTMENT_BUSINESS_ALLOWED_DAYS.join(",") },
         );
       }
     }
 
-    const availableAt = new Date(Date.now() + TWENTY_FOUR_HOURS_MS);
+    const availableAt = timing.availableAt;
     let feePercent: Decimal | null = null;
     if (audience === "business" && forced_removal) {
       feePercent = new Decimal(INVESTMENT_FORCED_REMOVAL_FEE_PERCENT);
@@ -83,6 +79,7 @@ export async function postInvestmentWithdrawRequest(
         forcedRemoval: audience === "business" && forced_removal === true,
         feePercent,
         availableAt,
+        createdAt: timing.requestedAt,
       },
     });
 
@@ -105,7 +102,12 @@ export async function postInvestmentWithdrawRequest(
   }
 }
 
-const WITHDRAWAL_STATUSES = ["requested", "available", "completed", "cancelled"] as const;
+const WITHDRAWAL_STATUSES = [
+  "requested",
+  "available",
+  "completed",
+  "cancelled",
+] as const;
 
 export const getWithdrawRequestsQuerySchema = z.object({
   limit: z
@@ -155,7 +157,7 @@ export async function getInvestmentWithdrawRequests(
     const nextCursor = hasMore ? page[page.length - 1].id : null;
 
     res.status(200).json({
-      requests: page.map((r: InvestmentWithdrawalRequest) => ({
+      requests: page.map((r: typeof list[number]) => ({
         id: r.id,
         amount_acbu: r.amountAcbu.toString(),
         status: r.status,
@@ -169,29 +171,4 @@ export async function getInvestmentWithdrawRequests(
   } catch (e) {
     next(e);
   }
-}
-
-/**
- * Publish investment_withdrawal_ready to NOTIFICATIONS queue (called by job).
- */
-export async function publishInvestmentWithdrawalReady(
-  userId: string | null,
-  amountAcbu: number,
-  organizationId?: string | null,
-): Promise<void> {
-  const ch = getRabbitMQChannel();
-  await ch.assertQueue(QUEUES.NOTIFICATIONS, { durable: true });
-  ch.sendToQueue(
-    QUEUES.NOTIFICATIONS,
-    Buffer.from(
-      JSON.stringify({
-        type: "investment_withdrawal_ready",
-        userId,
-        organizationId: organizationId ?? null,
-        amountAcbu,
-        timestamp: new Date().toISOString(),
-      }),
-    ),
-    { persistent: true },
-  );
 }

--- a/src/jobs/investmentWithdrawalJob.ts
+++ b/src/jobs/investmentWithdrawalJob.ts
@@ -2,23 +2,17 @@
  * Investment withdrawal job: at T+24h mark requests as 'available' and send "investment withdrawal ready" notification.
  */
 import { prisma } from "../config/database";
-import { publishInvestmentWithdrawalReady } from "../controllers/investmentController";
 import { logger } from "../config/logger";
+import { publishInvestmentWithdrawalReady } from "../services/investment/withdrawalNotificationService";
+import { getReadyInvestmentWithdrawalBatch } from "../services/investment/withdrawalTimingService";
 
 export async function processInvestmentWithdrawalAvailability(): Promise<void> {
-  const now = new Date();
-  const records = await prisma.investmentWithdrawalRequest.findMany({
-    where: {
-      status: { in: ["requested", "processing"] },
-      availableAt: { lte: now },
-    },
-    take: 100,
-  });
+  const { trustedNow, records } = await getReadyInvestmentWithdrawalBatch();
   for (const r of records) {
     try {
       await prisma.investmentWithdrawalRequest.update({
         where: { id: r.id },
-        data: { status: "available", notifiedAt: new Date() },
+        data: { status: "available", notifiedAt: trustedNow },
       });
       const amountAcbu = r.amountAcbu.toNumber();
       if (r.userId || r.organizationId) {
@@ -26,6 +20,7 @@ export async function processInvestmentWithdrawalAvailability(): Promise<void> {
           r.userId,
           amountAcbu,
           r.organizationId,
+          trustedNow,
         );
       }
       logger.info("Investment withdrawal marked available and notified", {

--- a/src/jobs/investmentWithdrawalJob.ts
+++ b/src/jobs/investmentWithdrawalJob.ts
@@ -4,16 +4,33 @@
 import { prisma } from "../config/database";
 import { logger } from "../config/logger";
 import { publishInvestmentWithdrawalReady } from "../services/investment/withdrawalNotificationService";
-import { getReadyInvestmentWithdrawalBatch } from "../services/investment/withdrawalTimingService";
+import {
+  getReadyInvestmentWithdrawalBatch,
+  READY_WITHDRAWAL_STATUSES,
+} from "../services/investment/withdrawalTimingService";
 
 export async function processInvestmentWithdrawalAvailability(): Promise<void> {
   const { trustedNow, records } = await getReadyInvestmentWithdrawalBatch();
   for (const r of records) {
     try {
-      await prisma.investmentWithdrawalRequest.update({
-        where: { id: r.id },
+      const transition = await prisma.investmentWithdrawalRequest.updateMany({
+        where: {
+          id: r.id,
+          status: { in: [...READY_WITHDRAWAL_STATUSES] },
+          availableAt: { lte: trustedNow },
+        },
         data: { status: "available", notifiedAt: trustedNow },
       });
+      if (transition.count === 0) {
+        logger.info(
+          "Investment withdrawal already processed or no longer ready",
+          {
+            requestId: r.id,
+          },
+        );
+        continue;
+      }
+
       const amountAcbu = r.amountAcbu.toNumber();
       if (r.userId || r.organizationId) {
         await publishInvestmentWithdrawalReady(

--- a/src/services/investment/withdrawalNotificationService.ts
+++ b/src/services/investment/withdrawalNotificationService.ts
@@ -1,0 +1,28 @@
+import { getRabbitMQChannel, QUEUES } from "../../config/rabbitmq";
+
+/**
+ * Publishes the investment withdrawal readiness notification from the service
+ * layer so background jobs do not depend on HTTP controllers.
+ */
+export async function publishInvestmentWithdrawalReady(
+  userId: string | null,
+  amountAcbu: number,
+  organizationId: string | null | undefined,
+  occurredAt: Date,
+): Promise<void> {
+  const ch = getRabbitMQChannel();
+  await ch.assertQueue(QUEUES.NOTIFICATIONS, { durable: true });
+  ch.sendToQueue(
+    QUEUES.NOTIFICATIONS,
+    Buffer.from(
+      JSON.stringify({
+        type: "investment_withdrawal_ready",
+        userId,
+        organizationId: organizationId ?? null,
+        amountAcbu,
+        timestamp: occurredAt.toISOString(),
+      }),
+    ),
+    { persistent: true },
+  );
+}

--- a/src/services/investment/withdrawalTimingService.test.ts
+++ b/src/services/investment/withdrawalTimingService.test.ts
@@ -1,0 +1,38 @@
+import { prisma } from "../../config/database";
+import { getInvestmentWithdrawalTiming } from "./withdrawalTimingService";
+
+jest.mock("../../config/database", () => ({
+  prisma: {
+    $queryRaw: jest.fn(),
+    investmentWithdrawalRequest: {
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+const mockQueryRaw = prisma.$queryRaw as jest.Mock;
+
+describe("getInvestmentWithdrawalTiming", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("maps withdrawal timing from the trusted database clock row", async () => {
+    const requestedAt = new Date("2026-05-15T09:30:00.000Z");
+    const availableAt = new Date("2026-05-16T09:30:00.000Z");
+    mockQueryRaw.mockResolvedValue([
+      {
+        requestedAt,
+        availableAt,
+        businessCalendarDay: 15,
+      },
+    ]);
+
+    await expect(getInvestmentWithdrawalTiming()).resolves.toEqual({
+      requestedAt,
+      availableAt,
+      businessCalendarDay: 15,
+      isBusinessWithdrawalAllowedDate: true,
+    });
+  });
+});

--- a/src/services/investment/withdrawalTimingService.ts
+++ b/src/services/investment/withdrawalTimingService.ts
@@ -4,7 +4,7 @@ import { isBusinessWithdrawalAllowedDay } from "../../config/investment";
 
 const WITHDRAWAL_DELAY_HOURS = 24;
 const READY_WITHDRAWAL_BATCH_SIZE = 100;
-const READY_WITHDRAWAL_STATUSES = ["requested", "processing"] as const;
+export const READY_WITHDRAWAL_STATUSES = ["requested", "processing"] as const;
 
 type WithdrawalTimingRow = {
   requestedAt: Date;

--- a/src/services/investment/withdrawalTimingService.ts
+++ b/src/services/investment/withdrawalTimingService.ts
@@ -1,0 +1,101 @@
+import type { InvestmentWithdrawalRequest } from "@prisma/client";
+import { prisma } from "../../config/database";
+import { isBusinessWithdrawalAllowedDay } from "../../config/investment";
+
+const WITHDRAWAL_DELAY_HOURS = 24;
+const READY_WITHDRAWAL_BATCH_SIZE = 100;
+const READY_WITHDRAWAL_STATUSES = ["requested", "processing"] as const;
+
+type WithdrawalTimingRow = {
+  requestedAt: Date;
+  availableAt: Date;
+  businessCalendarDay: number;
+};
+
+type TrustedClockRow = {
+  trustedNow: Date;
+};
+
+export type InvestmentWithdrawalTiming = {
+  requestedAt: Date;
+  availableAt: Date;
+  businessCalendarDay: number;
+  isBusinessWithdrawalAllowedDate: boolean;
+};
+
+export type ReadyInvestmentWithdrawalBatch = {
+  trustedNow: Date;
+  records: InvestmentWithdrawalRequest[];
+};
+
+/**
+ * Reads PostgreSQL's wall clock once and derives every withdrawal timing value
+ * from that trusted source. This keeps delay enforcement independent from API
+ * server clock drift.
+ */
+export async function getInvestmentWithdrawalTiming(): Promise<InvestmentWithdrawalTiming> {
+  const [row] = await prisma.$queryRaw<WithdrawalTimingRow[]>`
+    WITH trusted_clock AS (
+      SELECT clock_timestamp() AS trusted_now
+    )
+    SELECT
+      trusted_now AS "requestedAt",
+      trusted_now + make_interval(hours => ${WITHDRAWAL_DELAY_HOURS}) AS "availableAt",
+      EXTRACT(DAY FROM (trusted_now AT TIME ZONE 'UTC'))::int AS "businessCalendarDay"
+    FROM trusted_clock
+  `;
+
+  const requestedAt = assertDate(row?.requestedAt, "requestedAt");
+  const availableAt = assertDate(row?.availableAt, "availableAt");
+  const businessCalendarDay = assertBusinessCalendarDay(
+    row?.businessCalendarDay,
+  );
+
+  return {
+    requestedAt,
+    availableAt,
+    businessCalendarDay,
+    isBusinessWithdrawalAllowedDate:
+      isBusinessWithdrawalAllowedDay(businessCalendarDay),
+  };
+}
+
+export async function getReadyInvestmentWithdrawalBatch(
+  limit = READY_WITHDRAWAL_BATCH_SIZE,
+): Promise<ReadyInvestmentWithdrawalBatch> {
+  const trustedNow = await getTrustedDatabaseTime();
+  const records = await prisma.investmentWithdrawalRequest.findMany({
+    where: {
+      status: { in: [...READY_WITHDRAWAL_STATUSES] },
+      availableAt: { lte: trustedNow },
+    },
+    take: limit,
+  });
+
+  return { trustedNow, records };
+}
+
+async function getTrustedDatabaseTime(): Promise<Date> {
+  const [row] = await prisma.$queryRaw<TrustedClockRow[]>`
+    SELECT clock_timestamp() AS "trustedNow"
+  `;
+
+  return assertDate(row?.trustedNow, "trustedNow");
+}
+
+function assertDate(value: unknown, fieldName: string): Date {
+  if (value instanceof Date && Number.isFinite(value.getTime())) {
+    return value;
+  }
+
+  throw new Error(`Database clock query returned invalid ${fieldName}`);
+}
+
+function assertBusinessCalendarDay(value: unknown): number {
+  const day = Number(value);
+  if (Number.isInteger(day) && day >= 1 && day <= 31) {
+    return day;
+  }
+
+  throw new Error("Database clock query returned invalid businessCalendarDay");
+}

--- a/tests/investmentWithdrawal.test.ts
+++ b/tests/investmentWithdrawal.test.ts
@@ -7,7 +7,7 @@ jest.mock("../src/config/database", () => ({
     $queryRaw: jest.fn(),
     investmentWithdrawalRequest: {
       findMany: jest.fn(),
-      update: jest.fn(),
+      updateMany: jest.fn(),
     },
     user: {
       findUnique: jest.fn(),
@@ -30,13 +30,15 @@ import { Decimal } from "@prisma/client/runtime/library";
 
 const mockQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockFindMany = prisma.investmentWithdrawalRequest.findMany as jest.Mock;
-const mockUpdate = prisma.investmentWithdrawalRequest.update as jest.Mock;
+const mockUpdateMany = prisma.investmentWithdrawalRequest
+  .updateMany as jest.Mock;
 const mockPublish = publishInvestmentWithdrawalReady as jest.Mock;
 const trustedNow = new Date("2026-05-27T12:00:00.000Z");
 
 beforeEach(() => {
   jest.clearAllMocks();
   mockQueryRaw.mockResolvedValue([{ trustedNow }]);
+  mockUpdateMany.mockResolvedValue({ count: 1 });
 });
 
 describe("processInvestmentWithdrawalAvailability", () => {
@@ -55,8 +57,6 @@ describe("processInvestmentWithdrawalAvailability", () => {
         availableAt: new Date(now.getTime() - 1000),
       },
     ]);
-
-    mockUpdate.mockResolvedValue({});
 
     await processInvestmentWithdrawalAvailability();
 
@@ -83,8 +83,6 @@ describe("processInvestmentWithdrawalAvailability", () => {
         availableAt: new Date(now.getTime() - 1000),
       },
     ]);
-
-    mockUpdate.mockResolvedValue({});
 
     await processInvestmentWithdrawalAvailability();
 
@@ -113,12 +111,14 @@ describe("processInvestmentWithdrawalAvailability", () => {
       },
     ]);
 
-    mockUpdate.mockResolvedValue({});
-
     await processInvestmentWithdrawalAvailability();
 
-    expect(mockUpdate).toHaveBeenCalledWith({
-      where: { id: requestId },
+    expect(mockUpdateMany).toHaveBeenCalledWith({
+      where: {
+        id: requestId,
+        status: { in: ["requested", "processing"] },
+        availableAt: { lte: trustedNow },
+      },
       data: { status: "available", notifiedAt: trustedNow },
     });
   });
@@ -152,8 +152,6 @@ describe("processInvestmentWithdrawalAvailability", () => {
       },
     ]);
 
-    mockUpdate.mockResolvedValue({});
-
     await processInvestmentWithdrawalAvailability();
 
     expect(mockPublish).not.toHaveBeenCalled();
@@ -183,8 +181,6 @@ describe("processInvestmentWithdrawalAvailability", () => {
         availableAt: new Date(now.getTime() - 1000),
       },
     ]);
-
-    mockUpdate.mockResolvedValue({});
 
     await processInvestmentWithdrawalAvailability();
 
@@ -228,8 +224,8 @@ describe("processInvestmentWithdrawalAvailability", () => {
       },
     ]);
 
-    mockUpdate
-      .mockResolvedValueOnce({})
+    mockUpdateMany
+      .mockResolvedValueOnce({ count: 1 })
       .mockRejectedValueOnce(new Error("Update failed"));
 
     await processInvestmentWithdrawalAvailability();
@@ -243,5 +239,24 @@ describe("processInvestmentWithdrawalAvailability", () => {
       null,
       trustedNow,
     );
+  });
+
+  it("should not publish when another worker already transitioned the request", async () => {
+    const amountAcbu = new Decimal("100.00");
+    mockFindMany.mockResolvedValue([
+      {
+        id: "request-9",
+        userId: "user-333",
+        organizationId: null,
+        status: "requested",
+        amountAcbu,
+        availableAt: new Date(trustedNow.getTime() - 1000),
+      },
+    ]);
+    mockUpdateMany.mockResolvedValue({ count: 0 });
+
+    await processInvestmentWithdrawalAvailability();
+
+    expect(mockPublish).not.toHaveBeenCalled();
   });
 });

--- a/tests/investmentWithdrawal.test.ts
+++ b/tests/investmentWithdrawal.test.ts
@@ -1,8 +1,10 @@
+/// <reference types="jest" />
 import { processInvestmentWithdrawalAvailability } from "../src/jobs/investmentWithdrawalJob";
 
 // --- mock dependencies ---
 jest.mock("../src/config/database", () => ({
   prisma: {
+    $queryRaw: jest.fn(),
     investmentWithdrawalRequest: {
       findMany: jest.fn(),
       update: jest.fn(),
@@ -18,20 +20,23 @@ jest.mock("../src/config/logger", () => ({
   logger: { error: jest.fn(), info: jest.fn() },
 }));
 
-jest.mock("../src/controllers/investmentController", () => ({
+jest.mock("../src/services/investment/withdrawalNotificationService", () => ({
   publishInvestmentWithdrawalReady: jest.fn(),
 }));
 
 import { prisma } from "../src/config/database";
-import { publishInvestmentWithdrawalReady } from "../src/controllers/investmentController";
+import { publishInvestmentWithdrawalReady } from "../src/services/investment/withdrawalNotificationService";
 import { Decimal } from "@prisma/client/runtime/library";
 
+const mockQueryRaw = prisma.$queryRaw as jest.Mock;
 const mockFindMany = prisma.investmentWithdrawalRequest.findMany as jest.Mock;
 const mockUpdate = prisma.investmentWithdrawalRequest.update as jest.Mock;
 const mockPublish = publishInvestmentWithdrawalReady as jest.Mock;
+const trustedNow = new Date("2026-05-27T12:00:00.000Z");
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockQueryRaw.mockResolvedValue([{ trustedNow }]);
 });
 
 describe("processInvestmentWithdrawalAvailability", () => {
@@ -59,6 +64,7 @@ describe("processInvestmentWithdrawalAvailability", () => {
       userId,
       amountAcbu.toNumber(),
       null,
+      trustedNow,
     );
   });
 
@@ -82,7 +88,12 @@ describe("processInvestmentWithdrawalAvailability", () => {
 
     await processInvestmentWithdrawalAvailability();
 
-    expect(mockPublish).toHaveBeenCalledWith(null, amountAcbu.toNumber(), organizationId);
+    expect(mockPublish).toHaveBeenCalledWith(
+      null,
+      amountAcbu.toNumber(),
+      organizationId,
+      trustedNow,
+    );
   });
 
   it("should mark withdrawal as available with notifiedAt timestamp", async () => {
@@ -108,7 +119,21 @@ describe("processInvestmentWithdrawalAvailability", () => {
 
     expect(mockUpdate).toHaveBeenCalledWith({
       where: { id: requestId },
-      data: { status: "available", notifiedAt: expect.any(Date) },
+      data: { status: "available", notifiedAt: trustedNow },
+    });
+  });
+
+  it("should query ready withdrawals using the database clock", async () => {
+    mockFindMany.mockResolvedValue([]);
+
+    await processInvestmentWithdrawalAvailability();
+
+    expect(mockFindMany).toHaveBeenCalledWith({
+      where: {
+        status: { in: ["requested", "processing"] },
+        availableAt: { lte: trustedNow },
+      },
+      take: 100,
     });
   });
 
@@ -164,8 +189,18 @@ describe("processInvestmentWithdrawalAvailability", () => {
     await processInvestmentWithdrawalAvailability();
 
     expect(mockPublish).toHaveBeenCalledTimes(2);
-    expect(mockPublish).toHaveBeenCalledWith(user1Id, amountAcbu.toNumber(), null);
-    expect(mockPublish).toHaveBeenCalledWith(null, amountAcbu.toNumber(), org1Id);
+    expect(mockPublish).toHaveBeenCalledWith(
+      user1Id,
+      amountAcbu.toNumber(),
+      null,
+      trustedNow,
+    );
+    expect(mockPublish).toHaveBeenCalledWith(
+      null,
+      amountAcbu.toNumber(),
+      org1Id,
+      trustedNow,
+    );
   });
 
   it("should continue processing when one request fails", async () => {
@@ -202,6 +237,11 @@ describe("processInvestmentWithdrawalAvailability", () => {
     // Should call publish only for the first request that succeeded
     // Second request's publish is not called because update failed
     expect(mockPublish).toHaveBeenCalledTimes(1);
-    expect(mockPublish).toHaveBeenCalledWith(userId, amountAcbu.toNumber(), null);
+    expect(mockPublish).toHaveBeenCalledWith(
+      userId,
+      amountAcbu.toNumber(),
+      null,
+      trustedNow,
+    );
   });
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
+    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "strict": true,


### PR DESCRIPTION
closes #299 
## Summary
- Replaces server-local clock usage in investment withdrawal request timing with PostgreSQL `clock_timestamp()`.
- Uses trusted database time for withdrawal availability checks, `createdAt`, `availableAt`, `notifiedAt`, and notification timestamps.
- Moves withdrawal-ready notification publishing into the investment service layer so jobs do not depend on HTTP controllers.
- Adds focused tests for trusted timing, controller behavior, and scheduler availability processing.
- Keeps CommonJS TypeScript config and adds `ignoreDeprecations` for the moduleResolution deprecation warning.

## Reason
The previous implementation relied on API server-local time for the 24-hour withdrawal delay and business calendar-day validation. A drifted server clock could allow users to bypass withdrawal delays. Using PostgreSQL as the trusted timing source prevents that bypass across API nodes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved investment withdrawal timing accuracy by adopting a centralized database clock mechanism to reduce timing inconsistencies.
  * Enhanced business calendar restriction enforcement for withdrawal requests.
  * Strengthened reliability of withdrawal availability notifications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/331?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->