### PR TITLE
perf: add --transpile-only to ts-node scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:push": "prisma db push",
     "prisma:studio": "prisma studio",
-    "prisma:seed": "ts-node prisma/seed.ts",
-    "backfill:org-limits": "ts-node prisma/backfillOrgTransactionContext.ts",
-    "stellar:create-wallet": "ts-node scripts/create-stellar-wallet.ts",
-    "compute:basket-weights": "ts-node scripts/compute-basket-weights.ts",
+    "prisma:seed": "ts-node --transpile-only prisma/seed.ts",
+    "backfill:org-limits": "ts-node --transpile-only prisma/backfillOrgTransactionContext.ts",
+    "stellar:create-wallet": "ts-node --transpile-only scripts/create-stellar-wallet.ts",
+    "compute:basket-weights": "ts-node --transpile-only scripts/compute-basket-weights.ts",
     "postinstall": "prisma generate && tsc -p tsconfig.build.json"
   },
   "keywords": [


### PR DESCRIPTION
Skip runtime type-checking for one-off scripts (seed, backfill, stellar wallet, basket weights) to reduce startup time by 5-10s. Type safety is enforced by the CI build step.
closes #321 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build scripts for improved performance during data operations and initialization processes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/338?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->