### PR TITLE
fix(api): add cache headers for semi-static responses

### DIFF
--- a/src/middleware/cacheHeaders.ts
+++ b/src/middleware/cacheHeaders.ts
@@ -1,0 +1,11 @@
+import { Request, Response, NextFunction } from "express";
+
+/**
+ * Middleware to set Cache-Control and Surrogate-Control headers for semi-static API responses.
+ * Max-age is set to 1 hour (3600 seconds), and CDNs (Surrogate-Control) can cache it for 24 hours (86400 seconds).
+ */
+export function cacheSemiStatic(_req: Request, res: Response, next: NextFunction): void {
+  res.setHeader("Cache-Control", "public, max-age=3600, stale-while-revalidate=600");
+  res.setHeader("Surrogate-Control", "max-age=86400");
+  next();
+}

--- a/src/routes/configRoutes.ts
+++ b/src/routes/configRoutes.ts
@@ -1,10 +1,11 @@
 import { Router, type IRouter } from "express";
 import { getPublicAssetsConfig } from "../controllers/configController";
+import { cacheSemiStatic } from "../middleware/cacheHeaders";
 
 const router: IRouter = Router();
 
 // Public — no API key required. Used by the frontend to discover the exact
 // ACBU asset (code + issuer) + Stellar network to sign trustlines against.
-router.get("/assets", getPublicAssetsConfig);
+router.get("/assets", cacheSemiStatic, getPublicAssetsConfig);
 
 export default router;

--- a/src/routes/ratesRoutes.ts
+++ b/src/routes/ratesRoutes.ts
@@ -1,16 +1,13 @@
 import { Router, type IRouter } from "express";
-import {
-  getRates,
-  getRatesQuote,
-  getRatesBasket,
-} from "../controllers/ratesController";
+import { getRates, getRatesQuote, getRatesBasket } from "../controllers/ratesController";
 import { validateApiKey } from "../middleware/auth";
 import { apiKeyRateLimiter } from "../middleware/rateLimiter";
+import { cacheSemiStatic } from "../middleware/cacheHeaders";
 
 const router: IRouter = Router();
 router.use(validateApiKey);
 router.use(apiKeyRateLimiter);
-router.get("/", getRates);
+router.get("/", cacheSemiStatic, getRates);
 router.get("/quote", getRatesQuote);
-router.get("/basket", getRatesBasket);
+router.get("/basket", cacheSemiStatic, getRatesBasket);
 export default router;

--- a/tests/cacheHeaders.test.ts
+++ b/tests/cacheHeaders.test.ts
@@ -1,0 +1,22 @@
+import express from "express";
+import request from "supertest";
+import { cacheSemiStatic } from "../src/middleware/cacheHeaders";
+
+describe("cacheSemiStatic middleware", () => {
+  const app = express();
+
+  beforeAll(() => {
+    app.get("/test-cache", cacheSemiStatic, (_req, res) => {
+      res.status(200).json({ data: "ok" });
+    });
+  });
+
+  it("should set Cache-Control and Surrogate-Control headers", async () => {
+    const response = await request(app).get("/test-cache").expect(200);
+
+    expect(response.headers["cache-control"]).toBe(
+      "public, max-age=3600, stale-while-revalidate=600",
+    );
+    expect(response.headers["surrogate-control"]).toBe("max-age=86400");
+  });
+});


### PR DESCRIPTION
## Summary

Adds cache headers for semi-static API responses to reduce unnecessary origin requests and improve CDN caching.

## What Changed

* Added `cacheSemiStatic` middleware.
* Applied caching headers to:

  * `/v1/rates`
  * `/v1/rates/basket`
  * `/v1/config/assets`
* Added tests verifying `Cache-Control` and `Surrogate-Control` headers.

## Testing

```bash
pnpm jest tests/cacheHeaders.test.ts
```

## Related Issues

Closes #415
