### PR TITLE
Graceful HTTP shutdown with Node 18+ idle connection draining

### DIFF
--- a/src/gracefulShutdown.ts
+++ b/src/gracefulShutdown.ts
@@ -1,0 +1,65 @@
+import { type Server } from "http";
+import { logger } from "./config/logger";
+import { disconnectMongoDB } from "./config/mongodb";
+import { disconnectRabbitMQ } from "./config/rabbitmq";
+
+type AppServer = Server & { closeIdleConnections?: () => void };
+let httpServer: AppServer | null = null;
+
+export const setHttpServer = (server: AppServer | null): void => {
+  httpServer = server;
+};
+
+const closeServer = async (): Promise<void> => {
+  if (!httpServer) {
+    return;
+  }
+
+  if (typeof httpServer.closeIdleConnections === "function") {
+    try {
+      httpServer.closeIdleConnections();
+    } catch (error) {
+      logger.warn("Failed to close idle HTTP connections", error);
+    }
+  }
+
+  await new Promise<void>((resolve, reject) => {
+    httpServer?.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+
+  httpServer = null;
+};
+
+export const shutdown = async (): Promise<void> => {
+  logger.info("Shutting down gracefully...");
+  await closeServer();
+  await disconnectMongoDB();
+  await disconnectRabbitMQ();
+};
+
+let isShuttingDown = false;
+const handleTermination = async (): Promise<void> => {
+  if (isShuttingDown) {
+    return;
+  }
+
+  isShuttingDown = true;
+  try {
+    await shutdown();
+  } catch (error) {
+    logger.error("Graceful shutdown failed", error);
+  } finally {
+    process.exit(0);
+  }
+};
+
+export const registerGracefulShutdown = (): void => {
+  process.on("SIGTERM", handleTermination);
+  process.on("SIGINT", handleTermination);
+};

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,0 +1,56 @@
+jest.mock("./config/mongodb", () => ({
+  connectMongoDB: jest.fn(),
+  disconnectMongoDB: jest.fn(async () => undefined),
+}));
+
+jest.mock("./config/rabbitmq", () => ({
+  connectRabbitMQ: jest.fn(),
+  disconnectRabbitMQ: jest.fn(async () => undefined),
+}));
+
+jest.mock("./config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  },
+}));
+
+import { shutdown, setHttpServer } from "./gracefulShutdown";
+import { disconnectMongoDB } from "./config/mongodb";
+import { disconnectRabbitMQ } from "./config/rabbitmq";
+
+describe("HTTP graceful shutdown", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setHttpServer(null);
+  });
+
+  it("calls closeIdleConnections when available and waits for server close", async () => {
+    const closeIdleConnections = jest.fn();
+    const close = jest.fn((callback) => {
+      callback?.(undefined);
+    });
+
+    setHttpServer({ closeIdleConnections, close } as any);
+
+    await shutdown();
+
+    expect(closeIdleConnections).toHaveBeenCalledTimes(1);
+    expect(close).toHaveBeenCalledTimes(1);
+    expect(disconnectMongoDB).toHaveBeenCalledTimes(1);
+    expect(disconnectRabbitMQ).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes the server even if closeIdleConnections is unavailable", async () => {
+    const close = jest.fn((callback) => {
+      callback?.(undefined);
+    });
+
+    setHttpServer({ close } as any);
+
+    await shutdown();
+
+    expect(close).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import { standardRateLimiter } from "./middleware/rateLimiter";
 import { swaggerSpec } from "./config/swagger";
 import routes from "./routes";
 import webhookRoutes from "./routes/webhookRoutes";
+import { registerGracefulShutdown, setHttpServer } from "./gracefulShutdown";
 
 const app: express.Express = express();
 
@@ -202,7 +203,7 @@ async function startServer() {
     void eventListener.start();
 
     // Start HTTP server
-    app.listen(config.port, () => {
+    const server = app.listen(config.port, () => {
       logger.info(`Server running on port ${config.port}`);
       logger.info(`Environment: ${config.nodeEnv}`);
       logger.info(`API Version: ${config.apiVersion}`);
@@ -212,24 +213,15 @@ async function startServer() {
         );
       }
     });
+    setHttpServer(server);
   } catch (error) {
     logger.error("Failed to start server", error);
     process.exit(1);
   }
 }
 
-// Handle graceful shutdown
-const shutdown = async () => {
-  logger.info("Shutting down gracefully...");
-  await disconnectMongoDB();
-  await disconnectRabbitMQ();
-  process.exit(0);
-};
-
-process.on("SIGTERM", shutdown);
-process.on("SIGINT", shutdown);
-
 if (require.main === module) {
+  registerGracefulShutdown();
   void startServer();
 }
 


### PR DESCRIPTION
Closes #318

This PR ensures HTTP connections drain gracefully during shutdown by calling server.closeIdleConnections() when available before awaiting server.close(). It also keeps shutdown logic testable and avoids abrupt ECONNRESET failures for in-flight requests.