### PR TITLE
Fix/audit consumer manual ack

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,10 +20,10 @@
     "prisma:migrate:deploy": "prisma migrate deploy",
     "prisma:push": "prisma db push",
     "prisma:studio": "prisma studio",
-    "prisma:seed": "ts-node prisma/seed.ts",
-    "backfill:org-limits": "ts-node prisma/backfillOrgTransactionContext.ts",
-    "stellar:create-wallet": "ts-node scripts/create-stellar-wallet.ts",
-    "compute:basket-weights": "ts-node scripts/compute-basket-weights.ts",
+    "prisma:seed": "ts-node --transpile-only prisma/seed.ts",
+    "backfill:org-limits": "ts-node --transpile-only prisma/backfillOrgTransactionContext.ts",
+    "stellar:create-wallet": "ts-node --transpile-only scripts/create-stellar-wallet.ts",
+    "compute:basket-weights": "ts-node --transpile-only scripts/compute-basket-weights.ts",
     "postinstall": "prisma generate && tsc -p tsconfig.build.json"
   },
   "keywords": [

--- a/src/jobs/auditConsumer.ts
+++ b/src/jobs/auditConsumer.ts
@@ -11,6 +11,7 @@ export async function startAuditConsumer() {
 
   await assertQueueWithDLQ(QUEUES.AUDIT_LOGS, { durable: true });
 
+  channel.prefetch(1);
   channel.consume(QUEUES.AUDIT_LOGS, async (msg) => {
     if (!msg) return;
 
@@ -65,7 +66,7 @@ export async function startAuditConsumer() {
         }
       }
     }
-  });
+  }, { noAck: false });
 
   logger.info("Audit consumer started");
 }


### PR DESCRIPTION
Several event consumer jobs use channel.consume() without noAck: false or manual acknowledgment. If the consumer process crashes mid-handling, the message is lost and the event (mint, burn, transfer) is never recorded.
closes #262 