### PR TITLE
Session token in query string for WebSocket upgrade

### DIFF
--- a/prisma/migrations/20260624000000_replica_migration_sync/migration.sql
+++ b/prisma/migrations/20260624000000_replica_migration_sync/migration.sql
@@ -1,0 +1,85 @@
+-- #383: Replica promotion safety – sync _prisma_migrations history to the promoted replica.
+--
+-- Problem: _prisma_migrations is a regular table on the primary. If a read replica is promoted
+-- to primary after failover, it inherits all application data but NOT _prisma_migrations rows
+-- that were written after the replica's last WAL position.  Running `prisma migrate deploy`
+-- against the promoted replica may then re-apply already-applied migrations (if rows are missing)
+-- or fail with a checksum mismatch (if rows are partially present).
+--
+-- Fix: provide a stored procedure that an operator calls immediately after promoting a replica.
+-- The procedure upserts every row from the authoritative source (passed as input) so that
+-- `prisma migrate deploy` sees a complete, consistent history and becomes a no-op.
+--
+-- Usage (run on the newly-promoted primary right after promotion):
+--
+--   SELECT sync_prisma_migrations_from_primary(ARRAY[
+--     ROW('id-1', '20260129225314_init', 1706529194, 'hash...', NULL, 17486, 'Migration Author', false, NOW(), NULL)::_prisma_migration_row,
+--     ...
+--   ]);
+--
+-- In practice, export the rows from the old primary before failover and pipe them here, or
+-- generate the call from the migration files on disk (which are the source of truth):
+--
+--   psql $OLD_PRIMARY -c "\COPY _prisma_migrations TO '/tmp/migrations.csv' CSV HEADER"
+--   psql $NEW_PRIMARY -f <(scripts/ci/restore-migrations.sh /tmp/migrations.csv)
+--
+-- The simpler operational runbook (no procedure needed) is documented in scripts/ci/restore-migrations.sh.
+
+-- Composite type matching _prisma_migrations columns so callers can pass rows strongly-typed.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = '_prisma_migration_row') THEN
+    CREATE TYPE _prisma_migration_row AS (
+      id               VARCHAR(36),
+      checksum         VARCHAR(64),
+      finished_at      TIMESTAMPTZ,
+      migration_name   VARCHAR(255),
+      logs             TEXT,
+      rolled_back_at   TIMESTAMPTZ,
+      started_at       TIMESTAMPTZ,
+      applied_steps_count INTEGER
+    );
+  END IF;
+END
+$$;
+
+-- sync_prisma_migrations_from_snapshot: upserts the canonical migration history into
+-- _prisma_migrations on the current (promoted) primary.
+-- Each row from the snapshot is inserted; existing rows with the same id are left untouched
+-- (ON CONFLICT DO NOTHING) so the procedure is idempotent and safe to re-run.
+CREATE OR REPLACE FUNCTION sync_prisma_migrations_from_snapshot(
+  p_rows _prisma_migration_row[]
+)
+RETURNS TABLE(upserted INT, skipped INT)
+LANGUAGE plpgsql
+AS $$
+DECLARE
+  r       _prisma_migration_row;
+  v_upserted INT := 0;
+  v_skipped  INT := 0;
+BEGIN
+  FOREACH r IN ARRAY p_rows LOOP
+    INSERT INTO "_prisma_migrations" (
+      id, checksum, finished_at, migration_name,
+      logs, rolled_back_at, started_at, applied_steps_count
+    ) VALUES (
+      r.id, r.checksum, r.finished_at, r.migration_name,
+      r.logs, r.rolled_back_at, r.started_at, r.applied_steps_count
+    )
+    ON CONFLICT (id) DO NOTHING;
+
+    IF FOUND THEN
+      v_upserted := v_upserted + 1;
+    ELSE
+      v_skipped := v_skipped + 1;
+    END IF;
+  END LOOP;
+
+  RETURN QUERY SELECT v_upserted, v_skipped;
+END;
+$$;
+
+COMMENT ON FUNCTION sync_prisma_migrations_from_snapshot IS
+  '#383: Call this on a newly-promoted replica immediately after promotion to restore '
+  'complete _prisma_migrations history. Source rows from the pre-failover primary export. '
+  'Idempotent — safe to re-run; existing rows are skipped.';

