### PR TITLE
fix(jobs): add DLQ support to all RabbitMQ consumers

### DIFF
--- a/src/jobs/acbu_escrow_event_listener.ts
+++ b/src/jobs/acbu_escrow_event_listener.ts
@@ -6,7 +6,7 @@ import {
   ContractEvent,
 } from "../services/stellar/eventListener";
 import { contractAddresses } from "../config/contracts";
-import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger } from "../config/logger";
 
 const ESCROW_EFFECT_TYPES = [
@@ -25,7 +25,7 @@ export async function startEscrowEventListener(): Promise<void> {
   const handler = async (event: ContractEvent): Promise<void> => {
     try {
       const ch = await connectRabbitMQ();
-      await ch.assertQueue(QUEUES.ACBU_ESCROW_EVENTS, { durable: true });
+      await assertQueueWithDLQ(QUEUES.ACBU_ESCROW_EVENTS);
       ch.sendToQueue(
         QUEUES.ACBU_ESCROW_EVENTS,
         Buffer.from(

--- a/src/jobs/acbu_lending_pool_event_listener.ts
+++ b/src/jobs/acbu_lending_pool_event_listener.ts
@@ -6,7 +6,7 @@ import {
   ContractEvent,
 } from "../services/stellar/eventListener";
 import { contractAddresses } from "../config/contracts";
-import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger } from "../config/logger";
 
 const LENDING_POOL_EFFECT_TYPES = [
@@ -27,7 +27,7 @@ export async function startLendingPoolEventListener(): Promise<void> {
   const handler = async (event: ContractEvent): Promise<void> => {
     try {
       const ch = await connectRabbitMQ();
-      await ch.assertQueue(QUEUES.ACBU_LENDING_POOL_EVENTS, { durable: true });
+      await assertQueueWithDLQ(QUEUES.ACBU_LENDING_POOL_EVENTS);
       ch.sendToQueue(
         QUEUES.ACBU_LENDING_POOL_EVENTS,
         Buffer.from(

--- a/src/jobs/acbu_savings_vault_event_listener.ts
+++ b/src/jobs/acbu_savings_vault_event_listener.ts
@@ -6,7 +6,7 @@ import {
   ContractEvent,
 } from "../services/stellar/eventListener";
 import { contractAddresses } from "../config/contracts";
-import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger } from "../config/logger";
 
 const SAVINGS_VAULT_EFFECT_TYPES = [
@@ -27,7 +27,7 @@ export async function startSavingsVaultEventListener(): Promise<void> {
   const handler = async (event: ContractEvent): Promise<void> => {
     try {
       const ch = await connectRabbitMQ();
-      await ch.assertQueue(QUEUES.ACBU_SAVINGS_VAULT_EVENTS, { durable: true });
+      await assertQueueWithDLQ(QUEUES.ACBU_SAVINGS_VAULT_EVENTS);
       ch.sendToQueue(
         QUEUES.ACBU_SAVINGS_VAULT_EVENTS,
         Buffer.from(

--- a/src/jobs/notificationConsumer.ts
+++ b/src/jobs/notificationConsumer.ts
@@ -2,7 +2,7 @@
  * Consumes OTP_SEND and NOTIFICATIONS queues; sends email/SMS via NotificationService.
  */
 import type { ConsumeMessage } from "amqplib";
-import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger } from "../config/logger";
 import { prisma } from "../config/database";
 import {
@@ -114,32 +114,47 @@ async function processNotification(
   logger.debug("Notification type not handled", { type });
 }
 
+const MAX_RETRIES = 5;
+
 export async function startNotificationConsumer(): Promise<void> {
   const ch = await connectRabbitMQ();
   ch.prefetch(2);
 
-  await ch.assertQueue(QUEUES.OTP_SEND, { durable: true });
+  await assertQueueWithDLQ(QUEUES.OTP_SEND);
   ch.consume(
     QUEUES.OTP_SEND,
     async (msg: ConsumeMessage | null) => {
       if (!msg) return;
+      const headers = msg.properties.headers ?? {};
+      const retries = typeof headers["x-retries"] === "number" ? headers["x-retries"] : 0;
       try {
         const payload = JSON.parse(msg.content.toString()) as OtpSendPayload;
         await processOtpSend(payload);
         ch.ack(msg);
       } catch (e) {
         logger.error("OTP_SEND consumer error", { error: e });
-        ch.nack(msg, false, true);
+        if (retries >= MAX_RETRIES) {
+          logger.error("OTP_SEND failed permanently, sending to DLQ", { retries });
+          ch.nack(msg, false, false);
+          return;
+        }
+        ch.sendToQueue(QUEUES.OTP_SEND, msg.content, {
+          persistent: true,
+          headers: { ...headers, "x-retries": retries + 1 },
+        });
+        ch.ack(msg);
       }
     },
     { noAck: false },
   );
 
-  await ch.assertQueue(QUEUES.NOTIFICATIONS, { durable: true });
+  await assertQueueWithDLQ(QUEUES.NOTIFICATIONS);
   ch.consume(
     QUEUES.NOTIFICATIONS,
     async (msg: ConsumeMessage | null) => {
       if (!msg) return;
+      const headers = msg.properties.headers ?? {};
+      const retries = typeof headers["x-retries"] === "number" ? headers["x-retries"] : 0;
       try {
         const payload = JSON.parse(
           msg.content.toString(),
@@ -148,7 +163,16 @@ export async function startNotificationConsumer(): Promise<void> {
         ch.ack(msg);
       } catch (e) {
         logger.error("NOTIFICATIONS consumer error", { error: e });
-        ch.nack(msg, false, true);
+        if (retries >= MAX_RETRIES) {
+          logger.error("NOTIFICATIONS failed permanently, sending to DLQ", { retries });
+          ch.nack(msg, false, false);
+          return;
+        }
+        ch.sendToQueue(QUEUES.NOTIFICATIONS, msg.content, {
+          persistent: true,
+          headers: { ...headers, "x-retries": retries + 1 },
+        });
+        ch.ack(msg);
       }
     },
     { noAck: false },

--- a/src/jobs/usdcConversionJob.ts
+++ b/src/jobs/usdcConversionJob.ts
@@ -3,7 +3,7 @@
  * Updates transaction and reserve history; basket weight distribution uses BasketService.
  */
 import type { ConsumeMessage } from "amqplib";
-import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger } from "../config/logger";
 import { prisma } from "../config/database";
 import { basketService } from "../services/basket";
@@ -11,6 +11,7 @@ import { getFintechRouter } from "../services/fintech";
 import { Decimal } from "@prisma/client/runtime/library";
 
 const QUEUE = QUEUES.USDC_CONVERSION;
+const MAX_RETRIES = 5;
 
 export interface UsdcConversionPayload {
   usdcAmount: string;
@@ -21,12 +22,14 @@ export interface UsdcConversionPayload {
 
 export async function startUsdcConversionConsumer(): Promise<void> {
   const ch = await connectRabbitMQ();
-  await ch.assertQueue(QUEUE, { durable: true });
+  await assertQueueWithDLQ(QUEUE);
   ch.prefetch(1);
   ch.consume(
     QUEUE,
     async (msg: ConsumeMessage | null) => {
       if (!msg) return;
+      const headers = msg.properties.headers ?? {};
+      const retries = typeof headers["x-retries"] === "number" ? headers["x-retries"] : 0;
       try {
         const body = JSON.parse(
           msg.content.toString(),
@@ -82,7 +85,16 @@ export async function startUsdcConversionConsumer(): Promise<void> {
         ch.ack(msg);
       } catch (e) {
         logger.error("USDC conversion job failed", { error: e });
-        ch.nack(msg, false, true);
+        if (retries >= MAX_RETRIES) {
+          logger.error("USDC conversion job failed permanently, sending to DLQ", { retries });
+          ch.nack(msg, false, false);
+          return;
+        }
+        ch.sendToQueue(QUEUE, msg.content, {
+          persistent: true,
+          headers: { ...headers, "x-retries": retries + 1 },
+        });
+        ch.ack(msg);
       }
     },
     { noAck: false },
@@ -97,7 +109,7 @@ export async function enqueueUsdcConversion(
   payload: UsdcConversionPayload,
 ): Promise<void> {
   const ch = await connectRabbitMQ();
-  await ch.assertQueue(QUEUE, { durable: true });
+  await assertQueueWithDLQ(QUEUE);
   ch.sendToQueue(QUEUE, Buffer.from(JSON.stringify(payload)), {
     persistent: true,
   });

--- a/src/jobs/xlmToAcbuJob.ts
+++ b/src/jobs/xlmToAcbuJob.ts
@@ -4,7 +4,7 @@
  * Consumes XLM_TO_ACBU queue or polls OnRampSwap table for pending_convert.
  */
 import type { ConsumeMessage } from "amqplib";
-import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger, logFinancialEvent } from "../config/logger";
 import { prisma } from "../config/database";
 import { mintFromUsdcInternal } from "../controllers/mintController";
@@ -12,6 +12,7 @@ import { fetchXlmRateUsd } from "../services/oracle/cryptoClient";
 import { randomUUID } from "crypto";
 
 const QUEUE = QUEUES.XLM_TO_ACBU;
+const MAX_RETRIES = 5;
 
 export interface XlmToAcbuPayload {
   onRampSwapId: string;
@@ -23,12 +24,14 @@ export interface XlmToAcbuPayload {
 
 export async function startXlmToAcbuConsumer(): Promise<void> {
   const ch = await connectRabbitMQ();
-  await ch.assertQueue(QUEUE, { durable: true });
+  await assertQueueWithDLQ(QUEUE);
   ch.prefetch(1);
   ch.consume(
     QUEUE,
     async (msg: ConsumeMessage | null) => {
       if (!msg) return;
+      const headers = msg.properties.headers ?? {};
+      const retries = typeof headers["x-retries"] === "number" ? headers["x-retries"] : 0;
       try {
         const body = JSON.parse(msg.content.toString()) as XlmToAcbuPayload;
         const correlationId = randomUUID();
@@ -36,7 +39,16 @@ export async function startXlmToAcbuConsumer(): Promise<void> {
         ch.ack(msg);
       } catch (e) {
         logger.error("XLM→ACBU job failed", { error: e });
-        ch.nack(msg, false, true);
+        if (retries >= MAX_RETRIES) {
+          logger.error("XLM→ACBU job failed permanently, sending to DLQ", { retries });
+          ch.nack(msg, false, false);
+          return;
+        }
+        ch.sendToQueue(QUEUE, msg.content, {
+          persistent: true,
+          headers: { ...headers, "x-retries": retries + 1 },
+        });
+        ch.ack(msg);
       }
     },
     { noAck: false },
@@ -147,7 +159,7 @@ export async function enqueueXlmToAcbu(
   payload: XlmToAcbuPayload,
 ): Promise<void> {
   const ch = await connectRabbitMQ();
-  await ch.assertQueue(QUEUE, { durable: true });
+  await assertQueueWithDLQ(QUEUE);
   ch.sendToQueue(QUEUE, Buffer.from(JSON.stringify(payload)), {
     persistent: true,
   });


### PR DESCRIPTION
## Summary

Fixes #278

All RabbitMQ consumers in `src/jobs/` that previously discarded failed messages (via `nack(msg, false, true)` — infinite requeue, or plain `assertQueue` without dead-letter config) now have proper DLQ support.

## Changes

| File | Change |
|---|---|
| `usdcConversionJob.ts` | `assertQueueWithDLQ`, retry up to 5× with `x-retries` header, `nack(false,false)` to DLQ on exhaustion |
| `xlmToAcbuJob.ts` | Same retry+DLQ pattern |
| `notificationConsumer.ts` | `assertQueueWithDLQ` for `OTP_SEND` and `NOTIFICATIONS`, retry+DLQ on failure |
| `acbu_escrow_event_listener.ts` | `assertQueueWithDLQ` instead of `ch.assertQueue` |
| `acbu_savings_vault_event_listener.ts` | `assertQueueWithDLQ` instead of `ch.assertQueue` |
| `acbu_lending_pool_event_listener.ts` | `assertQueueWithDLQ` instead of `ch.assertQueue` |

Consumers that already had DLQ support (`webhookConsumer`, `auditConsumer`, `withdrawalProcessingJob`, `usdcConvertAndMintJob`) are unchanged.

## Tested

- Existing `auditConsumer.test.ts` passes ✓
- TypeScript type-check on all modified files passes ✓

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic retry mechanism with configurable limits for escrow events, lending pool events, savings vault events, notifications, OTP sending, USDC conversions, and XLM-to-ACBU conversions.
  * Implemented Dead Letter Queue (DLQ) support to capture and preserve failed messages for later analysis and recovery.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/345?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->