### PR TITLE
fix(#449): validate Content-Length against actual body size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import { connectMongoDB, disconnectMongoDB } from "./config/mongodb";
 import { connectRabbitMQ, disconnectRabbitMQ } from "./config/rabbitmq";
 import { prisma } from "./config/database";
 import { corsMiddleware } from "./middleware/cors";
+import { validateContentLength } from "./middleware/bodyParser";
 import { requestLogger } from "./middleware/logger";
 import { requestMetricsMiddleware } from "./middleware/metrics";
 import { errorHandler, AppError } from "./middleware/errorHandler";
@@ -53,6 +54,8 @@ app.use(corsMiddleware);
 // Compress all JSON/text responses to reduce bandwidth on large payloads
 app.use(compression());
 
+// Validate Content-Length against actual body size before parsing (#449)
+app.use(validateContentLength);
 app.use(express.urlencoded({ extended: true, limit: MAX_REQUEST_BODY_SIZE }));
 
 // ── Webhook Content-Type validation ────────────────────────────────────────────

--- a/src/middleware/bodyParser.ts
+++ b/src/middleware/bodyParser.ts
@@ -1,0 +1,60 @@
+import type { NextFunction, Request, Response } from "express";
+
+/**
+ * Validates that the Content-Length header, when present, matches the actual
+ * received body size. A mismatch indicates a truncated or padded payload and
+ * is rejected before it reaches the JSON/urlencoded parsers.
+ *
+ * Fixes #449.
+ */
+export function validateContentLength(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const declared = req.headers["content-length"];
+
+  // No header — nothing to validate; downstream parsers handle it.
+  if (declared === undefined) {
+    next();
+    return;
+  }
+
+  const declaredBytes = parseInt(declared, 10);
+  if (isNaN(declaredBytes) || declaredBytes < 0) {
+    res.status(400).json({
+      error: { code: "INVALID_CONTENT_LENGTH", message: "Invalid Content-Length header" },
+    });
+    return;
+  }
+
+  let received = 0;
+  req.on("data", (chunk: Buffer) => {
+    received += chunk.length;
+    // Early abort if body already exceeds declared size.
+    if (received > declaredBytes) {
+      res.status(400).json({
+        error: {
+          code: "CONTENT_LENGTH_MISMATCH",
+          message: "Request body exceeds declared Content-Length",
+        },
+      });
+      req.destroy();
+    }
+  });
+
+  req.on("end", () => {
+    if (!res.headersSent && received !== declaredBytes) {
+      res.status(400).json({
+        error: {
+          code: "CONTENT_LENGTH_MISMATCH",
+          message: "Request body size does not match Content-Length",
+        },
+      });
+      return;
+    }
+    if (!res.headersSent) {
+      next();
+    }
+  });
+}


### PR DESCRIPTION
## Summary
Adds `validateContentLength` middleware in `src/middleware/bodyParser.ts` that validates the `Content-Length` header against the actual received body size before it reaches the JSON/urlencoded parsers.

## Changes
- **New:** `src/middleware/bodyParser.ts` — middleware that rejects requests where declared `Content-Length` mismatches actual body size
- **Updated:** `src/index.ts` — mounts `validateContentLength` before body parsers

## Behaviour
- No `Content-Length` header → passes through (no regression)
- Malformed header → `400 INVALID_CONTENT_LENGTH`
- Body exceeds declared size → `400 CONTENT_LENGTH_MISMATCH` (early abort)
- Body smaller than declared size → `400 CONTENT_LENGTH_MISMATCH`

Closes #449 