--- a/scripts/ci/restore-migrations.sh
+++ b/scripts/ci/restore-migrations.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# #383: Replica promotion runbook — restore _prisma_migrations on a newly-promoted primary.
+#
+# Run this BEFORE executing `prisma migrate deploy` against the promoted replica.
+#
+# Usage:
+#   export OLD_PRIMARY="postgresql://user:pass@old-primary:5432/acbu"
+#   export NEW_PRIMARY="postgresql://user:pass@new-primary:5432/acbu"
+#   ./scripts/ci/restore-migrations.sh
+#
+# The script:
+#   1. Dumps _prisma_migrations rows from the old primary (or from a CSV if the old primary
+#      is unavailable — pass the CSV path as $1).
+#   2. Upserts them into the new primary via sync_prisma_migrations_from_snapshot().
+#   3. Prints a row count summary so you can verify completeness.
+#
+# After this script succeeds, run `prisma migrate deploy` normally — it will find the
+# complete history and become a no-op (all migrations already recorded as applied).
+
+set -euo pipefail
+
+CSV_FILE="${1:-}"
+NEW_PRIMARY="${NEW_PRIMARY:?NEW_PRIMARY env var required}"
+
+if [[ -z "$CSV_FILE" ]]; then
+  OLD_PRIMARY="${OLD_PRIMARY:?Either OLD_PRIMARY env var or a CSV file path argument is required}"
+  CSV_FILE="$(mktemp /tmp/prisma_migrations_XXXXXX.csv)"
+  echo "[restore-migrations] Exporting _prisma_migrations from old primary..."
+  psql "$OLD_PRIMARY" -c "\COPY \"_prisma_migrations\" TO '$CSV_FILE' CSV HEADER"
+  echo "[restore-migrations] Exported to $CSV_FILE"
+fi
+
+[[ -f "$CSV_FILE" ]] || { echo "CSV file not found: $CSV_FILE" >&2; exit 1; }
+
+ROW_COUNT=$(tail -n +2 "$CSV_FILE" | wc -l | tr -d ' ')
+echo "[restore-migrations] Rows in snapshot: $ROW_COUNT"
+
+# Build a VALUES list from the CSV and call the sync procedure.
+# Uses psql's \copy + a temporary table to avoid shell quoting nightmares.
+psql "$NEW_PRIMARY" <<SQL
+-- Load snapshot into a temp table
+CREATE TEMP TABLE _migrations_snapshot (
+  id               VARCHAR(36),
+  checksum         VARCHAR(64),
+  finished_at      TIMESTAMPTZ,
+  migration_name   VARCHAR(255),
+  logs             TEXT,
+  rolled_back_at   TIMESTAMPTZ,
+  started_at       TIMESTAMPTZ,
+  applied_steps_count INTEGER
+);
+
+\COPY _migrations_snapshot FROM '$CSV_FILE' CSV HEADER
+
+-- Upsert into _prisma_migrations (idempotent)
+INSERT INTO "_prisma_migrations" (
+  id, checksum, finished_at, migration_name,
+  logs, rolled_back_at, started_at, applied_steps_count
+)
+SELECT id, checksum, finished_at, migration_name,
+       logs, rolled_back_at, started_at, applied_steps_count
+FROM _migrations_snapshot
+ON CONFLICT (id) DO NOTHING;
+
+SELECT
+  (SELECT COUNT(*) FROM "_prisma_migrations") AS total_rows,
+  (SELECT COUNT(*) FROM _migrations_snapshot) AS snapshot_rows;
+SQL
+
+echo "[restore-migrations] Done. Verify total_rows == snapshot_rows above, then run: prisma migrate deploy"

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,7 @@ import { initTracing } from "./config/tracing";
 initTracing();
 
 import express, { type NextFunction, type Request, type Response } from "express";
-<<<<<<< fix/trust-proxy-config
 import helmet from "helmet";
-=======
->>>>>>> dev
 import compression from "compression";
 import swaggerUi from "swagger-ui-express";
 import { config } from "./config/env";

--- a/src/services/websocket/index.ts
+++ b/src/services/websocket/index.ts
@@ -1,0 +1,2 @@
+export { authenticateWsUpgrade, WsAuthError } from "./wsAuth";
+export type { WsAuthResult } from "./wsAuth";

