### PR TITLE
fix: prevent account_merge on treasury account to mitigate asset drai…

### DIFF
--- a/docs/STELLAR_SECURITY.md
+++ b/docs/STELLAR_SECURITY.md
@@ -1,0 +1,72 @@
+# Stellar Security Measures
+
+## Account Merge Protection
+
+### Vulnerability
+
+If the platform's Stellar account supports the `account_merge` operation without additional safeguards, a compromised backend could perform the following attack:
+
+1. An attacker gains control of the backend system
+2. They invoke `account_merge` on the treasury account, specifying their own account as the destination
+3. All assets held by the treasury account (the entire ACBU asset pool) are transferred to the attacker's account
+4. The treasury account is destroyed
+
+### Mitigation
+
+The `StellarClient` enforces a security policy that prevents dangerous operations on the treasury account:
+
+**Forbidden Operations:**
+- `accountMerge` - Prevents merging the treasury into another account
+
+**Implementation:**
+
+```typescript
+// Validation occurs automatically when building transactions
+const transaction = await stellarClient.buildTransaction(
+  treasuryAccountId,
+  operations, // accountMerge operation will be rejected here
+);
+```
+
+**Behavior:**
+- If a forbidden operation is detected on the treasury account, the transaction build fails with an error
+- Operations are validated for the account's public key (derived from `STELLAR_SECRET_KEY`)
+- Non-treasury accounts can perform any operation (backward compatible)
+
+### Defense in Depth
+
+**Recommended additional safeguards:**
+
+1. **Multi-signature Setup** - Configure the Stellar account with multiple signers so no single compromised key can authorize treasury operations
+2. **Stellar Signers Threshold** - Set the master weight and threshold such that treasury operations require multiple signatures
+3. **Key Rotation** - Regularly rotate the `STELLAR_SECRET_KEY` and implement key management best practices
+4. **Monitoring** - Alert on any attempt to use forbidden operations in logs (`Forbidden treasury operation attempted`)
+5. **Network-level Controls** - Restrict outbound connections to only approved Stellar Horizon endpoints
+
+### Testing
+
+Security validation is tested in `src/services/stellar/operationSecurity.test.ts`:
+
+```bash
+pnpm test -- operationSecurity.test.ts
+```
+
+Test coverage includes:
+- Safe operations are allowed for treasury accounts
+- Forbidden operations are rejected with clear error messages
+- All operations are allowed for non-treasury accounts
+- Graceful handling when no treasury account is configured
+
+### Future Enhancements
+
+If additional operations need to be restricted for treasury accounts, add them to `FORBIDDEN_TREASURY_OPERATIONS` in `src/services/stellar/operationSecurity.ts`:
+
+```typescript
+const FORBIDDEN_TREASURY_OPERATIONS = [
+  "accountMerge",
+  // Add more as needed
+  "allowTrust", // If vault-specific restrictions are needed
+];
+```
+
+Each added operation will automatically be validated on all treasury account transactions.

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import { initTracing } from "./config/tracing";
 initTracing();
 
 import express, { type NextFunction, type Request, type Response } from "express";
-<<<<<<< fix/trust-proxy-config
 import helmet from "helmet";
-=======
->>>>>>> dev
 import compression from "compression";
 import swaggerUi from "swagger-ui-express";
 import { config } from "./config/env";

--- a/src/services/stellar/client.ts
+++ b/src/services/stellar/client.ts
@@ -8,6 +8,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { config } from "../../config/env";
 import { logger } from "../../config/logger";
+import { validateOperationsForTreasuryAccount } from "./operationSecurity";
 
 const Server = Horizon.Server;
 
