### PR TITLE
fix: enforce idempotency on mint, burn, transfer, and on-ramp writes

### DIFF
--- a/prisma/migrations/20260528000000_add_onramp_swap_idempotency/migration.sql
+++ b/prisma/migrations/20260528000000_add_onramp_swap_idempotency/migration.sql
@@ -1,0 +1,3 @@
+-- Add idempotency_key column to on_ramp_swaps for retry-safe mint registration
+ALTER TABLE "on_ramp_swaps" ADD COLUMN "idempotency_key" VARCHAR(255);
+CREATE UNIQUE INDEX "idx_on_ramp_swaps_idempotency_key" ON "on_ramp_swaps"("idempotency_key") WHERE "idempotency_key" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -290,6 +290,7 @@ model Webhook {
 model OnRampSwap {
   id             String    @id @default(uuid()) @db.Uuid
   userId         String    @map("user_id") @db.Uuid
+  idempotencyKey String?   @unique @map("idempotency_key") @db.VarChar(255)
   stellarAddress String    @map("stellar_address") @db.VarChar(56)
   source         String    @default("xlm_deposit") @db.VarChar(20) // 'usdc_deposit' | 'xlm_deposit'
   xlmAmount      Decimal?  @map("xlm_amount") @db.Decimal(20, 7)

--- a/src/controllers/burnController.ts
+++ b/src/controllers/burnController.ts
@@ -24,6 +24,7 @@ import {
   calculateFee,
 } from "../utils/decimalUtils";
 import { AppError } from "../middleware/errorHandler";
+import { extractIdempotencyKey } from "../utils/idempotency";
 
 /** Best-effort stringify for Decimal-like values in Prisma models. */
 function toNullableStringDecimal(v: unknown): string | null {
@@ -40,7 +41,7 @@ function toNullableStringDecimal(v: unknown): string | null {
 function respondFromExistingBurnTx(
   res: Response,
   tx: any, // Using any to avoid type issues with Prisma client
-  blockchainTxHash: string,
+  blockchainTxHash: string | null | undefined,
 ): void {
   res.status(200).json({
     transaction_id: tx.id,
@@ -53,7 +54,7 @@ function respondFromExistingBurnTx(
       ({ acbu_ngn: null, timestamp: tx.createdAt.toISOString() } as const),
     status: tx.status,
     estimated_completion: null,
-    blockchain_tx_hash: blockchainTxHash,
+    blockchain_tx_hash: blockchainTxHash ?? undefined,
   });
 }
 
@@ -92,6 +93,26 @@ export async function burnAcbu(
     }
     const { acbu_amount, currency, recipient_account, blockchain_tx_hash } =
       parsed.data;
+
+    const idempotencyKey = extractIdempotencyKey(req);
+    if (idempotencyKey) {
+      const existingBurn = await prisma.transaction.findFirst({
+        where: {
+          idempotencyKey,
+          type: "burn",
+          userId: req.apiKey?.userId ?? undefined,
+          organizationId: req.apiKey?.organizationId ?? undefined,
+        },
+      });
+      if (existingBurn) {
+        respondFromExistingBurnTx(
+          res,
+          existingBurn,
+          existingBurn.blockchainTxHash ?? blockchain_tx_hash ?? null,
+        );
+        return;
+      }
+    }
 
     const addresses = getContractAddresses();
     const burningEnabled = Boolean(addresses.burning);
@@ -158,6 +179,7 @@ export async function burnAcbu(
         data: {
           userId: req.apiKey?.userId ?? undefined,
           organizationId: req.apiKey?.organizationId ?? undefined,
+          idempotencyKey,
           type: "burn",
           status: "pending",
           acbuAmountBurned: new Decimal(acbuNum),
@@ -174,6 +196,29 @@ export async function burnAcbu(
         },
       });
     } catch (createError) {
+      if (
+        idempotencyKey &&
+        createError instanceof Prisma.PrismaClientKnownRequestError &&
+        createError.code === "P2002"
+      ) {
+        const existing = await prisma.transaction.findFirst({
+          where: {
+            idempotencyKey,
+            type: "burn",
+            userId: req.apiKey?.userId ?? undefined,
+            organizationId: req.apiKey?.organizationId ?? undefined,
+          },
+        });
+        if (existing) {
+          respondFromExistingBurnTx(
+            res,
+            existing,
+            existing.blockchainTxHash ?? blockchain_tx_hash ?? null,
+          );
+          return;
+        }
+      }
+
       const isDuplicateBurnHash =
         burningEnabled &&
         Boolean(blockchain_tx_hash) &&

--- a/src/controllers/mintController.test.ts
+++ b/src/controllers/mintController.test.ts
@@ -1,6 +1,9 @@
-import { depositFromBasketCurrency } from "./mintController";
+import { depositFromBasketCurrency, mintFromUsdc } from "./mintController";
 import { prisma } from "../config/database";
 import { AppError } from "../middleware/errorHandler";
+import { assertUserWalletAddress } from "../services/wallet/walletService";
+import { checkDepositLimits, isMintingPaused } from "../services/limits/limitsService";
+import { enqueueUsdcConvertAndMint } from "../jobs/usdcConvertAndMintJob";
 import type { AuthRequest } from "../middleware/auth";
 import type { Response, NextFunction } from "express";
 
@@ -11,6 +14,11 @@ jest.mock("../config/database", () => ({
     },
     transaction: {
       create: jest.fn(),
+      findFirst: jest.fn(),
+    },
+    onRampSwap: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
     },
   },
 }));
@@ -20,6 +28,24 @@ jest.mock("../services/contracts", () => ({
     mintFromBasket: jest.fn(),
     mintFromUsdc: jest.fn(),
   },
+}));
+
+jest.mock("../services/wallet/walletService", () => ({
+  assertUserWalletAddress: jest.fn(),
+}));
+
+jest.mock("../jobs/usdcConvertAndMintJob", () => ({
+  enqueueUsdcConvertAndMint: jest.fn(),
+}));
+
+jest.mock("../services/limits/limitsService", () => ({
+  checkDepositLimits: jest.fn(),
+  isMintingPaused: jest.fn(),
+}));
+
+jest.mock("../services/rates", () => ({
+  convertLocalToUsd: jest.fn().mockResolvedValue(100),
+  convertLocalToUsdWithPrecision: jest.fn(),
 }));
 
 const makeRes = () => {
@@ -32,10 +58,23 @@ const makeRes = () => {
 const makeNext = () => jest.fn() as jest.MockedFunction<NextFunction>;
 
 const mockedUserFindUnique = prisma.user.findUnique as jest.Mock;
+const mockedAssertUserWalletAddress = assertUserWalletAddress as jest.Mock;
+const mockedCheckDepositLimits = checkDepositLimits as jest.Mock;
+const mockedIsMintingPaused = isMintingPaused as jest.Mock;
+const mockedEnqueueUsdcConvertAndMint = enqueueUsdcConvertAndMint as jest.Mock;
+
+const mockedOnRampSwapCreate = prisma.onRampSwap.create as jest.Mock;
+const mockedOnRampSwapFindFirst = prisma.onRampSwap.findFirst as jest.Mock;
+const mockedTransactionCreate = prisma.transaction.create as jest.Mock;
+const mockedTransactionFindFirst = prisma.transaction.findFirst as jest.Mock;
 
 describe("mintController", () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockedAssertUserWalletAddress.mockImplementation(async (_userId, walletAddress) => walletAddress);
+    mockedCheckDepositLimits.mockResolvedValue(undefined);
+    mockedIsMintingPaused.mockResolvedValue(false);
+    mockedEnqueueUsdcConvertAndMint.mockResolvedValue(undefined);
   });
 
   it("rejects /mint/deposit when API key has no user context", async () => {
@@ -60,6 +99,9 @@ describe("mintController", () => {
   });
 
   it("rejects /mint/deposit when wallet_address does not match the user's stored wallet", async () => {
+    mockedAssertUserWalletAddress.mockImplementation(async () => {
+      throw new AppError("Wallet address does not match user", 403);
+    });
     mockedUserFindUnique.mockResolvedValue({ stellarAddress: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF" });
     const res = makeRes();
     const next = makeNext();
@@ -69,16 +111,84 @@ describe("mintController", () => {
         body: {
           currency: "NGN",
           amount: "100",
-          wallet_address: "GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB",
+          wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
         },
       } as AuthRequest,
       res,
       next,
     );
 
+    expect(mockedAssertUserWalletAddress).toHaveBeenCalled();
     const err = (next as jest.Mock).mock.calls[0][0] as AppError;
     expect(err).toBeInstanceOf(AppError);
     expect(err.statusCode).toBe(403);
     expect(err.message).toBe("Wallet address does not match user");
+  });
+
+  it("returns the existing mint transaction on duplicate idempotency key", async () => {
+    mockedTransactionFindFirst.mockResolvedValue({
+      id: "tx-duplicate",
+      status: "pending",
+      localCurrency: "NGN",
+      localAmount: { toString: () => "100" },
+    });
+
+    const res = makeRes();
+    const next = makeNext();
+    await depositFromBasketCurrency(
+      {
+        apiKey: { id: "key-1", userId: "user-1", organizationId: null, permissions: [], rateLimit: 100 },
+        get: jest.fn().mockReturnValue("repeat-key"),
+        body: {
+          currency: "NGN",
+          amount: "100",
+          wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        },
+      } as unknown as AuthRequest,
+      res,
+      next,
+    );
+
+    expect(mockedTransactionCreate).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        transaction_id: "tx-duplicate",
+        status: "pending",
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns the existing on-ramp swap on duplicate idempotency key", async () => {
+    mockedOnRampSwapFindFirst.mockResolvedValue({
+      id: "swap-duplicate",
+      status: "pending_convert",
+    });
+
+    const res = makeRes();
+    const next = makeNext();
+    await mintFromUsdc(
+      {
+        apiKey: { id: "key-1", userId: "user-1", organizationId: null, permissions: [], rateLimit: 100 },
+        get: jest.fn().mockReturnValue("duplicate-usdc"),
+        body: {
+          usdc_amount: "10",
+          wallet_address: "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+        },
+      } as unknown as AuthRequest,
+      res,
+      next,
+    );
+
+    expect(mockedOnRampSwapCreate).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(202);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        on_ramp_swap_id: "swap-duplicate",
+        status: "pending_convert",
+      }),
+    );
+    expect(next).not.toHaveBeenCalled();
   });
 });

--- a/src/controllers/mintController.ts
+++ b/src/controllers/mintController.ts
@@ -21,15 +21,18 @@ import {
   isMintingPaused,
 } from "../services/limits/limitsService";
 import { enqueueUsdcConvertAndMint } from "../jobs/usdcConvertAndMintJob";
+import { Prisma } from "@prisma/client";
 import { AppError } from "../middleware/errorHandler";
 import { assertUserWalletAddress } from "../services/wallet/walletService";
 import { logger } from "../config/logger";
+import { convertLocalToUsd } from "../services/rates";
 import {
   parseMonetaryString,
   decimalToContractNumber,
   contractNumberToDecimal,
   calculateFee,
 } from "../utils/decimalUtils";
+import { extractIdempotencyKey } from "../utils/idempotency";
 
 const MINT_FEE_BPS = 30; // 0.3%
 
@@ -58,6 +61,23 @@ export async function mintFromUsdc(
     if (!userId) {
       throw new AppError("User context required for USDC deposit", 401);
     }
+
+    const idempotencyKey = extractIdempotencyKey(req);
+    if (idempotencyKey) {
+      const existingSwap = await prisma.onRampSwap.findFirst({
+        where: { idempotencyKey, userId },
+      });
+      if (existingSwap) {
+        res.status(202).json({
+          on_ramp_swap_id: existingSwap.id,
+          status: existingSwap.status,
+          message:
+            "USDC deposit received. We will convert USDC→XLM in the backend and mint ACBU to your wallet; you do not need to wait for pools or swaps.",
+        });
+        return;
+      }
+    }
+
     const parsed = usdcBodySchema.safeParse(req.body);
     if (!parsed.success) {
       throw new AppError("Invalid request", 400, "VALIDATION_ERROR", parsed.error.flatten());
@@ -92,16 +112,40 @@ export async function mintFromUsdc(
       userId,
       req.apiKey?.organizationId ?? null,
     );
-    const swap = await prisma.onRampSwap.create({
-      data: {
-        userId,
-        stellarAddress: userWalletAddress,
-        source: "usdc_deposit",
-        usdcAmount: new Decimal(usdcDecimal),
-        xlmAmount: null,
-        status: "pending_convert",
-      },
-    });
+    let swap;
+    try {
+      swap = await prisma.onRampSwap.create({
+        data: {
+          userId,
+          stellarAddress: userWalletAddress,
+          source: "usdc_deposit",
+          usdcAmount: new Decimal(usdcDecimal),
+          xlmAmount: null,
+          status: "pending_convert",
+          idempotencyKey,
+        },
+      });
+    } catch (createError) {
+      if (
+        idempotencyKey &&
+        createError instanceof Prisma.PrismaClientKnownRequestError &&
+        createError.code === "P2002"
+      ) {
+        const existingSwap = await prisma.onRampSwap.findFirst({
+          where: { idempotencyKey, userId },
+        });
+        if (existingSwap) {
+          res.status(202).json({
+            on_ramp_swap_id: existingSwap.id,
+            status: existingSwap.status,
+            message:
+              "USDC deposit received. We will convert USDC→XLM in the backend and mint ACBU to your wallet; you do not need to wait for pools or swaps.",
+          });
+          return;
+        }
+      }
+      throw createError;
+    }
     await enqueueUsdcConvertAndMint({ onRampSwapId: swap.id });
     res.status(202).json({
       on_ramp_swap_id: swap.id,
@@ -280,28 +324,85 @@ export async function depositFromBasketCurrency(
     // 2. Calculate ACBU equivalent: localAmount / localRate
     // 3. Convert to USD: acbuAmount * acbuUsdRate
     const amountUsd = await convertLocalToUsd(amountNum, currency);
-    
+
     await checkDepositLimits(
       audience,
-      amountUsdPlaceholder,
+      amountUsd,
       userId,
       req.apiKey?.organizationId ?? null,
     );
-    const tx = await prisma.transaction.create({
-      data: {
-        userId: req.apiKey?.userId ?? undefined,
-        organizationId: req.apiKey?.organizationId ?? undefined,
-        type: "mint",
-        status: "pending",
-        localCurrency: currency,
-        localAmount: new Decimal(amountDecimal),
-        rateSnapshot: {
-          deposit_currency: currency,
-          amount: amountDecimal.toNumber(),
-          timestamp: new Date().toISOString(),
+
+    const idempotencyKey = extractIdempotencyKey(req);
+    if (idempotencyKey) {
+      const existingTx = await prisma.transaction.findFirst({
+        where: {
+          idempotencyKey,
+          type: "mint",
+          userId,
+          organizationId: req.apiKey?.organizationId ?? undefined,
         },
-      },
-    });
+      });
+      if (existingTx) {
+        res.status(202).json({
+          transaction_id: existingTx.id,
+          currency: existingTx.localCurrency ?? currency,
+          amount: existingTx.localAmount?.toString() ?? amountDecimal.toString(),
+          wallet_address: wallet_address ? "***" : undefined,
+          status: existingTx.status,
+          message:
+            "Deposit received. Complete payment to the designated account for your currency; ACBU will be minted after confirmation.",
+        });
+        return;
+      }
+    }
+
+    let tx;
+    try {
+      tx = await prisma.transaction.create({
+        data: {
+          userId: req.apiKey?.userId ?? undefined,
+          organizationId: req.apiKey?.organizationId ?? undefined,
+          type: "mint",
+          status: "pending",
+          localCurrency: currency,
+          localAmount: new Decimal(amountDecimal),
+          rateSnapshot: {
+            deposit_currency: currency,
+            amount: amountDecimal.toNumber(),
+            timestamp: new Date().toISOString(),
+          },
+          idempotencyKey,
+        },
+      });
+    } catch (createError) {
+      if (
+        idempotencyKey &&
+        createError instanceof Prisma.PrismaClientKnownRequestError &&
+        createError.code === "P2002"
+      ) {
+        const existingTx = await prisma.transaction.findFirst({
+          where: {
+            idempotencyKey,
+            type: "mint",
+            userId,
+            organizationId: req.apiKey?.organizationId ?? undefined,
+          },
+        });
+        if (existingTx) {
+          res.status(202).json({
+            transaction_id: existingTx.id,
+            currency: existingTx.localCurrency ?? currency,
+            amount: existingTx.localAmount?.toString() ?? amountDecimal.toString(),
+            wallet_address: wallet_address ? "***" : undefined,
+            status: existingTx.status,
+            message:
+              "Deposit received. Complete payment to the designated account for your currency; ACBU will be minted after confirmation.",
+          });
+          return;
+        }
+      }
+      throw createError;
+    }
     await logAudit({
       eventType: "transaction",
       entityType: "transaction",

--- a/src/controllers/onrampController.ts
+++ b/src/controllers/onrampController.ts
@@ -9,10 +9,12 @@ import { prisma } from "../config/database";
 import { AuthRequest } from "../middleware/auth";
 import { Decimal } from "@prisma/client/runtime/library";
 import { enqueueXlmToAcbu } from "../jobs/xlmToAcbuJob";
+import { Prisma } from "@prisma/client";
 import { AppError } from "../middleware/errorHandler";
 import { isValidStellarAddress } from "../utils/stellar";
 import { assertUserWalletAddress } from "../services/wallet/walletService";
 import { logFinancialEvent } from "../config/logger";
+import { extractIdempotencyKey } from "../utils/idempotency";
 
 export const bodySchema = z.object({
   stellar_address: z
@@ -68,18 +70,59 @@ export async function registerOnRampSwap(
       userId,
       stellar_address,
     );
+
+    const idempotencyKey = extractIdempotencyKey(req);
+    if (idempotencyKey) {
+      const existingSwap = await prisma.onRampSwap.findFirst({
+        where: { idempotencyKey, userId },
+      });
+      if (existingSwap) {
+        res.status(202).json({
+          on_ramp_swap_id: existingSwap.id,
+          status: existingSwap.status,
+          message:
+            "XLM→ACBU job queued. ACBU will be minted to your wallet when processing completes.",
+        });
+        return;
+      }
+    }
+
     const xlmNum = Number(xlm_amount);
-    const swap = await prisma.onRampSwap.create({
-      data: {
-        userId,
-        stellarAddress: userWalletAddress,
-        source: "xlm_deposit",
-        xlmAmount: new Decimal(xlmNum),
-        usdcAmount:
-          usdc_amount != null ? new Decimal(Number(usdc_amount)) : null,
-        status: "pending_convert",
-      },
-    });
+    let swap;
+    try {
+      swap = await prisma.onRampSwap.create({
+        data: {
+          userId,
+          stellarAddress: userWalletAddress,
+          source: "xlm_deposit",
+          xlmAmount: new Decimal(xlmNum),
+          usdcAmount:
+            usdc_amount != null ? new Decimal(Number(usdc_amount)) : null,
+          status: "pending_convert",
+          idempotencyKey,
+        },
+      });
+    } catch (createError) {
+      if (
+        idempotencyKey &&
+        createError instanceof Prisma.PrismaClientKnownRequestError &&
+        createError.code === "P2002"
+      ) {
+        const existingSwap = await prisma.onRampSwap.findFirst({
+          where: { idempotencyKey, userId },
+        });
+        if (existingSwap) {
+          res.status(202).json({
+            on_ramp_swap_id: existingSwap.id,
+            status: existingSwap.status,
+            message:
+              "XLM→ACBU job queued. ACBU will be minted to your wallet when processing completes.",
+          });
+          return;
+        }
+      }
+      throw createError;
+    }
     const correlationId =
       (req.headers["x-request-id"] as string | undefined) ??
       crypto.randomUUID();

--- a/src/controllers/transferController.test.ts
+++ b/src/controllers/transferController.test.ts
@@ -136,6 +136,32 @@ describe("transferController", () => {
       });
     });
 
+    it("passes the Idempotency-Key header into transfer creation", async () => {
+      (createTransfer as jest.Mock).mockResolvedValue({
+        transactionId: "tx-2",
+        status: "completed",
+      });
+      const res = makeRes();
+      await postTransfers(
+        {
+          body: { to: "@bob", amount_acbu: "10.5" },
+          apiKey: { userId: "u1" },
+          get: jest.fn().mockReturnValue("idem-transfer"),
+        } as unknown as AuthRequest,
+        res,
+        makeNext(),
+      );
+      expect(createTransfer).toHaveBeenCalledWith(
+        expect.objectContaining({
+          senderUserId: "u1",
+          to: "@bob",
+          amountAcbu: "10.5",
+          idempotencyKey: "idem-transfer",
+        }),
+        expect.any(Object),
+      );
+    });
+
     it("returns 404 when recipient is not found", async () => {
       (createTransfer as jest.Mock).mockRejectedValue(
         new Error("Recipient not found or not available"),

--- a/src/controllers/transferController.ts
+++ b/src/controllers/transferController.ts
@@ -4,6 +4,7 @@ import { AuthRequest } from "../middleware/auth";
 import { createTransfer } from "../services/transfer/transferService";
 import { prisma } from "../config/database";
 import { AppError } from "../middleware/errorHandler";
+import { extractIdempotencyKey } from "../utils/idempotency";
 
 export const createTransferSchema = z.object({
   to: z.string().min(1, "to is required"),
@@ -36,11 +37,13 @@ export async function postTransfers(
       throw new AppError("User-scoped API key required", 401);
     }
     const body = createTransferSchema.parse(req.body);
+    const idempotencyKey = extractIdempotencyKey(req);
     const result = await createTransfer(
       {
         senderUserId: userId,
         to: body.to.trim(),
         amountAcbu: body.amount_acbu.trim(),
+        idempotencyKey,
       },
       {
         // Legacy behavior: without hash, tx stays pending until key/worker is wired.

--- a/src/services/transfer/transferService.ts
+++ b/src/services/transfer/transferService.ts
@@ -8,6 +8,7 @@ import {
   Keypair,
   TransactionBuilder,
 } from "@stellar/stellar-sdk";
+import { Prisma } from "@prisma/client";
 import { prisma } from "../../config/database";
 import { stellarClient } from "../stellar/client";
 import { getBaseFee } from "../stellar/feeManager";
@@ -67,7 +68,7 @@ export async function createTransfer(
   params: CreateTransferParams,
   options?: CreateTransferOptions,
 ): Promise<CreateTransferResult> {
-  const { senderUserId, to } = params;
+  const { senderUserId, to, idempotencyKey } = params;
   const amount = params.amountAcbu.trim();
   // Reject scientific notation and enforce up to 7 decimal places (Stellar max precision)
   if (!amount || !/^\d+(\.\d{1,7})?$/.test(amount) || Number(amount) <= 0) {
@@ -89,6 +90,22 @@ export async function createTransfer(
     );
   }
 
+  if (idempotencyKey) {
+    const existingTransfer = await prisma.transaction.findFirst({
+      where: {
+        idempotencyKey,
+        userId: senderUserId,
+        type: "transfer",
+      },
+    });
+    if (existingTransfer) {
+      return {
+        transactionId: existingTransfer.id,
+        status: existingTransfer.status,
+      };
+    }
+  }
+
   const recipientAddress = await resolveRecipientToStellarAddress(
     to,
     senderUserId,
@@ -102,15 +119,40 @@ export async function createTransfer(
     throw new Error("Cannot transfer to yourself");
   }
 
-  const tx = await prisma.transaction.create({
-    data: {
-      userId: senderUserId,
-      type: "transfer",
-      status: "pending",
-      recipientAddress,
-      acbuAmount: amount,
-    },
-  });
+  let tx;
+  try {
+    tx = await prisma.transaction.create({
+      data: {
+        userId: senderUserId,
+        type: "transfer",
+        status: "pending",
+        recipientAddress,
+        acbuAmount: amount,
+        idempotencyKey: idempotencyKey ?? undefined,
+      },
+    });
+  } catch (createError) {
+    if (
+      idempotencyKey &&
+      createError instanceof Prisma.PrismaClientKnownRequestError &&
+      createError.code === "P2002"
+    ) {
+      const existingTransfer = await prisma.transaction.findFirst({
+        where: {
+          idempotencyKey,
+          userId: senderUserId,
+          type: "transfer",
+        },
+      });
+      if (existingTransfer) {
+        return {
+          transactionId: existingTransfer.id,
+          status: existingTransfer.status,
+        };
+      }
+    }
+    throw createError;
+  }
 
   const correlationId = options?.correlationId ?? crypto.randomUUID();
   // Avoid float arithmetic: parse integer and fractional parts separately to
@@ -125,7 +167,7 @@ export async function createTransfer(
     event: "transfer.initiated",
     status: "pending",
     transactionId: tx.id,
-    idempotencyKey: tx.id,
+    idempotencyKey: idempotencyKey ?? tx.id,
     userId: senderUserId,
     accountId: sender.stellarAddress ?? senderUserId,
     destinationId: recipientAddress,

--- a/src/services/transfer/types.ts
+++ b/src/services/transfer/types.ts
@@ -7,6 +7,7 @@ export interface CreateTransferParams {
   senderUserId: string;
   to: string;
   amountAcbu: string;
+  idempotencyKey?: string;
 }
 
 export interface CreateTransferOptions {

--- a/src/utils/idempotency.ts
+++ b/src/utils/idempotency.ts
@@ -1,0 +1,32 @@
+import { AppError } from "../middleware/errorHandler";
+
+const IDEMPOTENCY_KEY_MAX_LENGTH = 255;
+
+export function extractIdempotencyKey(req: { get?(name: string): string | undefined; headers?: Record<string, string | string[] | undefined> }): string | undefined {
+  const rawKey =
+    typeof req.get === "function"
+      ? req.get("Idempotency-Key")
+      : req.headers?.["Idempotency-Key"] ?? req.headers?.["idempotency-key"];
+  if (rawKey === undefined) {
+    return undefined;
+  }
+
+  const normalizedKey = (Array.isArray(rawKey) ? rawKey[0] : rawKey).trim();
+  if (normalizedKey.length === 0) {
+    throw new AppError(
+      "Idempotency-Key header must be a non-empty string",
+      400,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  if (normalizedKey.length > IDEMPOTENCY_KEY_MAX_LENGTH) {
+    throw new AppError(
+      `Idempotency-Key header exceeds maximum length of ${IDEMPOTENCY_KEY_MAX_LENGTH}`,
+      400,
+      "VALIDATION_ERROR",
+    );
+  }
+
+  return normalizedKey;
+}

--- a/tests/burn.idempotency.test.ts
+++ b/tests/burn.idempotency.test.ts
@@ -120,10 +120,64 @@ describe("B-074 burn idempotency", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
+  it("returns the original transaction for duplicate idempotency key retries", async () => {
+    const existingTx = {
+      id: "tx-2",
+      userId: "user-3",
+      type: "burn",
+      status: "pending",
+      usdcAmount: null,
+      acbuAmount: null,
+      acbuAmountBurned: new Decimal("10"),
+      localCurrency: "NGN",
+      localAmount: new Decimal("5000"),
+      recipientAccount: { account_number: "1" },
+      recipientAddress: null,
+      fee: new Decimal("0.01"),
+      rateSnapshot: { acbu_ngn: null, timestamp: new Date().toISOString() },
+      blockchainTxHash: null,
+      confirmations: 0,
+      createdAt: new Date("2026-04-23T00:00:00.000Z"),
+      completedAt: null,
+    };
+
+    prismaMock.transaction.findFirst.mockResolvedValue(existingTx);
+
+    const req: any = {
+      body: {
+        acbu_amount: "10",
+        currency: "NGN",
+        recipient_account: {
+          account_number: "1",
+          bank_code: "000",
+          account_name: "Test",
+        },
+      },
+      apiKey: { userId: "user-3", organizationId: null },
+      audience: "retail",
+      get: jest.fn().mockReturnValue("dup-burn-key"),
+    };
+
+    const res: any = {
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn().mockReturnThis(),
+    };
+    const next = jest.fn();
+
+    await burnAcbu(req, res, next);
+
+    expect(prismaMock.transaction.create).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({ transaction_id: "tx-2" }),
+    );
+    expect(next).not.toHaveBeenCalled();
+  });
+
   it("recovers from concurrent submit via P2002 and returns the existing transaction", async () => {
     const blockchainTxHash = "b".repeat(64);
     const existingTx = {
-      id: "tx-2",
+      id: "tx-3",
       userId: null,
       type: "burn",
       status: "processing",
@@ -195,7 +249,7 @@ describe("B-074 burn idempotency", () => {
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(
-      expect.objectContaining({ transaction_id: "tx-2", blockchain_tx_hash: blockchainTxHash }),
+      expect.objectContaining({ transaction_id: "tx-3", blockchain_tx_hash: blockchainTxHash }),
     );
     expect(next).not.toHaveBeenCalled();
   });


### PR DESCRIPTION
Closes #261

---

## Summary
This change adds replay protection across the write paths that can be retried by clients:
-  parsing and validation via a shared helper.
- Burn replay handling with lookup-and-return semantics.
- Mint replay handling for both USDC on-ramp swaps and basket-currency deposits.
- Transfer idempotency propagation through the service layer.
- On-ramp swap idempotency support through Prisma schema and migration.

## Details
- Added  for shared header extraction and validation.
- Updated burn, mint, on-ramp, and transfer write paths to persist and reuse .
- Added unique enforcement for  with migration .
- Expanded regression coverage in , , and .

## Verification
- Focused Jest run passed:
  - 
  - 
  - 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented idempotent transaction handling for USDC and basket currency deposits, transfers, burns, and on-ramp swap registrations—clients can safely retry failed operations using idempotency keys without risking duplicate transactions.

* **Tests**
  * Added comprehensive tests for idempotency scenarios across all affected operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/367?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->