### PR TITLE
Fix swagger example PII and jest testTimeout

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,23 +1,24 @@
 module.exports = {
-  preset: 'ts-jest',
-  testEnvironment: 'node',
-  setupFiles: ['<rootDir>/tests/setup.ts'],
-  roots: ['<rootDir>/src', '<rootDir>/tests'],
-  testMatch: ['**/__tests__/**/*.ts', '**/?(*.)+(spec|test).ts'],
+  preset: "ts-jest",
+  testEnvironment: "node",
+  testTimeout: 30000,
+  setupFiles: ["<rootDir>/tests/setup.ts"],
+  roots: ["<rootDir>/src", "<rootDir>/tests"],
+  testMatch: ["**/__tests__/**/*.ts", "**/?(*.)+(spec|test).ts"],
   transform: {
-    '^.+\\.ts$': 'ts-jest',
+    "^.+\\.ts$": "ts-jest",
   },
   collectCoverageFrom: [
-    'src/**/*.ts',
-    '!src/**/*.d.ts',
-    '!src/**/*.spec.ts',
-    '!src/**/*.test.ts',
-    '!src/index.ts',
+    "src/**/*.ts",
+    "!src/**/*.d.ts",
+    "!src/**/*.spec.ts",
+    "!src/**/*.test.ts",
+    "!src/index.ts",
   ],
-  coverageDirectory: 'coverage',
-  coverageReporters: ['text', 'lcov', 'html'],
+  coverageDirectory: "coverage",
+  coverageReporters: ["text", "lcov", "html"],
   coverageThreshold: {
-    './src/services/transfer/': {
+    "./src/services/transfer/": {
       statements: 70,
       branches: 60,
       functions: 70,
@@ -25,6 +26,6 @@ module.exports = {
     },
   },
   moduleNameMapper: {
-    '^@/(.*)$': '<rootDir>/src/$1',
+    "^@/(.*)$": "<rootDir>/src/$1",
   },
 };

--- a/src/routes/userRoutes.ts
+++ b/src/routes/userRoutes.ts
@@ -25,6 +25,64 @@ const router: ReturnType<typeof Router> = Router();
 router.use(validateApiKey);
 router.use(apiKeyRateLimiter);
 
+/**
+ * @swagger
+ * tags:
+ *   - name: Users
+ *     description: User profile, wallet, and contact management
+ */
+
+/**
+ * @swagger
+ * /v1/users/me:
+ *   get:
+ *     tags:
+ *       - Users
+ *     summary: Get current user profile
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: User profile retrieved successfully
+ *   patch:
+ *     tags:
+ *       - Users
+ *     summary: Update user profile
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               username:
+ *                 type: string
+ *               email:
+ *                 type: string
+ *                 format: email
+ *                 example: alice@placeholder.test
+ *               phone_e164:
+ *                 type: string
+ *                 example: "+0000000000"
+ *               privacy_hide_from_search:
+ *                 type: boolean
+ *               passcode:
+ *                 type: string
+ *     responses:
+ *       200:
+ *         description: Profile updated successfully
+ *   delete:
+ *     tags:
+ *       - Users
+ *     summary: Delete user account
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       204:
+ *         description: Account deleted successfully
+ */
 router.get("/me", getMe);
 router.patch("/me", patchMe);
 router.delete("/me", deleteMe);
@@ -38,6 +96,46 @@ router.delete("/me/wallet", deleteWallet);
 router.post("/me/contacts", postContacts);
 router.get("/me/contacts", getContacts);
 router.delete("/me/contacts/:id", deleteContact);
+
+/**
+ * @swagger
+ * /v1/users/me/guardians:
+ *   get:
+ *     tags:
+ *       - Users
+ *     summary: List guardians
+ *     security:
+ *       - ApiKeyAuth: []
+ *     responses:
+ *       200:
+ *         description: Guardians retrieved successfully
+ *   post:
+ *     tags:
+ *       - Users
+ *     summary: Add guardian
+ *     security:
+ *       - ApiKeyAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             properties:
+ *               guardian_user_id:
+ *                 type: string
+ *                 format: uuid
+ *               guardian_email:
+ *                 type: string
+ *                 format: email
+ *                 example: guardian@placeholder.test
+ *               guardian_phone:
+ *                 type: string
+ *                 example: "+0000000000"
+ *     responses:
+ *       201:
+ *         description: Guardian added successfully
+ */
 router.post("/me/guardians", postGuardians);
 router.get("/me/guardians", getGuardians);
 router.delete("/me/guardians/:id", deleteGuardian);


### PR DESCRIPTION
## Summary

- **Swagger examples**: Added explicit `example` fields for email and phone properties in JSDoc swagger annotations using clearly fake placeholder data (`alice@placeholder.test`, `guardian@placeholder.test`, `+0000000000`) to prevent security scanners from flagging auto-generated example values as real PII.
- **Jest timeout**: Increased `testTimeout` from the default 5s to 30s to accommodate Stellar integration tests that wait for ledger close (~10-15 seconds).

Closes #322
Closes #313