### PR TITLE
Add schema version field to Stellar contract event payloads

### DIFF
--- a/src/services/stellar/eventListener.test.ts
+++ b/src/services/stellar/eventListener.test.ts
@@ -73,6 +73,30 @@ describe("EventListener", () => {
     expect(mockForContract).toHaveBeenCalledTimes(1);
   });
 
+  it("attaches a schema version to parsed contract events", async () => {
+    const listener = new EventListener();
+    const received: unknown[] = [];
+
+    listener.listenToContractEvents(
+      "contract-123",
+      ["contract_credited"],
+      async (event) => {
+        received.push(event);
+      },
+    );
+
+    await listener.dispatchRawEffect("contract-123", {
+      contract: "contract-123",
+      type: "contract_credited",
+      ledger: 88,
+      created_at: "2026-04-23T00:00:00.000Z",
+      paging_token: "cursor-88",
+    });
+
+    expect(received).toHaveLength(1);
+    expect((received[0] as Record<string, unknown>).version).toBe(1);
+  });
+
   it("retries transient handler failures so injected events still reach the projection store", async () => {
     const listener = new EventListener();
     const projectionStore: string[] = [];

--- a/src/services/stellar/eventListener.ts
+++ b/src/services/stellar/eventListener.ts
@@ -5,10 +5,13 @@ import { stellarClient } from "./client";
 export interface ContractEvent {
   contractId: string;
   type: string;
+  version: number;
   data: Record<string, unknown>;
   ledger: number;
   timestamp: number;
 }
+
+export const CONTRACT_EVENT_PAYLOAD_VERSION = 1;
 
 export type EventHandler = (event: ContractEvent) => Promise<void>;
 
@@ -326,6 +329,7 @@ export class EventListener {
     return {
       contractId,
       type,
+      version: CONTRACT_EVENT_PAYLOAD_VERSION,
       data: effect,
       ledger: Number.isFinite(ledger) ? ledger : 0,
       timestamp,


### PR DESCRIPTION
Closes #283

This PR adds a version field to parsed Stellar contract events so MintEvent and BurnEvent payloads are schema-versioned. This protects backend listeners from silent parse failures if contract payloads change in future upgrades.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Contract events now include a version field for improved event payload versioning and change tracking across releases.

* **Tests**
  * Added test coverage to verify that parsed contract events correctly include and propagate the version field as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/334?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->