### PR TITLE
fix: remove PII example values from swagger and ensure jest testTimeout

### DIFF
--- a/swagger.json
+++ b/swagger.json
@@ -5,9 +5,7 @@
     "version": "1.0.0",
     "description": "API documentation for ACBU (African Currency Basket Unit) platform",
     "contact": {
-      "name": "ACBU Support",
-      "email": "support@acbu.example.com",
-      "url": "https://acbu.example.com"
+      "name": "ACBU Support"
     }
   },
   "servers": [
@@ -54,24 +52,19 @@
                   "type": "object",
                   "properties": {
                     "totalAcbuSupply": {
-                      "type": "number",
-                      "example": 1000000
+                      "type": "number"
                     },
                     "totalReserveValueUsd": {
-                      "type": "number",
-                      "example": 1500000
+                      "type": "number"
                     },
                     "overcollateralizationRatio": {
-                      "type": "number",
-                      "example": 1.5
+                      "type": "number"
                     },
                     "reserveHealth": {
-                      "type": "string",
-                      "example": "healthy"
+                      "type": "string"
                     },
                     "currencies": {
-                      "type": "array",
-                      "example": ["USD", "EUR", "NGN"]
+                      "type": "array"
                     }
                   }
                 }


### PR DESCRIPTION
## Summary
- Remove email/URL and example values from swagger.json to prevent security scanners from flagging realistic-looking PII (Closes #322)
- jest.config.js already has `testTimeout: 30000` on main branch, which is sufficient for Stellar integration tests requiring ledger close (Closes #313)

Closes #322
Closes #313