--- a/src/services/websocket/wsAuth.test.ts
+++ b/src/services/websocket/wsAuth.test.ts
@@ -1,0 +1,177 @@
+import type { IncomingMessage } from "http";
+import bcrypt from "bcryptjs";
+import { authenticateWsUpgrade, WsAuthError } from "./wsAuth";
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock("../../config/database", () => ({
+  prisma: {
+    apiKey: {
+      findFirst: jest.fn(),
+      update: jest.fn().mockResolvedValue(undefined),
+    },
+  },
+}));
+
+jest.mock("../../config/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { prisma } from "../../config/database";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const VALID_SECRET = "a".repeat(64);
+const VALID_LOOKUP = "b".repeat(12);
+const VALID_KEY = `acbu_${VALID_LOOKUP}_${VALID_SECRET}`;
+
+async function makeKeyRecord(overrides: Record<string, unknown> = {}) {
+  const keyHash = await bcrypt.hash(VALID_SECRET, 1); // cost=1 for test speed
+  return {
+    id: "key-id-1",
+    lookupKey: VALID_LOOKUP,
+    keyHash,
+    userId: "user-id-1",
+    organizationId: null,
+    keyType: "USER_KEY",
+    permissions: ["p2p:write"],
+    revokedAt: null,
+    expiresAt: null,
+    emergencyExpiresAt: null,
+    emergencyReason: null,
+    lastUsedAt: null,
+    ...overrides,
+  };
+}
+
+function makeRequest(headers: Record<string, string>, url = "/"): IncomingMessage {
+  return { headers, url } as unknown as IncomingMessage;
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("authenticateWsUpgrade", () => {
+  const mockFindFirst = prisma.apiKey.findFirst as jest.Mock;
+
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Happy paths ──
+
+  it("authenticates via x-api-key header", async () => {
+    mockFindFirst.mockResolvedValueOnce(await makeKeyRecord());
+    const req = makeRequest({ "x-api-key": VALID_KEY });
+    const result = await authenticateWsUpgrade(req);
+    expect(result.keyId).toBe("key-id-1");
+    expect(result.userId).toBe("user-id-1");
+    expect(result.keyType).toBe("USER_KEY");
+    expect(result.permissions).toContain("p2p:write");
+  });
+
+  it("authenticates via Authorization: Bearer header", async () => {
+    mockFindFirst.mockResolvedValueOnce(await makeKeyRecord());
+    const req = makeRequest({ authorization: `Bearer ${VALID_KEY}` });
+    const result = await authenticateWsUpgrade(req);
+    expect(result.keyId).toBe("key-id-1");
+  });
+
+  it("is case-insensitive for 'bearer' prefix", async () => {
+    mockFindFirst.mockResolvedValueOnce(await makeKeyRecord());
+    const req = makeRequest({ authorization: `BEARER ${VALID_KEY}` });
+    await expect(authenticateWsUpgrade(req)).resolves.toBeDefined();
+  });
+
+  it("returns null organizationId when not set", async () => {
+    mockFindFirst.mockResolvedValueOnce(await makeKeyRecord({ organizationId: null }));
+    const req = makeRequest({ "x-api-key": VALID_KEY });
+    const result = await authenticateWsUpgrade(req);
+    expect(result.organizationId).toBeNull();
+  });
+
+  it("returns empty permissions array for invalid permission entries", async () => {
+    mockFindFirst.mockResolvedValueOnce(
+      await makeKeyRecord({ permissions: ["not_a_real_scope", null, 123] }),
+    );
+    const req = makeRequest({ "x-api-key": VALID_KEY });
+    const result = await authenticateWsUpgrade(req);
+    expect(result.permissions).toEqual([]);
+  });
+
+  // ── Query string rejection (#384) ──
+
+  it.each(["token", "api_key", "apikey", "access_token", "auth"])(
+    "rejects connection when token is in query string param '%s'",
+    async (param) => {
+      const req = makeRequest({}, `/?${param}=somesecret`);
+      await expect(authenticateWsUpgrade(req)).rejects.toThrow(WsAuthError);
+      await expect(authenticateWsUpgrade(req)).rejects.toThrow(/query string/);
+    },
+  );
+
+  it("does NOT reject benign query params that are not token-shaped", async () => {
+    mockFindFirst.mockResolvedValueOnce(await makeKeyRecord());
+    const req = makeRequest({ "x-api-key": VALID_KEY }, "/?room=general&page=1");
+    await expect(authenticateWsUpgrade(req)).resolves.toBeDefined();
+  });
+
+  it("query string check runs before DB lookup — no DB call on rejection", async () => {
+    const req = makeRequest({}, "/?token=leak");
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(WsAuthError);
+    expect(mockFindFirst).not.toHaveBeenCalled();
+  });
+
+  // ── Missing / invalid credentials ──
+
+  it("throws WsAuthError when no auth header is present", async () => {
+    const req = makeRequest({});
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(WsAuthError);
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(/header/);
+  });
+
+  it("throws WsAuthError for malformed key format", async () => {
+    const req = makeRequest({ "x-api-key": "not-a-valid-key" });
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(WsAuthError);
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(/format/);
+  });
+
+  it("throws WsAuthError when key not found in DB", async () => {
+    mockFindFirst.mockResolvedValueOnce(null);
+    const req = makeRequest({ "x-api-key": VALID_KEY });
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(WsAuthError);
+  });
+
+  it("throws WsAuthError on wrong secret (bcrypt mismatch)", async () => {
+    const record = await makeKeyRecord();
+    // Swap keyHash so bcrypt.compare will fail
+    record.keyHash = await bcrypt.hash("wrong_secret".padEnd(64, "z"), 1);
+    mockFindFirst.mockResolvedValueOnce(record);
+    const req = makeRequest({ "x-api-key": VALID_KEY });
+    await expect(authenticateWsUpgrade(req)).rejects.toThrow(WsAuthError);
+  });
+
+  it("throws WsAuthError with 401 status code", async () => {
+    const req = makeRequest({});
+    try {
+      await authenticateWsUpgrade(req);
+      fail("should have thrown");
+    } catch (e) {
+      expect(e).toBeInstanceOf(WsAuthError);
+      expect((e as WsAuthError).statusCode).toBe(401);
+    }
+  });
+
+  // ── WsAuthError class ──
+
+  it("WsAuthError.name is 'WsAuthError'", () => {
+    const err = new WsAuthError("test");
+    expect(err.name).toBe("WsAuthError");
+    expect(err).toBeInstanceOf(Error);
+  });
+
+  it("WsAuthError defaults statusCode to 401", () => {
+    expect(new WsAuthError("x").statusCode).toBe(401);
+  });
+
+  it("WsAuthError accepts custom statusCode 403", () => {
+    expect(new WsAuthError("x", 403).statusCode).toBe(403);
+  });
+});

--- a/src/services/websocket/wsAuth.ts
+++ b/src/services/websocket/wsAuth.ts
@@ -1,0 +1,146 @@
+/**
+ * #384: WebSocket upgrade authentication.
+ *
+ * Tokens MUST be sent in the `Authorization: Bearer <key>` or `x-api-key: <key>` header.
+ * Passing a token via the query string (?token=...) is explicitly rejected: query strings
+ * appear in proxy/CDN/load-balancer access logs, leaking session credentials to third parties.
+ */
+
+import type { IncomingMessage } from "http";
+import bcrypt from "bcryptjs";
+import { prisma } from "../../config/database";
+import { logger } from "../../config/logger";
+import type { ApiKeyType } from "../../middleware/auth";
+import type { PermissionScope } from "../../types/permissions";
+import { PermissionScopeEnum } from "../../types/permissions";
+
+const API_KEY_PREFIX = "acbu";
+const API_KEY_LOOKUP_LENGTH = 12;
+const API_KEY_SECRET_LENGTH = 64;
+const API_KEY_FORMAT = new RegExp(
+  `^${API_KEY_PREFIX}_([a-f0-9]{${API_KEY_LOOKUP_LENGTH}})_([a-f0-9]{${API_KEY_SECRET_LENGTH}})$`,
+  "i",
+);
+
+export interface WsAuthResult {
+  keyId: string;
+  userId: string | null;
+  organizationId: string | null;
+  keyType: ApiKeyType;
+  permissions: PermissionScope[];
+}
+
+export class WsAuthError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: 401 | 403 = 401,
+  ) {
+    super(message);
+    this.name = "WsAuthError";
+  }
+}
+
+function parseApiKey(raw: string): { lookupKey: string; secret: string } | null {
+  const match = raw.trim().match(API_KEY_FORMAT);
+  if (!match) return null;
+  return { lookupKey: match[1].toLowerCase(), secret: match[2].toLowerCase() };
+}
+
+function validatePermissions(raw: unknown): PermissionScope[] {
+  if (!Array.isArray(raw)) return [];
+  const valid: PermissionScope[] = [];
+  for (const p of raw) {
+    const r = PermissionScopeEnum.safeParse(p);
+    if (r.success) valid.push(r.data);
+  }
+  return valid;
+}
+
+/**
+ * Authenticate a WebSocket upgrade request.
+ *
+ * Reads the API key exclusively from request headers (`x-api-key` or
+ * `Authorization: Bearer`).  If the caller has also put a token in the query
+ * string the connection is immediately rejected — even if the header is valid —
+ * to prevent accidental log exposure during mixed-transport rollouts.
+ *
+ * @throws {WsAuthError} on any authentication failure
+ */
+export async function authenticateWsUpgrade(req: IncomingMessage): Promise<WsAuthResult> {
+  // #384: reject outright if any token-shaped query param is present.
+  // The URL on an IncomingMessage for a WS upgrade includes the full path + query string.
+  const rawUrl = req.url ?? "";
+  const queryString = rawUrl.includes("?") ? rawUrl.slice(rawUrl.indexOf("?") + 1) : "";
+  if (queryString) {
+    const params = new URLSearchParams(queryString);
+    const tokenParams = ["token", "api_key", "apikey", "access_token", "auth"];
+    for (const p of tokenParams) {
+      if (params.has(p)) {
+        logger.warn("[ws-auth] Rejected: auth token in query string", { param: p });
+        throw new WsAuthError(
+          "Authentication tokens must be sent in request headers, not the query string",
+          401,
+        );
+      }
+    }
+  }
+
+  // Extract key from header only.
+  const xApiKey = req.headers["x-api-key"];
+  const authorization = req.headers["authorization"];
+
+  let rawKey: string | undefined;
+  if (typeof xApiKey === "string" && xApiKey.trim()) {
+    rawKey = xApiKey.trim();
+  } else if (typeof authorization === "string") {
+    const bearer = authorization.match(/^Bearer\s+(.+)$/i);
+    rawKey = bearer?.[1]?.trim();
+  }
+
+  if (!rawKey) {
+    throw new WsAuthError("WebSocket upgrade requires an API key in x-api-key or Authorization header");
+  }
+
+  const parsed = parseApiKey(rawKey);
+  if (!parsed) {
+    throw new WsAuthError("Invalid API key format");
+  }
+
+  const record = await prisma.apiKey.findFirst({
+    where: {
+      lookupKey: parsed.lookupKey,
+      revokedAt: null,
+      AND: [
+        { OR: [{ expiresAt: null }, { expiresAt: { gt: new Date() } }] },
+        {
+          OR: [
+            { keyType: { not: "BREAK_GLASS_KEY" } },
+            { emergencyExpiresAt: { gt: new Date() } },
+          ],
+        },
+      ],
+    },
+  });
+
+  if (!record) {
+    throw new WsAuthError("Invalid API key");
+  }
+
+  const valid = await bcrypt.compare(parsed.secret, record.keyHash);
+  if (!valid) {
+    throw new WsAuthError("Invalid API key");
+  }
+
+  // Fire-and-forget lastUsedAt update — don't block the upgrade handshake.
+  prisma.apiKey
+    .update({ where: { id: record.id }, data: { lastUsedAt: new Date() } })
+    .catch((e: unknown) => logger.error("[ws-auth] Failed to update lastUsedAt", { e }));
+
+  return {
+    keyId: record.id,
+    userId: record.userId ?? null,
+    organizationId: record.organizationId ?? null,
+    keyType: record.keyType as ApiKeyType,
+    permissions: validatePermissions(record.permissions),
+  };
+}


### PR DESCRIPTION
## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.

closes #383 
closes #384 
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added WebSocket login support using API key headers during upgrade requests.
  * Added a recovery flow to restore migration history after a primary/replica failover.

* **Bug Fixes**
  * Tightened WebSocket auth to reject credentials passed in the URL and handle invalid permissions more safely.
  * Resolved a merge conflict artifact in the app startup code.

* **Tests**
  * Added coverage for WebSocket authentication success and failure cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->