### PR TITLE
 Event listener silently stops on Stellar RPC disconnect – H

### DIFF
--- a/src/services/health/healthService.ts
+++ b/src/services/health/healthService.ts
@@ -2,6 +2,7 @@ import { prisma } from "../../config/database";
 import { getMongoDB } from "../../config/mongodb";
 import { getRabbitMQChannel } from "../../config/rabbitmq";
 import { logger } from "../../config/logger";
+import { eventListenerHealth } from "../stellar/eventListener";
 
 const TIMEOUT_MS = 2000;
 
@@ -20,6 +21,7 @@ export interface HealthReport {
     postgres: HealthDetail;
     mongodb: HealthDetail;
     rabbitmq: HealthDetail;
+    sorobanEventListener: HealthDetail;
   };
 }
 
@@ -77,15 +79,21 @@ export async function getHealthReport(): Promise<HealthReport> {
     checkRabbitMQ(),
   ]);
 
+  const sorobanEventListener: HealthDetail = {
+    status: eventListenerHealth.status,
+    error: eventListenerHealth.lastError ?? undefined,
+  };
+
   const allUp =
     postgres.status === "up" &&
     mongodb.status === "up" &&
-    rabbitmq.status === "up";
+    rabbitmq.status === "up" &&
+    sorobanEventListener.status === "up";
 
   return {
     status: allUp ? "up" : "down",
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
-    details: { postgres, mongodb, rabbitmq },
+    details: { postgres, mongodb, rabbitmq, sorobanEventListener },
   };
 }

--- a/src/services/stellar/eventListener.test.ts
+++ b/src/services/stellar/eventListener.test.ts
@@ -5,6 +5,7 @@ const mockCursor = jest.fn();
 const mockForContract = jest.fn();
 const mockAssertQueue = jest.fn();
 const mockSendToQueue = jest.fn();
