### PR TITLE
fix(s3): enforce private ACL and SSE on KYC document uploads

### DIFF
--- a/src/services/storage/s3Service.ts
+++ b/src/services/storage/s3Service.ts
@@ -148,6 +148,10 @@ export async function generateUploadUrl(
     Bucket: config.s3.bucket,
     Key: objectKey,
     ContentType: mimeType,
+    // PII documents must never be publicly accessible
+    ACL: "private",
+    // Enforce encryption at rest at the object level
+    ServerSideEncryption: "AES256",
     // Tag the object immediately as pending scan — the virus-scan hook reads this
     Tagging: "scan-status=pending&owner=" + encodeURIComponent(userId),
     Metadata: {


### PR DESCRIPTION
PII documents (passports, ID cards, etc.) must never be publicly accessible. Explicitly set ACL: 'private' and ServerSideEncryption: 'AES256' on PutObjectCommand so objects are private and encrypted at rest regardless of bucket-level defaults.

Closes #295

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced security for file uploads with automatic server-side encryption and private access controls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/359?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->