### PR TITLE
fix: patch Express 4 router with express-async-errors (#420)

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "dotenv": "^16.4.5",
     "escape-string-regexp": "^5.0.0",
     "express": "^4.18.2",
+    "express-async-errors": "^3.1.1",
     "express-rate-limit": "^7.1.5",
     "helmet": "^7.1.0",
     "jsonwebtoken": "^9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       express:
         specifier: ^4.18.2
         version: 4.22.1
+      express-async-errors:
+        specifier: ^3.1.1
+        version: 3.1.1(express@4.22.1)
       express-rate-limit:
         specifier: ^7.1.5
         version: 7.5.1(express@4.22.1)
@@ -2330,6 +2333,11 @@ packages:
   expect@29.7.0:
     resolution: {integrity: sha512-2Zks0hf1VLFYI1kbh0I5jP3KHHyCHpkfyHBzsSXRFgl/Bg9mWYfMW8oD+PdMPlEwy5HNsR9JutYy6pMeOh61nw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
+  express-async-errors@3.1.1:
+    resolution: {integrity: sha512-h6aK1da4tpqWSbyCa3FxB/V6Ehd4EEB15zyQq9qe75OZBp0krinNKuH4rAY+S/U/2I36vdLAUFSjQJ+TFmODng==}
+    peerDependencies:
+      express: ^4.16.2
 
   express-rate-limit@7.5.1:
     resolution: {integrity: sha512-7iN8iPMDzOMHPUYllBEsQdWVB6fPDMPqwjBaFrgr4Jgr/+okjvzAy+UHlYYL/Vs0OsOrMkwS6PJDkFlJwoxUnw==}
@@ -6993,6 +7001,10 @@ snapshots:
       jest-matcher-utils: 29.7.0
       jest-message-util: 29.7.0
       jest-util: 29.7.0
+
+  express-async-errors@3.1.1(express@4.22.1):
+    dependencies:
+      express: 4.22.1
 
   express-rate-limit@7.5.1(express@4.22.1):
     dependencies:

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 import { initTracing } from "./config/tracing";
 initTracing();
 
+import "express-async-errors";
+
 import express, {
   type NextFunction,
   type Request,

--- a/tests/asyncErrors.test.ts
+++ b/tests/asyncErrors.test.ts
@@ -1,0 +1,10 @@
+import fs from "fs";
+import path from "path";
+
+describe("Express Async Errors Patching Integration", () => {
+  it("should have imported express-async-errors in src/index.ts", () => {
+    const indexPath = path.resolve(__dirname, "../src/index.ts");
+    const content = fs.readFileSync(indexPath, "utf8");
+    expect(content).toContain('import "express-async-errors";');
+  });
+});


### PR DESCRIPTION
## Description
Express 4 does not natively catch async errors/rejected promises thrown in route handlers, which can lead to unhandled promise rejections crashing the process. This PR resolves the issue by adding and importing `express-async-errors` at the entry point of the application to automatically patch the Express routing prototype.

Resolves #420

## Changes
- Added `express-async-errors` dependency to `package.json` and updated `pnpm-lock.yaml`.
- Imported `express-async-errors` in `src/index.ts` right after tracing initialization and before importing Express or defining routes.
- Added `tests/asyncErrors.test.ts` to programmatically assert that the package is correctly imported at the entry point.

## Verification
- Verified that the unit test runs and passes successfully.