### PR TITLE
Fix duplicate route mounting for international mint/burn routes

### DIFF
--- a/src/routes/burnRoutes.ts
+++ b/src/routes/burnRoutes.ts
@@ -3,12 +3,14 @@ import { burnAcbu } from "../controllers/burnController";
 import { validateApiKey } from "../middleware/auth";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 
-const router: IRouter = Router();
-router.use(validateApiKey);
-router.use(apiKeyRateLimiter);
-/**
- * @swagger
- * tags:
+export function createBurnRoutes(): ReturnType<typeof Router> {
+  const router: IRouter = Router();
+  router.use(validateApiKey);
+  router.use(apiKeyRateLimiter);
+
+  /**
+   * @swagger
+   * tags:
  *   - name: Burn
  *     description: Asset burning and redemptions
  */
@@ -59,4 +61,8 @@ router.use(apiKeyRateLimiter);
  *         description: Burn request accepted
  */
 router.post("/acbu", burnAcbu);
+  return router;
+}
+
+const router = createBurnRoutes();
 export default router;

--- a/src/routes/internationalRoutes.test.ts
+++ b/src/routes/internationalRoutes.test.ts
@@ -1,0 +1,17 @@
+import internationalRoutes from "./internationalRoutes";
+import mintRoutes from "./mintRoutes";
+import burnRoutes from "./burnRoutes";
+
+describe("internationalRoutes", () => {
+  it("uses fresh mint and burn routers instead of reusing top-level router instances", () => {
+    const stack = (internationalRoutes as any).stack as Array<unknown>;
+    expect(Array.isArray(stack)).toBe(true);
+
+    const nestedRouterHandles = stack
+      .filter((layer) => typeof (layer as any).handle === "function")
+      .map((layer) => (layer as any).handle);
+
+    expect(nestedRouterHandles).not.toContain(mintRoutes);
+    expect(nestedRouterHandles).not.toContain(burnRoutes);
+  });
+});

--- a/src/routes/internationalRoutes.ts
+++ b/src/routes/internationalRoutes.ts
@@ -3,8 +3,8 @@ import { validateApiKey } from "../middleware/auth";
 import { requireMinTier, requireSegmentScope } from "../middleware/segmentGuard";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 import { getRates } from "../controllers/ratesController";
-import mintRoutes from "./mintRoutes";
-import burnRoutes from "./burnRoutes";
+import { createMintRoutes } from "./mintRoutes";
+import { createBurnRoutes } from "./burnRoutes";
 
 const router: IRouter = Router();
 
@@ -14,7 +14,7 @@ router.use(requireSegmentScope("international:read", "international:write"));
 router.use(apiKeyRateLimiter);
 
 router.get("/quote", getRates);
-router.use("/mint", mintRoutes);
-router.use("/burn", burnRoutes);
+router.use("/mint", createMintRoutes());
+router.use("/burn", createBurnRoutes());
 
 export default router;

--- a/src/routes/mintRoutes.ts
+++ b/src/routes/mintRoutes.ts
@@ -6,12 +6,14 @@ import {
 import { validateApiKey } from "../middleware/auth";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
 
-const router: IRouter = Router();
-router.use(validateApiKey);
-router.use(apiKeyRateLimiter);
-/**
- * @swagger
- * tags:
+export function createMintRoutes(): ReturnType<typeof Router> {
+  const router: IRouter = Router();
+  router.use(validateApiKey);
+  router.use(apiKeyRateLimiter);
+
+  /**
+   * @swagger
+   * tags:
  *   - name: Mint
  *     description: Asset minting and deposits
  */
@@ -83,4 +85,8 @@ router.post("/usdc", mintFromUsdc);
  *         description: Deposit request accepted
  */
 router.post("/deposit", depositFromBasketCurrency);
+  return router;
+}
+
+const router = createMintRoutes();
 export default router;


### PR DESCRIPTION
Closes #317

This PR avoids reusing the top-level mint and burn router instances inside the international router by creating dedicated nested route instances. This prevents duplicate mounted APIs between segment routers and base routers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal route initialization architecture for enhanced modularity and maintainability.

* **Tests**
  * Added test coverage to verify proper route instance isolation and independence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/348?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->