### PR TITLE
fix: enforce exact basket weight validation and rounding

### DIFF
--- a/src/config/basket.ts
+++ b/src/config/basket.ts
@@ -41,6 +41,56 @@ export const BASKET_WEIGHTS_SUM = Object.values(BASKET_WEIGHTS).reduce(
   0,
 );
 
+/** 100% expressed in basis points (100.00% = 10000 bps). */
+export const BASKET_WEIGHT_BASIS_POINTS = 10000;
+
+/**
+ * Round normalized basket weights to exact 100.00% using basis-point allocation.
+ * This protects against rounding drift when storing weights as Decimal(5,2).
+ */
+export function roundWeightsToExactBasisPoints(
+  weights: Map<string, number>,
+): Map<string, number> {
+  const total = [...weights.values()].reduce((s, w) => s + w, 0);
+  if (Math.abs(total - BASKET_WEIGHTS_SUM) > 1e-8) {
+    throw new Error(
+      `Basket weights must sum to ${BASKET_WEIGHTS_SUM.toFixed(2)}; got ${total.toFixed(8)}`,
+    );
+  }
+
+  const entries = [...weights.entries()].map(([currency, weight]) => {
+    if (weight < 0 || weight > 100) {
+      throw new Error(`Invalid basket weight for ${currency}: ${weight}`);
+    }
+
+    const scaled = weight * 100;
+    const floored = Math.floor(scaled);
+    return {
+      currency,
+      scaled,
+      floored,
+      remainder: scaled - floored,
+    };
+  });
+
+  const baseSum = entries.reduce((s, entry) => s + entry.floored, 0);
+  const missing = BASKET_WEIGHT_BASIS_POINTS - baseSum;
+  if (missing < 0 || missing > entries.length) {
+    throw new Error(
+      `Cannot allocate exact basis-point basket weights from provided values; got base sum ${baseSum}`,
+    );
+  }
+
+  entries.sort((a, b) => b.remainder - a.remainder);
+  for (let i = 0; i < missing; i += 1) {
+    entries[i].floored += 1;
+  }
+
+  return new Map(
+    entries.map((entry) => [entry.currency, Number((entry.floored / 100).toFixed(2))]),
+  );
+}
+
 /** Currencies that must NOT be deposited into the pool. Deposit API accepts only basket currencies. */
 export const FORBIDDEN_DEPOSIT_CURRENCIES = ["USDC", "USDT"] as const;
 

--- a/src/services/basket/basketService.ts
+++ b/src/services/basket/basketService.ts
@@ -4,7 +4,7 @@
  * Fallback: if no active BasketConfig (e.g. before seed), uses DEFAULT_BASKET from config for seed compatibility.
  */
 import { prisma } from "../../config/database";
-import { BASKET_CURRENCIES, BASKET_WEIGHTS } from "../../config/basket";
+import { BASKET_CURRENCIES, BASKET_WEIGHTS, BASKET_WEIGHT_BASIS_POINTS } from "../../config/basket";
 
 export interface BasketEntry {
   currency: string;
@@ -44,11 +44,20 @@ export class BasketService {
       (s: number, r: (typeof currentRows)[0]) => s + r.weight.toNumber(),
       0,
     );
-    const scale = sum > 0 ? 100 / sum : 1;
+
+    // Validate that weights stored in DB sum exactly to 100.00% (10000 basis points).
+    // Stored weights are Decimal(5,2) representing percent points; multiply by 100
+    // to obtain basis points and compare after rounding to avoid floating noise.
+    const sumBps = Math.round(sum * 100);
+    if (sumBps !== BASKET_WEIGHT_BASIS_POINTS) {
+      throw new Error(
+        `Invalid active BasketConfig weights: sum ${sumBps} bps != expected ${BASKET_WEIGHT_BASIS_POINTS} bps`,
+      );
+    }
 
     return currentRows.map((r: (typeof currentRows)[0]) => ({
       currency: r.currency,
-      weight: Math.round(r.weight.toNumber() * scale * 100) / 100,
+      weight: Math.round(r.weight.toNumber() * 100) / 100,
     }));
   }
 
@@ -78,11 +87,17 @@ export class BasketService {
       (s: number, r: (typeof asOfRows)[0]) => s + r.weight.toNumber(),
       0,
     );
-    const scale = sum > 0 ? 100 / sum : 1;
+
+    const sumBps = Math.round(sum * 100);
+    if (sumBps !== BASKET_WEIGHT_BASIS_POINTS) {
+      throw new Error(
+        `Invalid active BasketConfig weights as-of ${date.toISOString()}: sum ${sumBps} bps != expected ${BASKET_WEIGHT_BASIS_POINTS} bps`,
+      );
+    }
 
     return asOfRows.map((r: (typeof asOfRows)[0]) => ({
       currency: r.currency,
-      weight: Math.round(r.weight.toNumber() * scale * 100) / 100,
+      weight: Math.round(r.weight.toNumber() * 100) / 100,
     }));
   }
 

--- a/src/services/metrics/metricsService.ts
+++ b/src/services/metrics/metricsService.ts
@@ -6,7 +6,7 @@ import { prisma } from "../../config/database";
 import { logger } from "../../config/logger";
 import { basketService } from "../basket";
 import { fetchGdpUsd, fetchPopulation } from "./worldBankClient";
-import { BASKET_CURRENCIES } from "../../config/basket";
+import { BASKET_CURRENCIES, roundWeightsToExactBasisPoints } from "../../config/basket";
 import { Decimal } from "@prisma/client/runtime/library";
 
 const GDP_WEIGHT = 0.4;
@@ -136,12 +136,16 @@ export async function ingestMetricsAndProposeWeights(
   }
   const proposedWeights = normalizeToScores(proposedWeightRaw);
 
-  for (const [currency, weight] of proposedWeights) {
+  // Round and allocate to exact basis points to avoid rounding drift when
+  // storing as Decimal(5,2) in BasketConfig.
+  const rounded = roundWeightsToExactBasisPoints(proposedWeights);
+
+  for (const [currency, weight] of rounded) {
     await prisma.basketConfig.create({
       data: {
         effectiveFrom,
         currency,
-        weight: new Decimal(Math.round(weight * 100) / 100),
+        weight: new Decimal(Number(weight)),
         status: "proposed",
       },
     });


### PR DESCRIPTION

This PR ensures basket currency weights always total exactly 10,000 basis points. It prevents fractional rounding drift by:

- Adding an exact basis-point rounding helper (BASIS_POINTS = 10000) and applying it when generating proposed basket weights.
- Persisting proposed `BasketConfig` rows with weights rounded to exact basis points.
- Validating active basket reads so runtime code rejects/flags configs that do not sum to exactly `10000` bps instead of silently rescaling.

Files changed:
- src/config/basket.ts
- src/services/metrics/metricsService.ts
- src/services/basket/basketService.ts

Why:
Ensures deterministic, auditable weight math and prevents subtle allocation bugs caused by percent-to-basis-point rounding.

Testing / Verification:
- Run unit tests: `pnpm test` or `npm test`
- Manually exercise the metrics ingestion and basket-proposal flow and confirm stored `BasketConfig` rows sum to `10000` bps.

Notes:
- This is a runtime/data-validation change only; no database migrations expected.
- If you want tests around weight rounding added, I can add them in a follow-up.

Closes: #298


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced basket weight calculations with basis-point precision to ensure exact 100% allocation.
  * Implemented deterministic weight rounding for consistent and reproducible basket configurations.

* **Bug Fixes**
  * Added validation checks to detect and report inconsistent basket weight sums, improving data integrity.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/353?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->