@@ -32,6 +33,7 @@ export class StellarClient {
   private network: "testnet" | "mainnet";
   private networkPassphrase: string;
   private keypair: Keypair | null = null;
+  private treasuryAccountId: string | null = null;
 
   constructor(cfg?: Partial<StellarNetworkConfig>) {
     const network = (cfg?.network ?? config.stellar.network) as
@@ -54,6 +56,7 @@ export class StellarClient {
     if (secretKey) {
       try {
         this.keypair = Keypair.fromSecret(secretKey);
+        this.treasuryAccountId = this.keypair.publicKey();
         logger.info("Stellar keypair initialized", {
           publicKey: this.keypair.publicKey(),
           network,
@@ -144,6 +147,15 @@ export class StellarClient {
     },
   ) {
     try {
+      // Validate operations for treasury account security
+      if (this.treasuryAccountId) {
+        validateOperationsForTreasuryAccount(
+          operations,
+          sourceAccountId,
+          this.treasuryAccountId,
+        );
+      }
+
       const sourceAccount = await this.getAccount(sourceAccountId);
       let fee = options?.fee;
       if (!fee) {

--- a/src/services/stellar/operationSecurity.test.ts
+++ b/src/services/stellar/operationSecurity.test.ts
@@ -1,0 +1,84 @@
+import {
+  validateOperationsForTreasuryAccount,
+  isTreasuryAccount,
+} from "./operationSecurity";
+
+describe("operationSecurity", () => {
+  const treasuryAccountId =
+    "GDZST3XVCDTUJ76ZAV2HA72KYLT5FGZD5G6N7NZ6XHFWLQDN5SWTB24F";
+  const otherAccountId =
+    "GBXDIBFH4ZRXO3KSQXQJIBQQFQULWIKFKFH4DBGFWJDX6GWVDGXC5X3";
+
+  describe("validateOperationsForTreasuryAccount", () => {
+    it("should allow safe operations for treasury account", () => {
+      const operations: any[] = [
+        { type: "payment", destination: otherAccountId, amount: "100" },
+        { type: "createAccount", destination: otherAccountId, startingBalance: "10" },
+      ];
+
+      expect(() =>
+        validateOperationsForTreasuryAccount(
+          operations,
+          treasuryAccountId,
+          treasuryAccountId,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should reject accountMerge operations for treasury account", () => {
+      const operations: any[] = [
+        { type: "accountMerge", destination: otherAccountId },
+      ];
+
+      expect(() =>
+        validateOperationsForTreasuryAccount(
+          operations,
+          treasuryAccountId,
+          treasuryAccountId,
+        ),
+      ).toThrow(
+        "Operation 'accountMerge' is forbidden for the treasury account to prevent asset drainage attacks",
+      );
+    });
+
+    it("should allow all operations for non-treasury accounts", () => {
+      const operations: any[] = [
+        { type: "accountMerge", destination: treasuryAccountId },
+      ];
+
+      expect(() =>
+        validateOperationsForTreasuryAccount(
+          operations,
+          otherAccountId,
+          treasuryAccountId,
+        ),
+      ).not.toThrow();
+    });
+
+    it("should allow operations when no treasury account is configured", () => {
+      const operations: any[] = [
+        { type: "accountMerge", destination: otherAccountId },
+      ];
+
+      expect(() =>
+        validateOperationsForTreasuryAccount(
+          operations,
+          treasuryAccountId,
+          "",
+        ),
+      ).not.toThrow();
+    });
+  });
+
+  describe("isTreasuryAccount", () => {
+    it("should identify treasury account correctly", () => {
+      expect(isTreasuryAccount(treasuryAccountId, treasuryAccountId)).toBe(
+        true,
+      );
+    });
+
+    it("should identify non-treasury account correctly", () => {
+      expect(isTreasuryAccount(otherAccountId, treasuryAccountId)).toBe(false);
+    });
+  });
+});

--- a/src/services/stellar/operationSecurity.ts
+++ b/src/services/stellar/operationSecurity.ts
@@ -1,0 +1,53 @@
+import { Operation } from "@stellar/stellar-sdk";
+import { logger } from "../../config/logger";
+
+/**
+ * Operations that are explicitly forbidden for the treasury account
+ * to prevent catastrophic attacks like account_merge that could drain assets
+ */
+const FORBIDDEN_TREASURY_OPERATIONS = [
+  "accountMerge", // Prevents merging treasury into attacker's account
+];
+
+/**
+ * Validate that a transaction doesn't contain dangerous operations for the treasury account
+ * @param operations - Array of Stellar operations
+ * @param accountId - The account ID executing the operations
+ * @param treasuryAccountId - The platform's treasury account ID
+ * @throws Error if a forbidden operation is detected
+ */
+export function validateOperationsForTreasuryAccount(
+  operations: Operation[],
+  accountId: string,
+  treasuryAccountId: string,
+): void {
+  if (accountId !== treasuryAccountId) {
+    return;
+  }
+
+  for (const operation of operations) {
+    const opType = (operation as any).type;
+
+    if (FORBIDDEN_TREASURY_OPERATIONS.includes(opType)) {
+      const error = new Error(
+        `Operation '${opType}' is forbidden for the treasury account to prevent asset drainage attacks`,
+      );
+      logger.error("Forbidden treasury operation attempted", {
+        operation: opType,
+        accountId,
+        treasuryAccountId,
+      });
+      throw error;
+    }
+  }
+}
+
+/**
+ * Check if an account is the treasury account
+ */
+export function isTreasuryAccount(
+  accountId: string,
+  treasuryAccountId: string,
+): boolean {
+  return accountId === treasuryAccountId;
+}


### PR DESCRIPTION
Stellar Account Merge Protection
  
  Problem
  
  A compromised backend could invoke account_merge on the treasury account, transferring the entire ACBU asset pool to an attacker's account and
  destroying the treasury.
  
  Solution
  
  Added operation validation in StellarClient to reject accountMerge operations on the treasury account before transaction submission.
  
  Changes
  
  - operationSecurity.ts - New module that validates operations and forbids accountMerge on treasury
  - operationSecurity.test.ts - Full test coverage (6 tests passing)
  - client.ts - Integrated validation into buildTransaction()
  - STELLAR_SECURITY.md - Security documentation with defense-in-depth recommendations
  
  Behavior
  
  - Forbidden operations on treasury account → transaction build fails with error
  - Non-treasury accounts → no restrictions (backward compatible)
  - All violations logged for monitoring and alerting

closes #395 