### PR TITLE
fix(#436): add memory usage monitoring and heap dump on leak detection

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,6 +20,21 @@ JWT_SECRET="dev-jwt-secret-change-me"
 # OPENAI_ORG_MONTHLY_BUDGET_USD=50
 # OPENAI_MAX_TOKENS_PER_REQUEST=2000
 
+# ── Memory / heap (#436) ─────────────────────────────────────────────────────
+# Cap the V8 heap so OOM kills happen predictably rather than at OS limit.
+# Set to ~75% of the container/instance memory. Omit to rely on V8 default (~1.4 GB).
+# NODE_OPTIONS=--max-old-space-size=512
+
+# Heap usage percentage (of heap_size_limit) at which a WARNING is logged (default 85).
+# MEMORY_LEAK_THRESHOLD_PCT=85
+
+# How often the memory monitor samples heap usage, in milliseconds (default 30000).
+# MEMORY_CHECK_INTERVAL_MS=30000
+
+# Directory where .heapsnapshot files are written when heap pressure turns CRITICAL (default ./heapdumps).
+# Ensure this path is writable and excluded from your Docker image or .gitignore.
+# HEAP_DUMP_DIR=./heapdumps
+
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=60000
 RATE_LIMIT_MAX_REQUESTS=100

--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,7 @@ Thumbs.db
 tmp/
 temp/
 .idea
+
+# Heap snapshots written by the memory leak detector (#436)
+heapdumps/
+*.heapsnapshot

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -53,6 +53,14 @@ const envSchema = z.object({
   DB_CONNECT_MAX_RETRIES: z.coerce.number().int().min(1).default(8),
   DB_CONNECT_BASE_BACKOFF_MS: z.coerce.number().int().min(1).default(250),
   DB_CONNECT_MAX_BACKOFF_MS: z.coerce.number().int().min(1).default(10000),
+
+  // #436: Memory leak detection thresholds.
+  // MEMORY_LEAK_THRESHOLD_PCT — warn when heapUsed crosses this % of heap_size_limit (default 85).
+  // MEMORY_CHECK_INTERVAL_MS  — how often to sample heap usage (default 30 000 ms).
+  // HEAP_DUMP_DIR             — directory for .heapsnapshot files written on critical heap pressure.
+  MEMORY_LEAK_THRESHOLD_PCT: z.coerce.number().int().min(50).max(99).default(85),
+  MEMORY_CHECK_INTERVAL_MS: z.coerce.number().int().min(1000).default(30000),
+  HEAP_DUMP_DIR: z.string().default("./heapdumps"),
 });
 
 const parsed = envSchema.safeParse(process.env);

--- a/src/config/promMetrics.ts
+++ b/src/config/promMetrics.ts
@@ -1,14 +1,19 @@
 /**
  * #388: Prometheus-compatible metrics for Prisma connection pool.
+ * #436: Heap usage ratio gauge and heap dump counter for memory leak detection.
  *
  * Instruments Prisma middleware to track:
  *  - prisma_pool_wait_seconds   – time spent waiting to acquire a connection (histogram)
  *  - prisma_pool_acquire_seconds – total time from request to first query byte (histogram)
  *  - prisma_pool_exhausted_total – P2024 (pool timeout) error counter
  *
+ * Memory metrics:
+ *  - nodejs_heap_used_ratio     – heapUsed / heap_size_limit (0–1 gauge)
+ *  - nodejs_heap_dump_total     – number of heap snapshots written to disk
+ *
  * Also collects default Node.js process metrics (event loop, memory, CPU).
  */
-import { Registry, Histogram, Counter, collectDefaultMetrics } from "prom-client";
+import { Registry, Histogram, Counter, Gauge, collectDefaultMetrics } from "prom-client";
 
 export const registry = new Registry();
 
@@ -32,5 +37,19 @@ export const poolAcquireHistogram = new Histogram({
 export const poolExhaustedCounter = new Counter({
   name: "prisma_pool_exhausted_total",
   help: "Total number of P2024 connection pool timeout errors",
+  registers: [registry],
+});
+
+// #436: heap usage ratio — heapUsed divided by the effective V8 heap size limit.
+// Values approaching 1.0 indicate a potential memory leak.
+export const heapUsedRatioGauge = new Gauge({
+  name: "nodejs_heap_used_ratio",
+  help: "Ratio of V8 heapUsed to heap_size_limit (0–1). Values near 1 indicate potential memory leak.",
+  registers: [registry],
+});
+
+export const heapDumpCounter = new Counter({
+  name: "nodejs_heap_dump_total",
+  help: "Total number of heap snapshots written to disk by the leak detector.",
   registers: [registry],
 });

--- a/src/gracefulShutdown.ts
+++ b/src/gracefulShutdown.ts
@@ -2,12 +2,18 @@ import { type Server } from "http";
 import { logger } from "./config/logger";
 import { disconnectMongoDB } from "./config/mongodb";
 import { disconnectRabbitMQ } from "./config/rabbitmq";
+import { stopMemoryMonitor } from "./utils/memoryMonitor";
 
 type AppServer = Server & { closeIdleConnections?: () => void };
 let httpServer: AppServer | null = null;
+let memoryMonitorHandle: NodeJS.Timeout | null = null;
 
 export const setHttpServer = (server: AppServer | null): void => {
   httpServer = server;
+};
+
+export const setMemoryMonitorHandle = (handle: NodeJS.Timeout): void => {
+  memoryMonitorHandle = handle;
 };
 
 const closeServer = async (): Promise<void> => {
@@ -38,6 +44,7 @@ const closeServer = async (): Promise<void> => {
 
 export const shutdown = async (): Promise<void> => {
   logger.info("Shutting down gracefully...");
+  if (memoryMonitorHandle) stopMemoryMonitor(memoryMonitorHandle);
   await closeServer();
   await disconnectMongoDB();
   await disconnectRabbitMQ();

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,6 @@ import { initTracing } from "./config/tracing";
 initTracing();
 
 import express, { type NextFunction, type Request, type Response } from "express";
-<<<<<<< fix/trust-proxy-config
-import helmet from "helmet";
-=======
->>>>>>> dev
 import compression from "compression";
 import swaggerUi from "swagger-ui-express";
 import { config } from "./config/env";
@@ -23,7 +19,8 @@ import { swaggerSpec } from "./config/swagger";
 import routes from "./routes";
 import webhookRoutes from "./routes/webhookRoutes";
 import { ErrorCodes } from "./types/errorCodes";
-import { registerGracefulShutdown, setHttpServer } from "./gracefulShutdown";
+import { registerGracefulShutdown, setHttpServer, setMemoryMonitorHandle } from "./gracefulShutdown";
+import { startMemoryMonitor } from "./utils/memoryMonitor";
 
 const app: express.Express = express();
 
@@ -282,6 +279,10 @@ async function startServer() {
     // Mark application as ready for health checks
     const { markStartupComplete } = await import("./services/health/healthService");
     markStartupComplete();
+
+    // #436: Start heap usage monitor — logs warnings/errors and writes heap snapshots on leak detection.
+    const memoryMonitorHandle = startMemoryMonitor();
+    setMemoryMonitorHandle(memoryMonitorHandle);
 
     // Start HTTP server
     const server = app.listen(config.port, () => {

--- a/src/utils/memoryMonitor.ts
+++ b/src/utils/memoryMonitor.ts
@@ -1,0 +1,87 @@
+import v8 from "v8";
+import fs from "fs";
+import path from "path";
+import { logger } from "../config/logger";
+import { heapUsedRatioGauge, heapDumpCounter } from "../config/promMetrics";
+
+const WARN_THRESHOLD_PCT = parseInt(process.env.MEMORY_LEAK_THRESHOLD_PCT || "85", 10);
+const CRITICAL_THRESHOLD_PCT = Math.min(WARN_THRESHOLD_PCT + 10, 98);
+const CHECK_INTERVAL_MS = parseInt(process.env.MEMORY_CHECK_INTERVAL_MS || "30000", 10);
+const HEAP_DUMP_DIR = process.env.HEAP_DUMP_DIR || "./heapdumps";
+
+let lastDumpAt = 0;
+const MIN_DUMP_INTERVAL_MS = 5 * 60 * 1000;
+
+function getEffectiveHeapLimitBytes(): number {
+  const stats = v8.getHeapStatistics();
+  // heap_size_limit reflects --max-old-space-size when set, otherwise V8 default
+  return stats.heap_size_limit;
+}
+
+function writeHeapSnapshot(): string | null {
+  try {
+    if (!fs.existsSync(HEAP_DUMP_DIR)) {
+      fs.mkdirSync(HEAP_DUMP_DIR, { recursive: true });
+    }
+    const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
+    const filename = path.join(HEAP_DUMP_DIR, `heap-${timestamp}.heapsnapshot`);
+    v8.writeHeapSnapshot(filename);
+    heapDumpCounter.inc();
+    return filename;
+  } catch (err) {
+    logger.error("Failed to write heap snapshot", { error: (err as Error).message });
+    return null;
+  }
+}
+
+function checkHeap(): void {
+  const mem = process.memoryUsage();
+  const heapLimit = getEffectiveHeapLimitBytes();
+  const usedPct = heapLimit > 0 ? (mem.heapUsed / heapLimit) * 100 : 0;
+
+  heapUsedRatioGauge.set(usedPct / 100);
+
+  const stats = {
+    heapUsedMB: (mem.heapUsed / 1024 / 1024).toFixed(1),
+    heapTotalMB: (mem.heapTotal / 1024 / 1024).toFixed(1),
+    heapLimitMB: (heapLimit / 1024 / 1024).toFixed(1),
+    rssMB: (mem.rss / 1024 / 1024).toFixed(1),
+    usedPct: usedPct.toFixed(1),
+  };
+
+  if (usedPct >= CRITICAL_THRESHOLD_PCT) {
+    const now = Date.now();
+    const dumpPath =
+      now - lastDumpAt > MIN_DUMP_INTERVAL_MS ? writeHeapSnapshot() : null;
+    if (dumpPath) lastDumpAt = now;
+
+    logger.error("CRITICAL: heap usage above threshold — possible memory leak", {
+      ...stats,
+      criticalThresholdPct: CRITICAL_THRESHOLD_PCT,
+      heapSnapshot: dumpPath ?? "skipped (too soon since last dump)",
+    });
+  } else if (usedPct >= WARN_THRESHOLD_PCT) {
+    logger.warn("Heap usage approaching limit", {
+      ...stats,
+      warnThresholdPct: WARN_THRESHOLD_PCT,
+    });
+  }
+}
+
+export function startMemoryMonitor(): NodeJS.Timeout {
+  const heapLimitMB = (getEffectiveHeapLimitBytes() / 1024 / 1024).toFixed(0);
+  logger.info("Memory monitor started", {
+    heapLimitMB,
+    warnThresholdPct: WARN_THRESHOLD_PCT,
+    criticalThresholdPct: CRITICAL_THRESHOLD_PCT,
+    checkIntervalMs: CHECK_INTERVAL_MS,
+    heapDumpDir: HEAP_DUMP_DIR,
+  });
+
+  checkHeap();
+  return setInterval(checkHeap, CHECK_INTERVAL_MS);
+}
+
+export function stopMemoryMonitor(handle: NodeJS.Timeout): void {
+  clearInterval(handle);
+}


### PR DESCRIPTION
- Create src/utils/memoryMonitor.ts: samples heap every 30 s via v8.getHeapStatistics(); logs WARN at configurable threshold (default 85% of heap_size_limit) and ERROR + v8.writeHeapSnapshot() at critical level (threshold + 10%, capped at 98%). Dump cadence is rate-limited to one file per 5 minutes to avoid filling disk during sustained pressure.

- Extend src/config/promMetrics.ts with two new metrics exported through the existing /metrics endpoint:
    nodejs_heap_used_ratio   – heapUsed / heap_size_limit (0–1 Gauge)
    nodejs_heap_dump_total   – cumulative heap snapshot count (Counter)

- Wire monitor into src/index.ts (started after startup completes) and src/gracefulShutdown.ts (cleared on SIGTERM/SIGINT via stopMemoryMonitor).

- Add MEMORY_LEAK_THRESHOLD_PCT, MEMORY_CHECK_INTERVAL_MS, and HEAP_DUMP_DIR to env schema (src/config/env.ts) with safe defaults.

- Document NODE_OPTIONS=--max-old-space-size, the three new env vars, and the heapdumps directory in .env.example.

- Add heapdumps/ and *.heapsnapshot to .gitignore so snapshot files are never committed.

- Resolve pre-existing merge conflict in src/index.ts (stray helmet import left by the fix/trust-proxy-config merge marker; securityHeadersMiddleware already covers helmet).

closes #436