+const mockGetServer = jest.fn();
 
 const mockBuilder = {
   order: mockOrder,
@@ -17,14 +18,15 @@ mockOrder.mockReturnValue(mockBuilder);
 mockLimit.mockReturnValue(mockBuilder);
 mockCursor.mockReturnValue(mockBuilder);
 mockForContract.mockReturnValue(mockBuilder);
+mockGetServer.mockImplementation(() => ({
+  effects: () => ({
+    forContract: mockForContract,
+  }),
+}));
 
 jest.mock("./client", () => ({
   stellarClient: {
-    getServer: () => ({
-      effects: () => ({
-        forContract: mockForContract,
-      }),
-    }),
+    getServer: mockGetServer,
   },
 }));
 
@@ -95,6 +97,20 @@ describe("EventListener", () => {
 
     expect(received).toHaveLength(1);
     expect((received[0] as Record<string, unknown>).version).toBe(1);
+  });
+
+  it("exposes Soroban event listener health status", async () => {
+    const listener = new EventListener();
+    listener.listenToContractEvents(
+      "contract-123",
+      ["contract_credited"],
+      async () => {},
+    );
+
+    await listener.pollOnce();
+
+    expect(listener.getHealthStatus().status).toBe("up");
+    expect(listener.getHealthStatus().lastHealthyAt).toBeGreaterThan(0);
   });
 
   it("retries transient handler failures so injected events still reach the projection store", async () => {

--- a/src/services/stellar/eventListener.ts
+++ b/src/services/stellar/eventListener.ts
@@ -43,6 +43,26 @@ const RETRY_BASE_DELAY_MS = 500;
 const ACTIVE_POLL_DELAY_MS = 250;
 const IDLE_POLL_DELAY_MS = 1000;
 const IDLE_WITHOUT_SUBSCRIPTIONS_DELAY_MS = 2000;
+const RECONNECT_MAX_ATTEMPTS = 5;
+const RECONNECT_BASE_DELAY_MS = 2000;
+
+export interface EventListenerHealthStatus {
+  status: "up" | "down";
+  lastHealthyAt: number | null;
+  lastUnhealthyAt: number | null;
+  lastError: string | null;
+  reconnectAttemptsTotal: number;
+  lastReconnectAttemptAt: number | null;
+}
+
+export const eventListenerHealth: EventListenerHealthStatus = {
+  status: "down",
+  lastHealthyAt: null,
+  lastUnhealthyAt: null,
+  lastError: null,
+  reconnectAttemptsTotal: 0,
+  lastReconnectAttemptAt: null,
+};
 
 export class EventListener {
   private server: ReturnType<typeof stellarClient.getServer>;
@@ -50,7 +70,9 @@ export class EventListener {
   private registeredContractIds: Set<string> = new Set();
   private contractCursors: Map<string, string | null> = new Map();
   private isListening = false;
+  private isReconnecting = false;
   private defaultCursor: string | null = null;
+  private healthStatus = eventListenerHealth;
 
   constructor() {
     this.server = stellarClient.getServer();
@@ -156,6 +178,81 @@ export class EventListener {
     }
   }
 
+  getHealthStatus(): EventListenerHealthStatus {
+    return { ...this.healthStatus };
+  }
+
+  private markHealthy(): void {
+    if (this.healthStatus.status !== "up") {
+      logger.info("Soroban event listener recovered", {
+        lastError: this.healthStatus.lastError,
+      });
+    }
+
+    this.healthStatus.status = "up";
+    this.healthStatus.lastHealthyAt = Date.now();
+    this.healthStatus.lastError = null;
+  }
+
+  private markUnhealthy(error: string): void {
+    if (this.healthStatus.status !== "down") {
+      logger.warn("Soroban event listener disconnected", { error });
+    }
+
+    this.healthStatus.status = "down";
+    this.healthStatus.lastUnhealthyAt = Date.now();
+    this.healthStatus.lastError = error;
+  }
+
+  private async reconnectServer(contractId?: string): Promise<void> {
+    if (this.isReconnecting) {
+      return;
+    }
+
+    this.isReconnecting = true;
+    try {
+      for (let attempt = 1; attempt <= RECONNECT_MAX_ATTEMPTS; attempt += 1) {
+        this.healthStatus.lastReconnectAttemptAt = Date.now();
+        this.healthStatus.reconnectAttemptsTotal += 1;
+
+        try {
+          this.server = stellarClient.getServer();
+
+          if (contractId) {
+            const cursor = this.contractCursors.get(contractId) ?? this.defaultCursor;
+            const builder = this.getEffectsApi()
+              .forContract(contractId)
+              .order("asc")
+              .limit(1);
+
+            if (cursor) {
+              builder.cursor(cursor);
+            }
+
+            await builder.call();
+          }
+
+          this.markHealthy();
+          return;
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          logger.warn("Soroban event listener reconnect attempt failed", {
+            contractId,
+            attempt,
+            error: message,
+          });
+          this.markUnhealthy(message);
+
+          if (attempt < RECONNECT_MAX_ATTEMPTS) {
+            await this.sleep(RECONNECT_BASE_DELAY_MS * attempt);
+          }
+        }
+      }
+    } finally {
+      this.isReconnecting = false;
+    }
+  }
+
   /**
    * Listen for specific contract events (MintEvent, BurnEvent, etc.).
    */
@@ -238,9 +335,10 @@ export class EventListener {
           processedAny ? ACTIVE_POLL_DELAY_MS : IDLE_POLL_DELAY_MS,
         );
       } catch (error) {
-        logger.error("Error listening for events", {
-          error: error instanceof Error ? error.message : String(error),
-        });
+        const message = error instanceof Error ? error.message : String(error);
+        logger.error("Error listening for events", { error: message });
+        this.markUnhealthy(message);
+        await this.reconnectServer();
         await this.sleep(IDLE_POLL_DELAY_MS);
       }
     }
@@ -273,6 +371,8 @@ export class EventListener {
         },
       });
 
+      this.markHealthy();
+
       for (const effect of effects.records) {
         await this.dispatchRawEffect(contractId, effect);
         this.updateCursor(contractId, effect);
@@ -280,11 +380,15 @@ export class EventListener {
 
       return effects.records.length > 0;
     } catch (error) {
+      const message =
+        error instanceof Error ? error.message : String(error);
       logger.error("Failed to poll contract effects", {
         contractId,
         cursor: this.contractCursors.get(contractId) ?? this.defaultCursor,
-        error: error instanceof Error ? error.message : String(error),
+        error: message,
       });
+      this.markUnhealthy(message);
+      await this.reconnectServer(contractId);
       return false;
     }
   }

--- a/tests/health.service.test.ts
+++ b/tests/health.service.test.ts
@@ -17,9 +17,30 @@ jest.mock("../src/config/logger", () => ({
   logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
 }));
 
+jest.mock("../src/services/stellar/eventListener", () => ({
+  eventListenerHealth: {
+    status: "up",
+    lastHealthyAt: Date.now(),
+    lastUnhealthyAt: null,
+    lastError: null,
+    reconnectAttemptsTotal: 0,
+    lastReconnectAttemptAt: null,
+  },
+}));
+
 import { prisma } from "../src/config/database";
 import { getMongoDB } from "../src/config/mongodb";
 import { getRabbitMQChannel } from "../src/config/rabbitmq";
+
+const mockEventListenerHealth = require("../src/services/stellar/eventListener")
+  .eventListenerHealth as {
+  status: "up" | "down";
+  lastHealthyAt: number | null;
+  lastUnhealthyAt: number | null;
+  lastError: string | null;
+  reconnectAttemptsTotal: number;
+  lastReconnectAttemptAt: number | null;
+};
 
 const mockPrismaQuery = prisma.$queryRaw as jest.Mock;
 const mockGetMongoDB = getMongoDB as jest.Mock;
@@ -32,6 +53,12 @@ const healthyMongo = () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockEventListenerHealth.status = "up";
+  mockEventListenerHealth.lastHealthyAt = Date.now();
+  mockEventListenerHealth.lastUnhealthyAt = null;
+  mockEventListenerHealth.lastError = null;
+  mockEventListenerHealth.reconnectAttemptsTotal = 0;
+  mockEventListenerHealth.lastReconnectAttemptAt = null;
 });
 
 describe("getHealthReport", () => {
@@ -46,6 +73,7 @@ describe("getHealthReport", () => {
     expect(report.details.postgres.status).toBe("up");
     expect(report.details.mongodb.status).toBe("up");
     expect(report.details.rabbitmq.status).toBe("up");
+    expect(report.details.sorobanEventListener.status).toBe("up");
   });
 
   it("should return 503-worthy status 'down' when PostgreSQL connection is lost", async () => {
@@ -58,9 +86,9 @@ describe("getHealthReport", () => {
     expect(report.status).toBe("down");
     expect(report.details.postgres.status).toBe("down");
     expect(report.details.postgres.error).toBe("PostgreSQL unreachable");
-    // other services still up
     expect(report.details.mongodb.status).toBe("up");
     expect(report.details.rabbitmq.status).toBe("up");
+    expect(report.details.sorobanEventListener.status).toBe("up");
   });
 
   it("should return status 'down' when MongoDB is unreachable", async () => {
@@ -74,6 +102,7 @@ describe("getHealthReport", () => {
 
     expect(report.status).toBe("down");
     expect(report.details.mongodb.status).toBe("down");
+    expect(report.details.sorobanEventListener.status).toBe("up");
   });
 
   it("should return status 'down' when RabbitMQ channel is unavailable", async () => {
@@ -85,6 +114,23 @@ describe("getHealthReport", () => {
 
     expect(report.status).toBe("down");
     expect(report.details.rabbitmq.status).toBe("down");
+    expect(report.details.sorobanEventListener.status).toBe("up");
+  });
+
+  it("should return status 'down' when Soroban event listener is unhealthy", async () => {
+    mockPrismaQuery.mockResolvedValue([{ "?column?": 1 }]);
+    mockGetMongoDB.mockReturnValue(healthyMongo());
+    mockGetRabbitMQChannel.mockReturnValue({ ack: jest.fn() });
+    mockEventListenerHealth.status = "down";
+    mockEventListenerHealth.lastError = "Event listener disconnected";
+
+    const report = await getHealthReport();
+
+    expect(report.status).toBe("down");
+    expect(report.details.sorobanEventListener.status).toBe("down");
+    expect(report.details.sorobanEventListener.error).toBe(
+      "Event listener disconnected",
+    );
   });
 
   it("should include timestamp and uptime in the report", async () => {


### PR DESCRIPTION
Closes #267 

Objective
Fix the Soroban event listener so it can recover from Horizon disconnects and expose a health metric when the listener is unavailable.

## Changes
- `src/services/stellar/eventListener.ts`
  - Added event listener health tracking via `EventListenerHealthStatus` and exported `eventListenerHealth`.
  - Added `getHealthStatus()` for runtime and test inspection.
  - Added reconnect logic on Soroban contract effect fetch failures.
  - Marked listener unhealthy on fetch failures and recovered health state once reconnect succeeds.
- `src/services/health/healthService.ts`
  - Extended the deep health report to include `sorobanEventListener` status.
  - Overall health now fails if the event listener status is down.
- `src/services/stellar/eventListener.test.ts`
  - Added coverage for exposed Soroban event listener health status.
- `tests/health.service.test.ts`
  - Added expectations for the new `sorobanEventListener` health dependency.
  - Added a failure case for when the Soroban event listener is unhealthy.

## Testing
1. Run the targeted tests:
   - `pnpm test -- src/services/stellar/eventListener.test.ts tests/health.service.test.ts`
2. Start the server with `pnpm dev`.
3. Confirm health output includes the new listener dependency:
   - `GET /api/v1/health/deep`
   - `GET /api/v1/health/metrics`
4. For reconnect behavior, temporarily interrupt the Soroban RPC and verify the listener reconnects and the health status returns to `up` after recovery.

## Notes
- Editor diagnostics show no errors in the modified files.
- The branch for this work is `Pi-Defi-world/acbu-backend`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added health monitoring for Soroban event listener with real-time status tracking
  * Implemented automatic reconnection mechanism for event listener failures

* **Improvements**
  * Enhanced overall service health reporting to include event listener status
  * Improved error detection and recovery in event listening operations

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/350?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->