### PR TITLE
feat: add user-agent filter middleware to block scanners and abuse tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import { corsMiddleware } from "./middleware/cors";
 import { requestLogger } from "./middleware/logger";
 import { errorHandler, AppError } from "./middleware/errorHandler";
 import { standardRateLimiter } from "./middleware/rateLimiter";
+import { userAgentFilter } from "./middleware/userAgentFilter";
 import { swaggerSpec } from "./config/swagger";
 import routes from "./routes";
 import webhookRoutes from "./routes/webhookRoutes";
@@ -108,6 +109,9 @@ app.use(requestLogger);
 
 // Rate limiting
 app.use(standardRateLimiter);
+
+// Block known scanners, credential-stuffing tools, and headless abuse scripts
+app.use(userAgentFilter);
 
 // API Documentation — disabled in production to prevent endpoint enumeration (#274)
 if (config.nodeEnv !== "production") {

--- a/src/middleware/userAgentFilter.test.ts
+++ b/src/middleware/userAgentFilter.test.ts
@@ -1,0 +1,45 @@
+import express from "express";
+import request from "supertest";
+import { userAgentFilter } from "./userAgentFilter";
+import { errorHandler } from "./errorHandler";
+
+const app = express();
+app.get("/test", userAgentFilter, (_req, res) => res.status(200).json({ ok: true }));
+app.use(errorHandler);
+
+describe("userAgentFilter", () => {
+  const GOOD_UA = "ACBU-Mobile/1.0 (iOS 17)";
+
+  it("allows legitimate user agents", async () => {
+    await request(app).get("/test").set("User-Agent", GOOD_UA).expect(200);
+  });
+
+  it("blocks missing User-Agent", async () => {
+    await request(app)
+      .get("/test")
+      .unset("User-Agent")
+      .expect(400)
+      .expect((res) => expect(res.body.error.code).toBe("MISSING_USER_AGENT"));
+  });
+
+  it.each([
+    ["python-requests/2.28.0"],
+    ["curl/7.88.1"],
+    ["Wget/1.21"],
+    ["go-http-client/1.1"],
+    ["masscan/1.3"],
+    ["Nikto/2.1.6"],
+    ["sqlmap/1.7"],
+    ["nuclei/2.9.0"],
+    ["scrapy/2.11"],
+    ["libwww-perl/6.72"],
+    ["axios/1.4.0"],
+    ["java/17.0.6"],
+  ])("blocks %s", async (ua) => {
+    await request(app)
+      .get("/test")
+      .set("User-Agent", ua)
+      .expect(403)
+      .expect((res) => expect(res.body.error.code).toBe("FORBIDDEN_USER_AGENT"));
+  });
+});

--- a/src/middleware/userAgentFilter.ts
+++ b/src/middleware/userAgentFilter.ts
@@ -1,0 +1,68 @@
+import type { NextFunction, Request, Response } from "express";
+import { AppError } from "./errorHandler";
+
+/**
+ * Patterns that identify known malicious scanners, credential-stuffing tools,
+ * and broken/headless scripts. Checked case-insensitively.
+ *
+ * Override at runtime via the BLOCKED_USER_AGENT_PATTERNS environment variable
+ * (comma-separated regex strings) to add project-specific rules without a
+ * code change.
+ */
+const DEFAULT_BLOCKED_PATTERNS: RegExp[] = [
+  // Generic scanners / fuzzers
+  /masscan/,
+  /zgrab/,
+  /nmap/,
+  /nikto/,
+  /nuclei/,
+  /sqlmap/,
+  /dirbuster/,
+  /gobuster/,
+  /ffuf/,
+  /wfuzz/,
+  /hydra/,
+  /medusa/,
+  // Headless / scripted abuse tools
+  /python-requests/,
+  /go-http-client/,
+  /libwww-perl/,
+  /curl\/[0-9]/,   // bare curl (not curl wrapped in a real UA)
+  /wget\//,
+  /scrapy/,
+  /java\/[0-9]/,   // raw Java HttpURLConnection
+  /axios\/[0-9]/,  // raw axios without an app-level UA
+];
+
+function buildBlockedPatterns(): RegExp[] {
+  const extra = process.env.BLOCKED_USER_AGENT_PATTERNS;
+  if (!extra) return DEFAULT_BLOCKED_PATTERNS;
+  const extras = extra
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean)
+    .map((s) => new RegExp(s, "i"));
+  return [...DEFAULT_BLOCKED_PATTERNS, ...extras];
+}
+
+const BLOCKED_PATTERNS = buildBlockedPatterns();
+
+export function userAgentFilter(
+  req: Request,
+  _res: Response,
+  next: NextFunction,
+): void {
+  const ua = (req.headers["user-agent"] ?? "").toLowerCase();
+
+  if (!ua) {
+    return next(new AppError("Missing User-Agent header", 400, "MISSING_USER_AGENT"));
+  }
+
+  for (const pattern of BLOCKED_PATTERNS) {
+    if (pattern.test(ua)) {
+      return next(new AppError("Forbidden", 403, "FORBIDDEN_USER_AGENT"));
+    }
+  }
+
+  next();
+}


### PR DESCRIPTION
 Title: feat: add User-Agent filter middleware
  
  Description:
  
  ───────────────────────────────────────────────────────────────────────────────────────────────
  
  Summary
  
  Adds userAgentFilter middleware that blocks requests from known malicious scanners,
  credential-stuffing tools, and headless abuse scripts before they reach any route handler.
  
  Changes
  
  - src/middleware/userAgentFilter.ts — new middleware; rejects missing User-Agent (400) and
  matches against a blocklist of known scanner/abuse patterns (403). Blocklist is extensible at
  runtime via BLOCKED_USER_AGENT_PATTERNS env var (comma-separated regexes).
  - src/middleware/userAgentFilter.test.ts — 14 tests covering the allow path, missing UA, and
  each blocked tool category.
  - src/index.ts — registers the middleware globally after the rate limiter, so abusive clients
  are dropped before any business logic executes.
  
  Blocked patterns
  
  masscan, zgrab, nmap, nikto, nuclei, sqlmap, dirbuster, gobuster, ffuf, wfuzz, hydra, medusa,
  python-requests, go-http-client, libwww-perl, bare curl/wget, scrapy, raw Java
  HttpURLConnection, bare axios.
  
  Testing
  
  npx jest --testPathPattern=userAgentFilter --no-coverage

closes #438

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented User-Agent validation to identify and block requests from known automated tools, scanners, and malicious bots attempting to abuse the service
  * Requests without User-Agent headers are now rejected during initial request validation
  * Service security has been improved through enhanced filtering to reduce malicious traffic and abuse attempts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->