### PR TITLE
fix(jobs): Centralize retry limits and cap withdrawal processing retr…

### DIFF
--- a/src/jobs/auditConsumer.test.ts
+++ b/src/jobs/auditConsumer.test.ts
@@ -35,6 +35,7 @@ describe("AuditConsumer", () => {
     consume: jest.fn(),
     ack: jest.fn(),
     nack: jest.fn(),
+    prefetch: jest.fn(),
   };
 
   const entry = {

--- a/src/jobs/auditConsumer.ts
+++ b/src/jobs/auditConsumer.ts
@@ -1,9 +1,10 @@
+import type { ConsumeMessage } from "amqplib";
 import { prisma } from "../config/database";
 import { logger } from "../config/logger";
-import { QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
-import { getRabbitMQChannel } from "../config/rabbitmq";
+import { QUEUES, assertQueueWithDLQ, getRabbitMQChannel } from "../config/rabbitmq";
+import { getQueueMaxRetries } from "./queueConfig";
 
-const MAX_RETRIES = 3;
+const MAX_RETRIES = getQueueMaxRetries(QUEUES.AUDIT_LOGS);
 const INITIAL_BACKOFF_MS = 1000;
 
 export async function startAuditConsumer() {
@@ -12,7 +13,7 @@ export async function startAuditConsumer() {
   await assertQueueWithDLQ(QUEUES.AUDIT_LOGS, { durable: true });
 
   channel.prefetch(1);
-  channel.consume(QUEUES.AUDIT_LOGS, async (msg) => {
+  channel.consume(QUEUES.AUDIT_LOGS, async (msg: ConsumeMessage | null) => {
     if (!msg) return;
 
     const content = msg.content.toString();

--- a/src/jobs/notificationConsumer.ts
+++ b/src/jobs/notificationConsumer.ts
@@ -3,6 +3,7 @@
  */
 import type { ConsumeMessage } from "amqplib";
 import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
+import { getQueueMaxRetries } from "./queueConfig";
 import { logger } from "../config/logger";
 import { prisma } from "../config/database";
 import {
@@ -114,7 +115,6 @@ async function processNotification(
   logger.debug("Notification type not handled", { type });
 }
 
-const MAX_RETRIES = 5;
 
 export async function startNotificationConsumer(): Promise<void> {
   const ch = await connectRabbitMQ();
@@ -133,7 +133,8 @@ export async function startNotificationConsumer(): Promise<void> {
         ch.ack(msg);
       } catch (e) {
         logger.error("OTP_SEND consumer error", { error: e });
-        if (retries >= MAX_RETRIES) {
+        const maxRetries = getQueueMaxRetries(QUEUES.OTP_SEND);
+        if (retries >= maxRetries) {
           logger.error("OTP_SEND failed permanently, sending to DLQ", { retries });
           ch.nack(msg, false, false);
           return;
@@ -163,7 +164,8 @@ export async function startNotificationConsumer(): Promise<void> {
         ch.ack(msg);
       } catch (e) {
         logger.error("NOTIFICATIONS consumer error", { error: e });
-        if (retries >= MAX_RETRIES) {
+        const maxRetries = getQueueMaxRetries(QUEUES.NOTIFICATIONS);
+        if (retries >= maxRetries) {
           logger.error("NOTIFICATIONS failed permanently, sending to DLQ", { retries });
           ch.nack(msg, false, false);
           return;

--- a/src/jobs/queueConfig.ts
+++ b/src/jobs/queueConfig.ts
@@ -1,0 +1,18 @@
+import { QUEUES } from "../config/rabbitmq";
+
+export const QUEUE_RETRY_LIMITS: Record<string, number> = {
+  [QUEUES.AUDIT_LOGS]: 3,
+  [QUEUES.NOTIFICATIONS]: 5,
+  [QUEUES.OTP_SEND]: 5,
+  [QUEUES.USDC_CONVERSION]: 5,
+  [QUEUES.WEBHOOKS]: 5,
+  [QUEUES.XLM_TO_ACBU]: 5,
+  [QUEUES.USDC_CONVERT_AND_MINT]: 5,
+  [QUEUES.WITHDRAWAL_PROCESSING]: 5,
+};
+
+export const DEFAULT_MAX_RETRIES = 5;
+
+export function getQueueMaxRetries(queueName: string): number {
+  return QUEUE_RETRY_LIMITS[queueName] ?? DEFAULT_MAX_RETRIES;
+}

--- a/src/jobs/usdcConversionJob.ts
+++ b/src/jobs/usdcConversionJob.ts
@@ -4,6 +4,7 @@
  */
 import type { ConsumeMessage } from "amqplib";
 import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
+import { getQueueMaxRetries } from "./queueConfig";
 import { logger } from "../config/logger";
 import { prisma } from "../config/database";
 import { basketService } from "../services/basket";
@@ -11,7 +12,7 @@ import { getFintechRouter } from "../services/fintech";
 import { Decimal } from "@prisma/client/runtime/library";
 
 const QUEUE = QUEUES.USDC_CONVERSION;
-const MAX_RETRIES = 5;
+const MAX_RETRIES = getQueueMaxRetries(QUEUE);
 
 export interface UsdcConversionPayload {
   usdcAmount: string;

--- a/src/jobs/usdcConvertAndMintJob.ts
+++ b/src/jobs/usdcConvertAndMintJob.ts
@@ -12,6 +12,7 @@ import {
   QUEUES,
   assertQueueWithDLQ,
 } from "../config/rabbitmq";
+import { getQueueMaxRetries } from "./queueConfig";
 import { logger } from "../config/logger";
 import { prisma } from "../config/database";
 import { mintFromUsdcInternal } from "../controllers/mintController";
@@ -19,7 +20,7 @@ import { swapUsdcToXlm } from "../services/stellar/usdcSwap";
 import { Decimal } from "@prisma/client/runtime/library";
 
 const QUEUE = QUEUES.USDC_CONVERT_AND_MINT;
-const MAX_RETRIES = 5;
+const MAX_RETRIES = getQueueMaxRetries(QUEUE);
 
 export interface UsdcConvertAndMintPayload {
   onRampSwapId: string;

--- a/src/jobs/webhookConsumer.ts
+++ b/src/jobs/webhookConsumer.ts
@@ -3,6 +3,7 @@
  */
 import type { ConsumeMessage } from "amqplib";
 import { connectRabbitMQ, QUEUES } from "../config/rabbitmq";
+import { getQueueMaxRetries } from "./queueConfig";
 import { logger } from "../config/logger";
 import { deliverWebhook } from "../services/webhook";
 
@@ -10,7 +11,7 @@ interface WebhookJobPayload {
   webhookId: string;
 }
 
-const MAX_RETRIES = 5;
+const MAX_RETRIES = getQueueMaxRetries(QUEUES.WEBHOOKS);
 
 export async function startWebhookConsumer(): Promise<void> {
   const ch = await connectRabbitMQ();

--- a/src/jobs/withdrawalProcessingJob.ts
+++ b/src/jobs/withdrawalProcessingJob.ts
@@ -4,11 +4,7 @@
  */
 import { randomUUID } from "crypto";
 import type { ConsumeMessage } from "amqplib";
-import {
-  connectRabbitMQ,
-  QUEUES,
-  assertQueueWithDLQ,
-} from "../config/rabbitmq";
+import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
 import { logger, logFinancialEvent } from "../config/logger";
 import { prisma } from "../config/database";
 import { getFintechRouter } from "../services/fintech";
@@ -72,16 +68,8 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
 
         const currency = tx.localCurrency;
         const amount = tx.localAmount ? Number(tx.localAmount) : 0;
-        const recipientJson = tx.recipientAccount as Record<
-          string,
-          unknown
-        > | null;
-        if (
-          !currency ||
-          !Number.isFinite(amount) ||
-          amount <= 0 ||
-          !recipientJson
-        ) {
+        const recipientJson = tx.recipientAccount as Record<string, unknown> | null;
+        if (!currency || !Number.isFinite(amount) || amount <= 0 || !recipientJson) {
           await prisma.transaction.update({
             where: { id: transactionId },
             data: { status: "failed" },
@@ -94,15 +82,9 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
         }
 
         const recipient: DisburseRecipient = {
-          accountNumber: String(
-            recipientJson.account_number ?? recipientJson.accountNumber ?? "",
-          ),
-          bankCode: String(
-            recipientJson.bank_code ?? recipientJson.bankCode ?? "",
-          ),
-          accountName: String(
-            recipientJson.account_name ?? recipientJson.accountName ?? "",
-          ),
+          accountNumber: String(recipientJson.account_number ?? recipientJson.accountNumber ?? ""),
+          bankCode: String(recipientJson.bank_code ?? recipientJson.bankCode ?? ""),
+          accountName: String(recipientJson.account_name ?? recipientJson.accountName ?? ""),
         };
         if (!recipient.accountNumber || !recipient.bankCode) {
           await prisma.transaction.update({
@@ -115,9 +97,8 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
         }
 
         const providerName =
-          ({ NGN: "paystack", RWF: "mtn_momo" } as Record<string, string>)[
-            currency
-          ] ?? "flutterwave";
+          ({ NGN: "paystack", RWF: "mtn_momo" } as Record<string, string>)[currency] ??
+          "flutterwave";
 
         logFinancialEvent({
           event: "withdrawal.processing",
@@ -139,24 +120,18 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
           try {
             provider = await router.getProvider(currency);
             usedProviderId = provider.constructor?.name || "unknown";
-            result = await provider.disburseFunds(
-              amount,
-              currency,
-              recipient,
-            );
+            result = await provider.disburseFunds(amount, currency, recipient);
           } catch (err) {
-            logger.warn("Primary provider failed, attempting failover", { transactionId, error: err });
+            logger.warn("Primary provider failed, attempting failover", {
+              transactionId,
+              error: err,
+            });
             // Simulate outage for primary, try next
             provider = await router.getProvider(currency, {
-              simulateOutageFor:
-                router.getPreferredProviderId(currency) ?? undefined,
+              simulateOutageFor: router.getPreferredProviderId(currency) ?? undefined,
             });
             usedProviderId = provider.constructor?.name || "unknown";
-            result = await provider.disburseFunds(
-              amount,
-              currency,
-              recipient,
-            );
+            result = await provider.disburseFunds(amount, currency, recipient);
           }
           await prisma.transaction.update({
             where: { id: transactionId },
@@ -198,32 +173,34 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
           logger.error("Withdrawal disbursement failed", {
             transactionId,
             error: err,
+            retries,
+            maxRetries: MAX_RETRIES,
           });
-          logFinancialEvent({
-            event: "withdrawal.failed",
-            status: "failed",
-            transactionId,
-            userId: tx.userId ?? "",
-            accountId: tx.userId ?? "",
-            idempotencyKey: transactionId,
-            amount: Math.round(amount * 100),
-            currency,
-            provider: providerName,
-            correlationId,
-            errorMessage: err instanceof Error ? err.message : String(err),
-          });
-          await prisma.transaction.update({
-            where: { id: transactionId },
-            data: { status: "failed" },
-          });
-          await publishWithdrawalNotification(
-            transactionId,
-            tx.userId,
-            "failed",
-            currency,
-            amount,
-          );
           if (retries >= MAX_RETRIES) {
+            logFinancialEvent({
+              event: "withdrawal.failed",
+              status: "failed",
+              transactionId,
+              userId: tx.userId ?? "",
+              accountId: tx.userId ?? "",
+              idempotencyKey: transactionId,
+              amount: Math.round(amount * 100),
+              currency,
+              provider: providerName,
+              correlationId,
+              errorMessage: err instanceof Error ? err.message : String(err),
+            });
+            await prisma.transaction.update({
+              where: { id: transactionId },
+              data: { status: "failed" },
+            });
+            await publishWithdrawalNotification(
+              transactionId,
+              tx.userId,
+              "failed",
+              currency,
+              amount,
+            );
             logger.error("Withdrawal processing job failed permanently, sending to DLQ", {
               transactionId,
               retries,
@@ -302,18 +279,12 @@ async function publishWithdrawalNotification(
 /**
  * Enqueue a withdrawal processing job (call from BurnEvent handler).
  */
-export async function enqueueWithdrawalProcessing(
-  payload: WithdrawalPayload,
-): Promise<void> {
+export async function enqueueWithdrawalProcessing(payload: WithdrawalPayload): Promise<void> {
   const ch = await connectRabbitMQ();
   await assertQueueWithDLQ(QUEUES.WITHDRAWAL_PROCESSING);
-  ch.sendToQueue(
-    QUEUES.WITHDRAWAL_PROCESSING,
-    Buffer.from(JSON.stringify(payload)),
-    {
-      persistent: true,
-    },
-  );
+  ch.sendToQueue(QUEUES.WITHDRAWAL_PROCESSING, Buffer.from(JSON.stringify(payload)), {
+    persistent: true,
+  });
   logger.info("Withdrawal processing enqueued", {
     transactionId: payload.transactionId,
   });

--- a/src/jobs/withdrawalProcessingJob.ts
+++ b/src/jobs/withdrawalProcessingJob.ts
@@ -13,6 +13,7 @@ import { logger, logFinancialEvent } from "../config/logger";
 import { prisma } from "../config/database";
 import { getFintechRouter } from "../services/fintech";
 import type { DisburseRecipient } from "../services/fintech/types";
+import { getQueueMaxRetries } from "./queueConfig";
 
 export interface WithdrawalPayload {
   transactionId: string;
@@ -29,6 +30,9 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
     async (msg: ConsumeMessage | null) => {
       if (!msg) return;
       const correlationId = randomUUID();
+      const headers = msg.properties.headers ?? {};
+      const retries = typeof headers["x-retries"] === "number" ? headers["x-retries"] : 0;
+      const MAX_RETRIES = getQueueMaxRetries(queue);
       try {
         const body = JSON.parse(msg.content.toString()) as WithdrawalPayload;
         const { transactionId, txHash } = body;
@@ -219,13 +223,42 @@ export async function startWithdrawalProcessingConsumer(): Promise<void> {
             currency,
             amount,
           );
-          ch.nack(msg, false, true);
+          if (retries >= MAX_RETRIES) {
+            logger.error("Withdrawal processing job failed permanently, sending to DLQ", {
+              transactionId,
+              retries,
+            });
+            ch.nack(msg, false, false);
+            return;
+          }
+          ch.sendToQueue(queue, msg.content, {
+            persistent: true,
+            headers: {
+              ...headers,
+              "x-retries": retries + 1,
+            },
+          });
+          ch.ack(msg);
           return;
         }
         ch.ack(msg);
       } catch (e) {
         logger.error("Withdrawal job failed", { error: e });
-        ch.nack(msg, false, true);
+        if (retries >= MAX_RETRIES) {
+          logger.error("Withdrawal processing job failed permanently, sending to DLQ", {
+            retries,
+          });
+          ch.nack(msg, false, false);
+          return;
+        }
+        ch.sendToQueue(queue, msg.content, {
+          persistent: true,
+          headers: {
+            ...headers,
+            "x-retries": retries + 1,
+          },
+        });
+        ch.ack(msg);
       }
     },
     { noAck: false },

--- a/src/jobs/xlmToAcbuJob.ts
+++ b/src/jobs/xlmToAcbuJob.ts
@@ -5,6 +5,7 @@
  */
 import type { ConsumeMessage } from "amqplib";
 import { connectRabbitMQ, QUEUES, assertQueueWithDLQ } from "../config/rabbitmq";
+import { getQueueMaxRetries } from "./queueConfig";
 import { logger, logFinancialEvent } from "../config/logger";
 import { prisma } from "../config/database";
 import { mintFromUsdcInternal } from "../controllers/mintController";
@@ -12,7 +13,7 @@ import { fetchXlmRateUsd } from "../services/oracle/cryptoClient";
 import { randomUUID } from "crypto";
 
 const QUEUE = QUEUES.XLM_TO_ACBU;
-const MAX_RETRIES = 5;
+const MAX_RETRIES = getQueueMaxRetries(QUEUE);
 
 export interface XlmToAcbuPayload {
   onRampSwapId: string;

--- a/tests/withdrawalProcessingJob.test.ts
+++ b/tests/withdrawalProcessingJob.test.ts
@@ -144,6 +144,7 @@ describe("WithdrawalProcessingConsumer", () => {
     );
     expect(mockChannel.ack).toHaveBeenCalled();
     expect(mockChannel.nack).not.toHaveBeenCalled();
+    expect(prisma.transaction.update).not.toHaveBeenCalled();
   });
 
   it("should permanently fail and nack to DLQ when retry limit is exceeded", async () => {
@@ -160,9 +161,13 @@ describe("WithdrawalProcessingConsumer", () => {
     expect(mockChannel.sendToQueue).not.toHaveBeenCalledWith(
       QUEUES.WITHDRAWAL_PROCESSING,
       expect.any(Buffer),
-      expect.any(Object)
+      expect.any(Object),
     );
     expect(mockChannel.nack).toHaveBeenCalledWith(expect.any(Object), false, false);
     expect(mockChannel.ack).not.toHaveBeenCalled();
+    expect(prisma.transaction.update).toHaveBeenCalledWith({
+      where: { id: "tx-123" },
+      data: expect.objectContaining({ status: "failed" }),
+    });
   });
 });

--- a/tests/withdrawalProcessingJob.test.ts
+++ b/tests/withdrawalProcessingJob.test.ts
@@ -1,0 +1,168 @@
+import { startWithdrawalProcessingConsumer } from "../src/jobs/withdrawalProcessingJob";
+import { prisma } from "../src/config/database";
+import {
+  connectRabbitMQ,
+  getRabbitMQChannel,
+  QUEUES,
+  assertQueueWithDLQ,
+} from "../src/config/rabbitmq";
+import { getFintechRouter } from "../src/services/fintech";
+
+jest.mock("../src/config/database", () => ({
+  prisma: {
+    transaction: {
+      findUnique: jest.fn(),
+      update: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../src/config/rabbitmq", () => ({
+  connectRabbitMQ: jest.fn(),
+  getRabbitMQChannel: jest.fn(),
+  assertQueueWithDLQ: jest.fn().mockResolvedValue({}),
+  QUEUES: {
+    WITHDRAWAL_PROCESSING: "withdrawal_processing",
+    NOTIFICATIONS: "notifications",
+  },
+}));
+
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+  logFinancialEvent: jest.fn(),
+}));
+
+jest.mock("../src/services/fintech", () => ({
+  getFintechRouter: jest.fn(),
+}));
+
+describe("WithdrawalProcessingConsumer", () => {
+  const mockChannel = {
+    consume: jest.fn(),
+    ack: jest.fn(),
+    nack: jest.fn(),
+    sendToQueue: jest.fn(),
+    prefetch: jest.fn(),
+  };
+
+  const payload = {
+    transactionId: "tx-123",
+    txHash: "0x123",
+  };
+
+  const mockMsg = (retries: number) => ({
+    content: Buffer.from(JSON.stringify(payload)),
+    properties: {
+      headers: {
+        "x-retries": retries,
+      },
+    },
+  });
+
+  const mockTx = {
+    id: "tx-123",
+    type: "burn",
+    status: "processing",
+    localCurrency: "NGN",
+    localAmount: 100,
+    recipientAccount: {
+      account_number: "1234567890",
+      bank_code: "011",
+      account_name: "John Doe",
+    },
+    userId: "user-123",
+  };
+
+  const mockProvider = {
+    disburseFunds: jest.fn(),
+  };
+
+  const mockRouter = {
+    getProvider: jest.fn().mockResolvedValue(mockProvider),
+    getPreferredProviderId: jest.fn().mockReturnValue("paystack"),
+  };
+
+  const flushPromises = () => new Promise((resolve) => setImmediate(resolve));
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (connectRabbitMQ as jest.Mock).mockResolvedValue(mockChannel);
+    (getRabbitMQChannel as jest.Mock).mockReturnValue(mockChannel);
+    (getFintechRouter as jest.Mock).mockReturnValue(mockRouter);
+    mockChannel.prefetch.mockReturnValue(undefined);
+  });
+
+  it("should successfully process disbursement and ack the message", async () => {
+    (prisma.transaction.findUnique as jest.Mock).mockResolvedValue(mockTx);
+    (prisma.transaction.update as jest.Mock).mockResolvedValue({});
+    mockProvider.disburseFunds.mockResolvedValue({ transactionId: "fintech-tx-999" });
+
+    mockChannel.consume.mockImplementation((_queue, callback) => {
+      callback(mockMsg(0));
+    });
+
+    await startWithdrawalProcessingConsumer();
+    await flushPromises();
+
+    expect(assertQueueWithDLQ).toHaveBeenCalledWith(QUEUES.WITHDRAWAL_PROCESSING);
+    expect(mockProvider.disburseFunds).toHaveBeenCalledWith(100, "NGN", {
+      accountNumber: "1234567890",
+      bankCode: "011",
+      accountName: "John Doe",
+    });
+    expect(prisma.transaction.update).toHaveBeenCalledWith({
+      where: { id: "tx-123" },
+      data: expect.objectContaining({ status: "completed" }),
+    });
+    expect(mockChannel.ack).toHaveBeenCalled();
+  });
+
+  it("should retry and increment x-retries header when disbursement fails and retries < max", async () => {
+    (prisma.transaction.findUnique as jest.Mock).mockResolvedValue(mockTx);
+    mockProvider.disburseFunds.mockRejectedValue(new Error("Outage"));
+
+    mockChannel.consume.mockImplementation((_queue, callback) => {
+      callback(mockMsg(2)); // Attempt count = 2
+    });
+
+    await startWithdrawalProcessingConsumer();
+    await flushPromises();
+
+    expect(mockChannel.sendToQueue).toHaveBeenCalledWith(
+      QUEUES.WITHDRAWAL_PROCESSING,
+      expect.any(Buffer),
+      expect.objectContaining({
+        headers: expect.objectContaining({
+          "x-retries": 3,
+        }),
+      }),
+    );
+    expect(mockChannel.ack).toHaveBeenCalled();
+    expect(mockChannel.nack).not.toHaveBeenCalled();
+  });
+
+  it("should permanently fail and nack to DLQ when retry limit is exceeded", async () => {
+    (prisma.transaction.findUnique as jest.Mock).mockResolvedValue(mockTx);
+    mockProvider.disburseFunds.mockRejectedValue(new Error("Permanent failure"));
+
+    mockChannel.consume.mockImplementation((_queue, callback) => {
+      callback(mockMsg(5)); // Attempt count = 5 (equals to Max retries of 5)
+    });
+
+    await startWithdrawalProcessingConsumer();
+    await flushPromises();
+
+    expect(mockChannel.sendToQueue).not.toHaveBeenCalledWith(
+      QUEUES.WITHDRAWAL_PROCESSING,
+      expect.any(Buffer),
+      expect.any(Object)
+    );
+    expect(mockChannel.nack).toHaveBeenCalledWith(expect.any(Object), false, false);
+    expect(mockChannel.ack).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Closes #410 by centralizing queue retry limits and preventing indefinite retry loops for failed jobs.

## Type of Change

* [x] Bug fix

## What Changed and Why

* Added `src/jobs/queueConfig.ts` to define retry limits per queue in a single place.
* Replaced hardcoded retry limits across consumers with configuration-based limits.
* Fixed `withdrawalProcessingJob` so failed jobs no longer retry indefinitely.
* Added retry cap enforcement using the existing `x-retries` header pattern.
* Jobs that exceed the configured retry limit are now routed to the configured DLQ instead of being requeued forever.
* Added tests covering retry behavior and DLQ routing.

This prevents permanently failing jobs from consuming worker capacity and aligns retry handling across queues.

## How to Test

1. Run the withdrawal processing tests:

   ```bash
   pnpm jest tests/withdrawalProcessingJob.test.ts
   ```

2. Run the audit consumer tests:

   ```bash
   pnpm jest src/jobs/auditConsumer.test.ts
   ```

3. Verify that failed withdrawal jobs are retried up to the configured limit and then routed to the DLQ.

## Checklist

* [x] Added tests for the new behavior
* [x] No secrets or environment files committed
* [x] Changes are scoped to retry handling and queue configuration

## Related Issues

Closes #410


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable retry limits for job queues, replacing hardcoded values with per-queue settings.
  * Audit logs now support exponential backoff for retries.

* **Bug Fixes**
  * Improved message handling in withdrawal processing with proper retry boundaries and dead-letter queue routing.

* **Tests**
  * Added comprehensive test coverage for withdrawal processing job scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->