### PR TITLE
fix: add log rotation and clean up test teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "swagger-ui-express": "^5.0.0",
     "typescript": "^5.3.3",
     "winston": "^3.11.0",
+    "winston-daily-rotate-file": "^5.0.0",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -140,6 +140,9 @@ importers:
       winston:
         specifier: ^3.11.0
         version: 3.19.0
+      winston-daily-rotate-file:
+        specifier: ^5.0.0
+        version: 5.0.0(winston@3.19.0)
       zod:
         specifier: ^3.23.8
         version: 3.25.76
@@ -2394,6 +2397,9 @@ packages:
     resolution: {integrity: sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==}
     engines: {node: ^10.12.0 || >=12.0.0}
 
+  file-stream-rotator@0.6.1:
+    resolution: {integrity: sha512-u+dBid4PvZw17PmDeRcNOtCP9CCK/9lRN2w+r1xIS7yOL9JFrIBKTvrYsxT4P0pGtThYTn++QS5ChHaUov3+zQ==}
+
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
@@ -3040,6 +3046,9 @@ packages:
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
 
+  moment@2.30.1:
+    resolution: {integrity: sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==}
+
   mongodb-connection-string-url@3.0.2:
     resolution: {integrity: sha512-rMO7CGo/9BFwyZABcKAWL8UJwH/Kc2x0g72uhDWzG48URRax5TCIcJ7Rc3RZqffZzO/Gwff/jyKwCU9TN8gehA==}
 
@@ -3125,6 +3134,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -3829,6 +3842,12 @@ packages:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
     hasBin: true
+
+  winston-daily-rotate-file@5.0.0:
+    resolution: {integrity: sha512-JDjiXXkM5qvwY06733vf09I2wnMXpZEhxEVOSPenZMii+g7pcDcTBt2MRugnoi8BwVSuCT2jfRXBUy+n1Zz/Yw==}
+    engines: {node: '>=8'}
+    peerDependencies:
+      winston: ^3
 
   winston-transport@4.9.0:
     resolution: {integrity: sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==}
@@ -7087,6 +7106,10 @@ snapshots:
     dependencies:
       flat-cache: 3.2.0
 
+  file-stream-rotator@0.6.1:
+    dependencies:
+      moment: 2.30.1
+
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
@@ -7897,6 +7920,8 @@ snapshots:
 
   module-details-from-path@1.0.4: {}
 
+  moment@2.30.1: {}
+
   mongodb-connection-string-url@3.0.2:
     dependencies:
       '@types/whatwg-url': 11.0.5
@@ -7953,6 +7978,8 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -8637,6 +8664,14 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  winston-daily-rotate-file@5.0.0(winston@3.19.0):
+    dependencies:
+      file-stream-rotator: 0.6.1
+      object-hash: 3.0.0
+      triple-beam: 1.4.1
+      winston: 3.19.0
+      winston-transport: 4.9.0
 
   winston-transport@4.9.0:
     dependencies:

--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -1,4 +1,5 @@
 import winston from "winston";
+import DailyRotateFile from "winston-daily-rotate-file";
 import path from "path";
 import { config } from "./env";
 import { FinancialLogPayload, FinancialEventEnvironment } from "../types/logging";
@@ -39,14 +40,24 @@ export const logger = winston.createLogger({
     new winston.transports.Console({
       format: consoleFormat,
     }),
-    // Write all logs with level 'error' and below to error.log
-    new winston.transports.File({
-      filename: path.join(logDir, "error.log"),
+    // Rotating error log: daily rotation, 14-day retention, 100 MB max per file
+    new DailyRotateFile({
+      dirname: logDir,
+      filename: "error-%DATE%.log",
+      datePattern: "YYYY-MM-DD",
       level: "error",
+      maxFiles: "14d",
+      maxSize: "100m",
+      zippedArchive: true,
     }),
-    // Write all logs to combined.log
-    new winston.transports.File({
-      filename: config.logFile,
+    // Rotating combined log: daily rotation, 30-day retention, 100 MB max per file
+    new DailyRotateFile({
+      dirname: logDir,
+      filename: "combined-%DATE%.log",
+      datePattern: "YYYY-MM-DD",
+      maxFiles: "30d",
+      maxSize: "100m",
+      zippedArchive: true,
     }),
   ],
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import { initTracing } from "./config/tracing";
 initTracing();
 
 import express, { type NextFunction, type Request, type Response } from "express";
-<<<<<<< fix/trust-proxy-config
 import helmet from "helmet";
-=======
->>>>>>> dev
 import compression from "compression";
 import swaggerUi from "swagger-ui-express";
 import { config } from "./config/env";

--- a/tests/jest.setup.ts
+++ b/tests/jest.setup.ts
@@ -5,7 +5,9 @@ process.env.MONGODB_URI ||= "mongodb://localhost:27017/acbu_test";
 process.env.RABBITMQ_URL ||= "amqp://guest:guest@localhost:5672";
 process.env.JWT_SECRET ||= "test-jwt-secret-for-ci";
 process.env.API_KEY_SALT ||= "test-api-key-salt";
-process.env.DATABASE_URL ||= "postgresql://test:test@localhost:5432/acbu_test";
-process.env.MONGODB_URI ||= "mongodb://localhost:27017/acbu_test";
-process.env.RABBITMQ_URL ||= "amqp://localhost:5672";
-process.env.JWT_SECRET ||= "test-secret";
+
+// Disconnect Prisma after the entire test suite to prevent open handles.
+afterAll(async () => {
+  const { prisma } = await import("../src/config/database");
+  await prisma.$disconnect();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,10 +2,10 @@
   "compilerOptions": {
     "target": "ES2022",
     "module": "commonjs",
-    "ignoreDeprecations": "6.0",
     "lib": ["ES2022"],
     "outDir": "./dist",
     "strict": true,
+    "strictNullChecks": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,


### PR DESCRIPTION
- Replace static Winston File transports with DailyRotateFile (winston-daily-rotate-file)
  - error logs: daily rotation, 14-day retention, 100 MB max, gzip compressed
  - combined logs: daily rotation, 30-day retention, 100 MB max, gzip compressed
  - resolves #476 (logs/ growing unboundedly)
- Remove duplicate env assignments in tests/jest.setup.ts
- Add global afterAll to disconnect Prisma after the full test suite, preventing open handles and leftover connection state across runs
  - resolves #448
- Resolve pre-existing merge conflict in src/index.ts (keep helmet import)

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
closes #448 
closes #476 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a broken import preventing module compilation.

* **Chores**
  * Implemented daily rotating log files with automatic archival and retention policies (14-30 day windows).
  * Updated test environment configuration and added proper cleanup procedures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->