### PR TITLE
fix(mongodb): add exponential backoff retry on connection failure

### DIFF
--- a/src/config/mongodb.ts
+++ b/src/config/mongodb.ts
@@ -5,64 +5,71 @@ import { logger } from "./logger";
 let client: MongoClient | null = null;
 let db: Db | null = null;
 
+const MAX_RETRIES = 5;
+const BASE_DELAY_MS = 500;
+
 export async function connectMongoDB(): Promise<Db> {
   if (db) return db;
 
-  try {
-    client = new MongoClient(config.mongodbUri);
-    await client.connect();
-    db = client.db();
-
-    logger.info("MongoDB connected successfully");
-
-    const collection = db.collection("cache");
-
-    // Define index configurations
-    const indexConfigs: Array<{
-      spec: Record<string, 1>;
-      options: { name: string; expireAfterSeconds?: number };
-      critical: boolean;
-    }> = [
-      {
-        spec: { key: 1, expiresAt: 1 },
-        options: { name: "idx_key_expiresAt" },
-        critical: false,
-      },
-      {
-        spec: { expiresAt: 1 },
-        options: { name: "idx_expiresAt_ttl", expireAfterSeconds: 0 },
-        critical: true, // TTL failure impacts security logic
-      },
-    ];
-
-    // Execute all index creations regardless of individual failures
-    const results = await Promise.allSettled(
-      indexConfigs.map((idx) => collection.createIndex(idx.spec, idx.options)),
-    );
-
-    // Evaluate results
-    results.forEach((result, i) => {
-      if (result.status === "rejected") {
-        const config = indexConfigs[i];
-        const logData = {
-          indexName: config.options.name,
-          error: result.reason,
-        };
-
-        if (config.critical) {
-          // TTL failures are logged as errors because they break brute-force protection
-          logger.error("Critical index creation failed", logData);
-        } else {
-          logger.warn("Index creation warning", logData);
-        }
-      }
-    });
-
-    return db;
-  } catch (error) {
-    logger.error("Failed to connect to MongoDB", { error });
-    throw error;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      client = new MongoClient(config.mongodbUri);
+      await client.connect();
+      db = client.db();
+      logger.info("MongoDB connected successfully");
+      break;
+    } catch (error) {
+      lastError = error;
+      client = null;
+      if (attempt === MAX_RETRIES) break;
+      const delay = BASE_DELAY_MS * 2 ** (attempt - 1);
+      logger.warn(`MongoDB connection attempt ${attempt} failed, retrying in ${delay}ms`, { error });
+      await new Promise((resolve) => setTimeout(resolve, delay));
+    }
   }
+
+  if (!db) {
+    logger.error("Failed to connect to MongoDB after retries", { error: lastError });
+    throw lastError;
+  }
+
+  const collection = db.collection("cache");
+
+  const indexConfigs: Array<{
+    spec: Record<string, 1>;
+    options: { name: string; expireAfterSeconds?: number };
+    critical: boolean;
+  }> = [
+    {
+      spec: { key: 1, expiresAt: 1 },
+      options: { name: "idx_key_expiresAt" },
+      critical: false,
+    },
+    {
+      spec: { expiresAt: 1 },
+      options: { name: "idx_expiresAt_ttl", expireAfterSeconds: 0 },
+      critical: true,
+    },
+  ];
+
+  const results = await Promise.allSettled(
+    indexConfigs.map((idx) => collection.createIndex(idx.spec, idx.options)),
+  );
+
+  results.forEach((result, i) => {
+    if (result.status === "rejected") {
+      const cfg = indexConfigs[i];
+      const logData = { indexName: cfg.options.name, error: result.reason };
+      if (cfg.critical) {
+        logger.error("Critical index creation failed", logData);
+      } else {
+        logger.warn("Index creation warning", logData);
+      }
+    }
+  });
+
+  return db;
 }
 
 export async function disconnectMongoDB(): Promise<void> {


### PR DESCRIPTION
Retry up to 5 times with delays of 500ms, 1s, 2s, 4s before throwing. Prevents transient network blips from crashing the process at startup.

closes #273 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Database connection now includes automatic retry with exponential backoff to improve startup resilience.
  * Index initialization records per-index outcomes; critical index failures are logged as errors, non-critical as warnings.
  * Improved error logging captures final failure details and surfaces the last encountered connection error for clearer diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/341?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->