### PR TITLE
fix: enforce fintech_tx_id validation and uniqueness in mint deposit flow

### DIFF
--- a/src/controllers/mintController.ts
+++ b/src/controllers/mintController.ts
@@ -10,6 +10,7 @@ import { acbuMintingService } from "../services/contracts";
 import { stellarClient } from "../services/stellar/client";
 import { AuthRequest } from "../middleware/auth";
 import { Decimal } from "@prisma/client/runtime/library";
+import { Prisma } from "@prisma/client";
 import { logAudit } from "../services/audit";
 import {
   BASKET_CURRENCIES,
@@ -23,6 +24,7 @@ import {
 import { enqueueUsdcConvertAndMint } from "../jobs/usdcConvertAndMintJob";
 import { AppError } from "../middleware/errorHandler";
 import { assertUserWalletAddress } from "../services/wallet/walletService";
+import { convertLocalToUsd } from "../services/rates";
 import { logger } from "../config/logger";
 import {
   parseMonetaryString,
@@ -60,7 +62,12 @@ export async function mintFromUsdc(
     }
     const parsed = usdcBodySchema.safeParse(req.body);
     if (!parsed.success) {
-      throw new AppError("Invalid request", 400, "VALIDATION_ERROR", parsed.error.flatten());
+      throw new AppError(
+        "Invalid request",
+        400,
+        "VALIDATION_ERROR",
+        parsed.error.flatten(),
+      );
     }
 
     const { usdc_amount, wallet_address } = parsed.data;
@@ -81,7 +88,6 @@ export async function mintFromUsdc(
         "CIRCUIT_BREAKER",
       );
     }
-
 
     // Apply deposit limits - use retail as default if no audience is set
     // FIX #32: Defaulting to "retail" prevents limit bypass when audience is undefined
@@ -204,6 +210,14 @@ export async function mintFromUsdcInternal(
   }
 }
 
+const fintechTxIdSchema = z
+  .string()
+  .trim()
+  .min(1, "fintech_tx_id must be provided")
+  .max(255, "fintech_tx_id must be 255 characters or fewer")
+  .regex(/^[^\s]+$/, "fintech_tx_id must not contain whitespace")
+  .optional();
+
 export const depositBodySchema = z.object({
   currency: z.string().length(3).toUpperCase(),
   amount: z
@@ -214,6 +228,7 @@ export const depositBodySchema = z.object({
       "must be positive with up to 7 decimal places",
     ),
   wallet_address: z.string().length(56).regex(/^G/),
+  fintech_tx_id: fintechTxIdSchema,
 });
 
 /**
@@ -232,7 +247,7 @@ export async function depositFromBasketCurrency(
         .json({ error: "Invalid request", details: parsed.error.flatten() });
       return;
     }
-    const { currency, amount, wallet_address } = parsed.data;
+    const { currency, amount, wallet_address, fintech_tx_id } = parsed.data;
     if (isForbiddenDepositCurrency(currency)) {
       throw new AppError(
         `Deposits in ${currency} are not allowed. Only basket (pool) currencies are accepted: ${BASKET_CURRENCIES.join(", ")}. For USDC, use the on-ramp (swap USDC→XLM via Stellar LP).`,
@@ -256,6 +271,19 @@ export async function depositFromBasketCurrency(
       throw new AppError("User context required for deposit", 401);
     }
     await assertUserWalletAddress(userId, wallet_address);
+    if (fintech_tx_id) {
+      const existingTx = await prisma.transaction.findUnique({
+        where: { idempotencyKey: fintech_tx_id },
+      });
+      if (existingTx) {
+        throw new AppError(
+          "Duplicate fintech_tx_id detected",
+          409,
+          "DUPLICATE_FINTECH_TX_ID",
+          { fintech_tx_id },
+        );
+      }
+    }
     // SECURITY: Always enforce circuit breaker and deposit limits
     // Previously these checks were skipped when req.audience was undefined,
     // allowing bypass of critical financial controls via direct /mint/deposit route
@@ -268,10 +296,9 @@ export async function depositFromBasketCurrency(
       );
     }
 
-
     // Apply deposit limits - use retail as default if no audience is set
     const audience = req.audience || "retail";
-    
+
     // CRITICAL: Convert local currency amount to USD for accurate limit checking.
     // Previously, the raw local amount was passed directly to checkDepositLimits,
     // treating 100,000 NGN as if it were 100,000 USD.
@@ -280,28 +307,47 @@ export async function depositFromBasketCurrency(
     // 2. Calculate ACBU equivalent: localAmount / localRate
     // 3. Convert to USD: acbuAmount * acbuUsdRate
     const amountUsd = await convertLocalToUsd(amountNum, currency);
-    
+
     await checkDepositLimits(
       audience,
-      amountUsdPlaceholder,
+      amountUsd,
       userId,
       req.apiKey?.organizationId ?? null,
     );
-    const tx = await prisma.transaction.create({
-      data: {
-        userId: req.apiKey?.userId ?? undefined,
-        organizationId: req.apiKey?.organizationId ?? undefined,
-        type: "mint",
-        status: "pending",
-        localCurrency: currency,
-        localAmount: new Decimal(amountDecimal),
-        rateSnapshot: {
-          deposit_currency: currency,
-          amount: amountDecimal.toNumber(),
-          timestamp: new Date().toISOString(),
+    let tx;
+    try {
+      tx = await prisma.transaction.create({
+        data: {
+          userId: req.apiKey?.userId ?? undefined,
+          organizationId: req.apiKey?.organizationId ?? undefined,
+          type: "mint",
+          status: "pending",
+          localCurrency: currency,
+          localAmount: new Decimal(amountDecimal),
+          idempotencyKey: fintech_tx_id ?? undefined,
+          rateSnapshot: {
+            deposit_currency: currency,
+            amount: amountDecimal.toNumber(),
+            timestamp: new Date().toISOString(),
+          },
         },
-      },
-    });
+      });
+    } catch (err: unknown) {
+      if (
+        err instanceof Prisma.PrismaClientKnownRequestError &&
+        err.code === "P2002" &&
+        Array.isArray(err.meta?.target) &&
+        (err.meta.target as string[]).includes("idempotency_key")
+      ) {
+        throw new AppError(
+          "Duplicate fintech_tx_id detected",
+          409,
+          "DUPLICATE_FINTECH_TX_ID",
+          { fintech_tx_id },
+        );
+      }
+      throw err;
+    }
     await logAudit({
       eventType: "transaction",
       entityType: "transaction",

--- a/src/routes/mintRoutes.ts
+++ b/src/routes/mintRoutes.ts
@@ -78,6 +78,9 @@ router.post("/usdc", mintFromUsdc);
  *                 type: string
  *               wallet_address:
  *                 type: string
+ *               fintech_tx_id:
+ *                 type: string
+ *                 description: Optional external payment transaction ID used for idempotency and duplicate detection
  *     responses:
  *       202:
  *         description: Deposit request accepted

--- a/src/tests/controllers/monetaryControllerIntegration.test.ts
+++ b/src/tests/controllers/monetaryControllerIntegration.test.ts
@@ -1,5 +1,10 @@
 import request from "supertest";
 import Decimal from "decimal.js";
+import {
+  contractNumberToDecimal,
+  decimalToContractNumber,
+  parseMonetaryString,
+} from "../../utils/decimalUtils";
 import { prisma } from "../../config/database";
 import app from "../../index";
 
@@ -22,7 +27,7 @@ describe("Monetary Controller Integration Tests", () => {
 
       expect(response.status).toBe(202);
       expect(response.body.on_ramp_swap_id).toBeDefined();
-      
+
       // Verify the stored amount preserves precision
       const swap = await prisma.onRampSwap.findUnique({
         where: { id: response.body.on_ramp_swap_id },
@@ -40,7 +45,7 @@ describe("Monetary Controller Integration Tests", () => {
         .set("Authorization", "Bearer test-api-key");
 
       expect(response.status).toBe(202);
-      
+
       const swap = await prisma.onRampSwap.findUnique({
         where: { id: response.body.on_ramp_swap_id },
       });
@@ -57,7 +62,9 @@ describe("Monetary Controller Integration Tests", () => {
         .set("Authorization", "Bearer test-api-key");
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toContain("must be positive with up to 7 decimal places");
+      expect(response.body.error).toContain(
+        "must be positive with up to 7 decimal places",
+      );
     });
 
     it("should reject scientific notation in USDC amounts", async () => {
@@ -70,7 +77,9 @@ describe("Monetary Controller Integration Tests", () => {
         .set("Authorization", "Bearer test-api-key");
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toContain("must be positive with up to 7 decimal places");
+      expect(response.body.error).toContain(
+        "must be positive with up to 7 decimal places",
+      );
     });
 
     it("should handle basket currency deposit with precision", async () => {
@@ -85,11 +94,56 @@ describe("Monetary Controller Integration Tests", () => {
 
       expect(response.status).toBe(202);
       expect(response.body.amount).toBe("999999999.9999999");
-      
+
       const tx = await prisma.transaction.findUnique({
         where: { id: response.body.transaction_id },
       });
       expect(tx?.localAmount?.toString()).toBe("999999999.9999999");
+    });
+
+    it("should reject duplicate fintech_tx_id values in basket deposit mint flow", async () => {
+      const payload = {
+        currency: "NGN",
+        amount: "1000",
+        wallet_address: "GABCDEFGHIJKLMNOPQRSTUVWXYZ123456789",
+        fintech_tx_id: "fintech-12345",
+      };
+
+      const firstResponse = await request(app)
+        .post("/v1/mint/deposit")
+        .send(payload)
+        .set("Authorization", "Bearer test-api-key");
+
+      expect(firstResponse.status).toBe(202);
+      expect(firstResponse.body.transaction_id).toBeDefined();
+
+      const secondResponse = await request(app)
+        .post("/v1/mint/deposit")
+        .send(payload)
+        .set("Authorization", "Bearer test-api-key");
+
+      expect(secondResponse.status).toBe(409);
+      expect(secondResponse.body.error?.code).toBe("DUPLICATE_FINTECH_TX_ID");
+      expect(secondResponse.body.error?.message).toContain(
+        "Duplicate fintech_tx_id detected",
+      );
+    });
+
+    it("should reject invalid fintech_tx_id values in basket deposit mint flow", async () => {
+      const response = await request(app)
+        .post("/v1/mint/deposit")
+        .send({
+          currency: "NGN",
+          amount: "1000",
+          wallet_address: "GABCDEFGHIJKLMNOPQRSTUVWXYZ123456789",
+          fintech_tx_id: "invalid tx id",
+        })
+        .set("Authorization", "Bearer test-api-key");
+
+      expect(response.status).toBe(400);
+      expect(response.body.error?.message).toContain(
+        "fintech_tx_id must not contain whitespace",
+      );
     });
   });
 
@@ -111,7 +165,7 @@ describe("Monetary Controller Integration Tests", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.acbu_amount).toBe("987654321.1234567");
-      
+
       const tx = await prisma.transaction.findUnique({
         where: { id: response.body.transaction_id },
       });
@@ -135,7 +189,7 @@ describe("Monetary Controller Integration Tests", () => {
 
       expect(response.status).toBe(200);
       expect(response.body.fee).toBeDefined();
-      
+
       // Fee should be calculated with Decimal precision
       const tx = await prisma.transaction.findUnique({
         where: { id: response.body.transaction_id },
@@ -159,13 +213,15 @@ describe("Monetary Controller Integration Tests", () => {
         .set("Authorization", "Bearer test-api-key");
 
       expect(response.status).toBe(400);
-      expect(response.body.error).toContain("must be positive with up to 7 decimal places");
+      expect(response.body.error).toContain(
+        "must be positive with up to 7 decimal places",
+      );
     });
 
     it("should handle ACBU burn at fee calculation boundaries", async () => {
       // Test amount that would cause precision issues with Number()
       const boundaryAmount = "0.00333333"; // 0.00333333 * 50 bps = 0.0000000166665
-      
+
       const response = await request(app)
         .post("/v1/burn/acbu")
         .send({
@@ -181,11 +237,11 @@ describe("Monetary Controller Integration Tests", () => {
         .set("Authorization", "Bearer test-api-key");
 
       expect(response.status).toBe(200);
-      
+
       const tx = await prisma.transaction.findUnique({
         where: { id: response.body.transaction_id },
       });
-      
+
       // Verify fee is calculated precisely
       const expectedFee = new Decimal(boundaryAmount).mul(50).div(10000);
       expect(tx?.fee?.toString()).toBe(expectedFee.toString());
@@ -230,11 +286,11 @@ describe("Monetary Controller Integration Tests", () => {
         .set("Authorization", "Bearer test-api-key");
 
       expect(response.status).toBe(200);
-      
+
       const tx = await prisma.transaction.findUnique({
         where: { id: response.body.transaction_id },
       });
-      
+
       // Verify fee doesn't overflow and maintains precision
       expect(tx?.fee?.toString()).toMatch(/^\d+\.\d+$/);
     });
@@ -244,22 +300,17 @@ describe("Monetary Controller Integration Tests", () => {
     it("should convert amounts to contract format with explicit rounding", async () => {
       // This test would require mocking the contract service
       // For now, we test the internal conversion logic
-      const { decimalToContractNumber } = require("../../utils/decimalUtils");
-      const { parseMonetaryString } = require("../../utils/decimalUtils");
-      
       const amount = parseMonetaryString("123.4567891");
       const contractNumber = decimalToContractNumber(amount);
-      
+
       // Should round down, not up
       expect(contractNumber).toBe(1234567891);
     });
 
     it("should handle contract number conversion back to Decimal", async () => {
-      const { contractNumberToDecimal } = require("../../utils/decimalUtils");
-      
       const contractNumber = 1234567891;
       const decimal = contractNumberToDecimal(contractNumber);
-      
+
       expect(decimal.toString()).toBe("123.4567891");
     });
   });


### PR DESCRIPTION
Description:
- Adds backend validation for optional `fintech_tx_id` on `/v1/mint/deposit`
- Rejects whitespace, empty strings, and values longer than 255 characters
- Checks `transaction.idempotencyKey` for duplicates before mint transaction creation
- Persists `fintech_tx_id` to `idempotencyKey` on new mint transactions
- Handles concurrent duplicate races via Prisma `P2002` and returns `409 DUPLICATE_FINTECH_TX_ID`
- Adds API docs and integration tests for duplicate and invalid `fintech_tx_id`

Closes #259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added idempotency support for deposit transactions to prevent accidental duplicate submissions.

* **Improvements**
  * Enhanced validation error handling for deposit and USDC mint requests with clearer error responses.
  * Added duplicate transaction detection that rejects conflicting submissions with a conflict status.
  * Updated API documentation to reflect the new idempotency field.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/351?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->