### PR TITLE
jest --detectOpenHandles not used in CI to find

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,7 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/acbu_test
 
       - name: Run tests
-        run: pnpm test
+        run: pnpm run test:ci
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/acbu_test
           MONGODB_URI: mongodb://localhost:27017/acbu_test

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "format:check": "prettier --check \"src/**/*.ts\"",
     "test": "jest --coverage",
     "test:coverage": "jest --coverage",
+    "test:ci": "jest --coverage --detectOpenHandles",
     "prisma:generate": "prisma generate",
     "prisma:migrate": "prisma migrate dev",
     "prisma:migrate:deploy": "prisma migrate deploy",


### PR DESCRIPTION
Close: #470

## Summary
Implemented the CI leak-detection check.
Changed [package.json (line 22)](C:/Users/ADMIN/Desktop/lekan-drips/acbu-backend/package.json:22) to add:
test:ci: jest --coverage --detectOpenHandles
Changed [.github/workflows/ci.yml (line 93)](C:/Users/ADMIN/Desktop/lekan-drips/acbu-backend/.github/workflows/ci.yml:93) so CI runs pnpm run test:ci instead of plain pnpm test.
Verification: package.json parses, the script value is correct, workflow references the new script, and git diff --check passes. I couldn’t execute pnpm run test:ci locally because the sandbox blocked pnpm’s user-profile cache creation.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI test execution to use a dedicated CI test script.
  * Added a CI-friendly test command that runs with coverage and improved detection of hanging async operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->