### PR TITLE
fix: add engines field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,10 @@
   "name": "acbu-backend",
   "version": "1.0.0",
   "packageManager": "pnpm@10.33.1",
+  "engines": {
+    "node": ">=20.0.0",
+    "pnpm": ">=10.0.0"
+  },
   "description": "ACBU Backend API Server",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
Closes #319

Adds an `engines` field to `package.json` specifying the minimum required Node.js (>=20) and pnpm (>=10) versions. This prevents deployments on incompatible runtimes and makes the version requirement explicit to tooling (npm, pnpm, CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated minimum required versions for Node.js (20.0.0 or higher) and pnpm package manager (10.0.0 or higher).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->