### PR TITLE
chore(build): exclude test and mock files from tsconfig build output

### DIFF
--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -9,8 +9,9 @@
   "exclude": [
     "node_modules",
     "dist",
-    "src/**/*.test.ts",
-    "src/**/__tests__/**",
-    "src/**/*.spec.ts"
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/__tests__/**",
+    "**/__mocks__/**"
   ]
 }


### PR DESCRIPTION
## Summary
- Hardened `tsconfig.build.json` to ensure test artifacts are never emitted to production build output.
- Added global exclude patterns for `*.test.ts`, `*.spec.ts`, `__tests__`, and `__mocks__`.
- Mitigates the risk of shipping mock secrets and test data in `dist/`.

## Why
Build output should only contain production runtime code. Test and mock files can include sensitive dummy credentials, fixtures, and non-production logic that must not be deployed.

## Scope
- Updated: `tsconfig.build.json`
- No runtime/business logic changes.
- No API, schema, or infrastructure changes.

Closes #308 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to more comprehensively exclude test files, test directories, and mock directories from the build output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->