### PR TITLE
fix(prisma): map composite @@unique constraints to database-level ind…

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -129,7 +129,7 @@ model Reserve {
   reserveValueUsd Decimal  @map("reserve_value_usd") @db.Decimal(20, 2)
   timestamp       DateTime @default(now()) @db.Timestamp(6)
 
-  @@unique([currency, segment, timestamp])
+  @@unique([currency, segment, timestamp], map: "reserves_currency_segment_timestamp_key")
   @@index([currency], map: "idx_reserves_currency")
   @@index([segment], map: "idx_reserves_segment")
   @@index([timestamp], map: "idx_reserves_timestamp")
@@ -168,7 +168,7 @@ model OracleRate {
   validatorSignatures Json?    @map("validator_signatures")
   timestamp           DateTime @default(now()) @db.Timestamp(6)
 
-  @@unique([currency, timestamp])
+  @@unique([currency, timestamp], map: "oracle_rates_currency_timestamp_key")
   @@index([timestamp], map: "idx_oracle_rates_timestamp")
   @@map("oracle_rates")
 }
@@ -207,7 +207,7 @@ model BasketMetrics {
   source         String?  @db.VarChar(100)
   createdAt      DateTime @default(now()) @map("created_at") @db.Timestamp(6)
 
-  @@unique([currency, period])
+  @@unique([currency, period], map: "basket_metrics_currency_period_key")
   @@index([currency], map: "idx_basket_metrics_currency")
   @@index([period], map: "idx_basket_metrics_period")
   @@map("basket_metrics")
@@ -223,7 +223,7 @@ model BasketConfig {
   proposalId    String?  @map("proposal_id") @db.Uuid
   status        String   @db.VarChar(20) // proposed | approved | active
 
-  @@unique([effectiveFrom, currency])
+  @@unique([effectiveFrom, currency], map: "basket_config_effective_from_currency_key")
   @@index([status], map: "idx_basket_config_status")
   @@index([effectiveFrom], map: "idx_basket_config_effective_from")
   @@index([status, effectiveFrom(sort: Desc)], map: "idx_basket_config_current")
@@ -425,7 +425,7 @@ model UserContact {
   user        User  @relation("UserContacts", fields: [userId], references: [id], onDelete: Cascade)
   contactUser User? @relation("ContactOf", fields: [contactUserId], references: [id], onDelete: SetNull)
 
-  @@unique([userId, contactUserId])
+  @@unique([userId, contactUserId], map: "user_contacts_user_id_contact_user_id_key")
   @@index([userId], map: "idx_user_contact_user_id")
   @@index([contactUserId], map: "idx_user_contact_contact_user_id")
   @@map("user_contacts")
@@ -508,7 +508,7 @@ model KycValidator {
   validations KycValidation[]
   rewards     KycValidatorReward[]
 
-  @@unique([userId, countryCode])
+  @@unique([userId, countryCode], map: "kyc_validators_user_id_country_code_key")
   @@index([countryCode], map: "idx_kyc_validator_country")
   @@index([status], map: "idx_kyc_validator_status")
   @@map("kyc_validators")


### PR DESCRIPTION
## Summary

This PR resolves drift between Prisma composite `@@unique` constraints and their corresponding PostgreSQL unique index names by explicitly mapping each constraint to the existing database-level index using the `map` attribute.

The database already enforces these uniqueness guarantees through snake_case index names, while Prisma was relying on generated constraint names derived from model field names. Aligning the schema with the actual index names improves consistency between Prisma and PostgreSQL and ensures constraint violations are correctly associated with the underlying database indexes.

## Changes

Updated composite unique constraints in the following models:

* Reserve
* OracleRate
* BasketMetrics
* BasketConfig
* UserContact
* KycValidator

Each `@@unique` definition now explicitly references its existing database index name.

## Verification

* Regenerated the Prisma client with `pnpm prisma:generate`
* Verified the schema remains valid and integrates without additional database migrations
* Confirmed the change is limited to Prisma schema metadata and does not alter runtime behavior or database structure

Closes #422


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated database constraint definitions across multiple data models to improve system stability and maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->