### PR TITLE
fix(eslint): enable reportUnusedDisableDirectives as warn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
   ],
   "rules": {
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
+    "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }],
+    "reportUnusedDisableDirectives": "warn"
   },
   "env": {
     "node": true,


### PR DESCRIPTION
Closes #479

Unnecessary `eslint-disable` comments will now be reported as warnings.
Helps surface dead disables without breaking the build/CI.

Changes:
- Added `"reportUnusedDisableDirectives": "warn"` in `.eslintrc.json`

Note: Set to "warn" to avoid immediate CI breakage. Can be tightened to "error" later after cleanup.