### PR TITLE
fix(stellar): prefer configured network passphrase from env/config

### DIFF
--- a/src/services/stellar/client.ts
+++ b/src/services/stellar/client.ts
@@ -33,6 +33,7 @@ export class StellarClient {
     const horizonUrl = cfg?.horizonUrl ?? config.stellar.horizonUrl;
     const networkPassphrase =
       cfg?.networkPassphrase ??
+      config.stellar.networkPassphrase ??
       (network === "testnet"
         ? "Test SDF Network ; September 2015"
         : "Public Global Stellar Network ; September 2015");
@@ -276,4 +277,5 @@ export const stellarClient = new StellarClient({
   network: config.stellar.network as "testnet" | "mainnet",
   horizonUrl: config.stellar.horizonUrl,
   secretKey: config.stellar.secretKey,
+  networkPassphrase: config.stellar.networkPassphrase,
 });


### PR DESCRIPTION
Summary

Fix Stellar network passphrase usage so the client uses the configured passphrase instead of a hardcoded literal.

closes #304 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network configuration resolution with improved fallback mechanism to support configuration from multiple sources for greater flexibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Pi-Defi-world/acbu-backend/pull/371?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->