### PR TITLE
Fix/acbu rate ttl cache

### DIFF
--- a/src/controllers/burnController.ts
+++ b/src/controllers/burnController.ts
@@ -24,6 +24,7 @@ import {
   calculateFee,
 } from "../utils/decimalUtils";
 import { AppError } from "../middleware/errorHandler";
+import { getLatestAcbuRate } from "../services/rates/acbuRateCache";
 
 /** Best-effort stringify for Decimal-like values in Prisma models. */
 function toNullableStringDecimal(v: unknown): string | null {
@@ -111,12 +112,7 @@ export async function burnAcbu(
     const feeAcbuDecimal = calculateFee(acbuDecimal, burnFeeBps);
     const acbuAmount7 = decimalToContractNumber(acbuDecimal).toString();
 
-    const acbuRateRecord = await prisma.acbuRate.findFirst({
-      orderBy: { timestamp: "desc" },
-    });
-    if (!acbuRateRecord) {
-      throw new Error("ACBU rates not available");
-    }
+    const acbuRateRecord = await getLatestAcbuRate();
     const rateKey =
       `acbu${currency.charAt(0).toUpperCase() + currency.slice(1).toLowerCase()}` as keyof typeof acbuRateRecord;
     const acbuPerLocal = acbuRateRecord[rateKey];

--- a/src/controllers/ratesController.ts
+++ b/src/controllers/ratesController.ts
@@ -4,8 +4,9 @@
  * GET /v1/rates/basket - Local amounts per 1 ACBU from basket weights + oracle consensus.
  */
 import { Request, Response, NextFunction } from "express";
-import { prisma } from "../config/database";
+import { AcbuRate } from "@prisma/client";
 import { basketService } from "../services/basket";
+import { getLatestAcbuRate } from "../services/rates/acbuRateCache";
 import { computeSyntheticBasketOneAcbuForBasket } from "../services/oracle/syntheticBasket";
 
 export async function getRates(
@@ -14,9 +15,12 @@ export async function getRates(
   next: NextFunction,
 ): Promise<void> {
   try {
-    const latest = await prisma.acbuRate.findFirst({
-      orderBy: { timestamp: "desc" },
-    });
+    let latest: AcbuRate | null = null;
+    try {
+      latest = await getLatestAcbuRate();
+    } catch {
+      // No rates yet
+    }
     if (!latest) {
       res.status(200).json({
         acbu_usd: null,
@@ -64,9 +68,12 @@ export async function getRatesQuote(
   try {
     const amount = Math.max(0, Number(req.query.amount) || 0);
 
-    const latest = await prisma.acbuRate.findFirst({
-      orderBy: { timestamp: "desc" },
-    });
+    let latest: AcbuRate | null = null;
+    try {
+      latest = await getLatestAcbuRate();
+    } catch {
+      // No rates yet
+    }
     if (!latest) {
       res.status(200).json({
         amount_acbu: amount,

--- a/src/services/fiat/fiatService.ts
+++ b/src/services/fiat/fiatService.ts
@@ -1,6 +1,7 @@
 import { prisma } from "../../config/database";
 import { BASKET_CURRENCIES, type BasketCurrency } from "../../config/basket";
 import { Decimal } from "@prisma/client/runtime/library";
+import { getLatestAcbuRate } from "../rates/acbuRateCache";
 import {
   acbuBurningService,
   acbuMintingService,
@@ -424,12 +425,7 @@ export async function simulateOffRamp(
     throw new Error("User wallet address not set");
   }
 
-  const acbuRateRecord = await prisma.acbuRate.findFirst({
-    orderBy: { timestamp: "desc" },
-  });
-  if (!acbuRateRecord) {
-    throw new Error("ACBU rates not available");
-  }
+  const acbuRateRecord = await getLatestAcbuRate();
 
   const rateKey =
     `acbu${currency.charAt(0).toUpperCase() + currency.slice(1).toLowerCase()}` as keyof typeof acbuRateRecord;

--- a/src/services/rates/acbuRateCache.test.ts
+++ b/src/services/rates/acbuRateCache.test.ts
@@ -1,0 +1,73 @@
+import { prisma } from "../../config/database";
+import { Decimal } from "@prisma/client/runtime/library";
+import { getLatestAcbuRate, invalidateAcbuRateCache } from "./acbuRateCache";
+
+jest.mock("../../config/database", () => ({
+  prisma: {
+    acbuRate: {
+      findFirst: jest.fn(),
+    },
+  },
+}));
+
+const mockRate = {
+  id: "1",
+  acbuUsd: new Decimal("0.50"),
+  acbuNgn: new Decimal("1000"),
+  timestamp: new Date(),
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  invalidateAcbuRateCache();
+});
+
+describe("getLatestAcbuRate", () => {
+  it("fetches from DB on first call", async () => {
+    (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue(mockRate);
+
+    const result = await getLatestAcbuRate();
+
+    expect(result).toBe(mockRate);
+    expect(prisma.acbuRate.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns cached value on second call within TTL", async () => {
+    (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue(mockRate);
+
+    await getLatestAcbuRate();
+    await getLatestAcbuRate();
+
+    expect(prisma.acbuRate.findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("coalesces concurrent misses into one DB query", async () => {
+    (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue(mockRate);
+
+    const [a, b, c] = await Promise.all([
+      getLatestAcbuRate(),
+      getLatestAcbuRate(),
+      getLatestAcbuRate(),
+    ]);
+
+    expect(prisma.acbuRate.findFirst).toHaveBeenCalledTimes(1);
+    expect(a).toBe(b);
+    expect(b).toBe(c);
+  });
+
+  it("throws when no rate row exists", async () => {
+    (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue(null);
+
+    await expect(getLatestAcbuRate()).rejects.toThrow("ACBU rates not available");
+  });
+
+  it("re-fetches after invalidation", async () => {
+    (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue(mockRate);
+
+    await getLatestAcbuRate();
+    invalidateAcbuRateCache();
+    await getLatestAcbuRate();
+
+    expect(prisma.acbuRate.findFirst).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/services/rates/acbuRateCache.ts
+++ b/src/services/rates/acbuRateCache.ts
@@ -1,0 +1,40 @@
+import { prisma } from "../../config/database";
+import { AcbuRate } from "@prisma/client";
+
+const TTL_MS = 10_000; // 10 seconds
+
+let cached: AcbuRate | null = null;
+let expiresAt = 0;
+let inflight: Promise<AcbuRate> | null = null;
+
+async function fetchFromDb(): Promise<AcbuRate> {
+  const row = await prisma.acbuRate.findFirst({ orderBy: { timestamp: "desc" } });
+  if (!row) throw new Error("ACBU rates not available");
+  cached = row;
+  expiresAt = Date.now() + TTL_MS;
+  return row;
+}
+
+/**
+ * Return the latest AcbuRate, served from an in-memory cache for up to TTL_MS.
+ * Concurrent callers during a cache miss share a single DB query (request coalescing).
+ */
+export async function getLatestAcbuRate(): Promise<AcbuRate> {
+  if (cached && Date.now() < expiresAt) {
+    return cached;
+  }
+
+  if (!inflight) {
+    inflight = fetchFromDb().finally(() => {
+      inflight = null;
+    });
+  }
+
+  return inflight;
+}
+
+/** Invalidate the cache (e.g. after a new rate is written). */
+export function invalidateAcbuRateCache(): void {
+  cached = null;
+  expiresAt = 0;
+}

--- a/src/services/rates/currencyConverter.ts
+++ b/src/services/rates/currencyConverter.ts
@@ -4,8 +4,8 @@
  * Uses high-precision Decimal math to avoid floating-point rounding errors.
  */
 
-import { prisma } from "../../config/database";
 import { Decimal } from "@prisma/client/runtime/library";
+import { getLatestAcbuRate } from "./acbuRateCache";
 import { AppError } from "../../middleware/errorHandler";
 
 /**
@@ -78,9 +78,7 @@ export async function convertLocalToUsd(
   }
 
   // Fetch the latest exchange rates
-  const latestRate = await prisma.acbuRate.findFirst({
-    orderBy: { timestamp: "desc" },
-  });
+  const latestRate = await getLatestAcbuRate().catch(() => null);
 
   if (!latestRate) {
     throw new AppError(
@@ -151,9 +149,7 @@ export async function convertLocalToUsdWithPrecision(
   }
 
   // Fetch the latest exchange rates
-  const latestRate = await prisma.acbuRate.findFirst({
-    orderBy: { timestamp: "desc" },
-  });
+  const latestRate = await getLatestAcbuRate().catch(() => null);
 
   if (!latestRate) {
     throw new AppError(

--- a/src/services/rates/index.ts
+++ b/src/services/rates/index.ts
@@ -3,3 +3,4 @@
  */
 
 export { convertLocalToUsd, convertLocalToUsdWithPrecision } from "./currencyConverter";
+export { getLatestAcbuRate, invalidateAcbuRateCache } from "./acbuRateCache";


### PR DESCRIPTION
fix: cache AcbuRate to prevent thundering-herd on mint/burn (https://github.com/Pi-Defi-world/acbu-backend/issues/282)
prisma.acbuRate.findFirst was called on every mint, burn, and currency
conversion with no caching. Under concurrent load this hammers the rates
table with redundant identical queries.

- Add src/services/rates/acbuRateCache.ts: 10 s in-memory TTL cache with
  request coalescing (concurrent misses share one DB round-trip)
- Expose invalidateAcbuRateCache() for post-write invalidation
- Replace bare prisma.acbuRate.findFirst calls in:
    currencyConverter.ts (x2), burnController.ts, fiatService.ts,
    ratesController.ts (x2)
- 5 unit tests covering: cache hit, TTL, coalescing, null row, invalidation

## Closes
Closes #282 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Implemented intelligent caching for exchange rates to improve application response times and reduce database load.
  * Optimized concurrent rate lookups to prevent redundant database queries.

* **System Improvements**
  * Added cache management capabilities for manual rate data synchronization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/360?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->