### PR TITLE
fix(cors): document no-Origin passthrough and add whitelist-enforceme…

### DIFF
--- a/src/middleware/cors.test.ts
+++ b/src/middleware/cors.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Edge-case tests for the CORS middleware.
+ * Core allow/deny/preflight behaviour is covered in tests/cors.test.ts.
+ * This file focuses on the whitelist-enforcement properties that are most
+ * relevant to the security boundary: no silent reflection of arbitrary origins.
+ */
+import express from "express";
+import request from "supertest";
+import { createCorsMiddleware, resolveCorsOrigin } from "./cors";
+
+const ALLOWED = ["https://app.example.com", "https://admin.example.com"];
+
+function buildApp(allowedOrigins: string[]) {
+  const app = express();
+  app.use(createCorsMiddleware(allowedOrigins));
+  app.get("/ping", (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+describe("resolveCorsOrigin — whitelist strictness", () => {
+  it("does not match a differently-cased origin", () => {
+    expect(resolveCorsOrigin("https://APP.EXAMPLE.COM", ALLOWED)).toBe(false);
+  });
+
+  it("does not match a subdomain of an allowed origin", () => {
+    expect(resolveCorsOrigin("https://sub.app.example.com", ALLOWED)).toBe(false);
+  });
+
+  it("does not match an allowed origin with a different port", () => {
+    expect(resolveCorsOrigin("https://app.example.com:8080", ALLOWED)).toBe(false);
+  });
+
+  it("does not match an allowed origin with a path appended", () => {
+    expect(resolveCorsOrigin("https://app.example.com/extra", ALLOWED)).toBe(false);
+  });
+});
+
+describe("createCorsMiddleware — security-relevant headers", () => {
+  const app = buildApp(ALLOWED);
+
+  it("sets Vary: Origin so caches do not serve one origin's response to another", async () => {
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://app.example.com")
+      .expect(200);
+
+    expect(res.headers["vary"]).toMatch(/origin/i);
+  });
+
+  it("passes requests with no Origin header (non-browser / server-to-server)", async () => {
+    await request(app).get("/ping").expect(200);
+  });
+
+  it("does not set Access-Control-Allow-Origin when there is no Origin header", async () => {
+    const res = await request(app).get("/ping").expect(200);
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("blocks preflight from an unknown origin", async () => {
+    const res = await request(app)
+      .options("/ping")
+      .set("Origin", "https://attacker.example.com")
+      .set("Access-Control-Request-Method", "GET");
+
+    expect(res.headers["access-control-allow-origin"]).toBeUndefined();
+  });
+
+  it("never emits Access-Control-Allow-Origin: * (incompatible with credentials)", async () => {
+    const res = await request(app)
+      .get("/ping")
+      .set("Origin", "https://app.example.com")
+      .expect(200);
+
+    expect(res.headers["access-control-allow-origin"]).not.toBe("*");
+  });
+});

--- a/src/middleware/cors.ts
+++ b/src/middleware/cors.ts
@@ -35,6 +35,9 @@ export function createCorsMiddleware(allowedOrigins: readonly string[]) {
     origin: (origin, callback) => {
       const resolved = resolveCorsOrigin(origin, allowedOrigins);
       if (resolved === null) {
+        // No Origin header → non-browser / same-origin request (curl, server-to-server).
+        // CORS is a browser mechanism; passing through here does not expose the API to
+        // cross-origin browser requests because browsers always send an Origin header.
         callback(null, true);
         return;
       }


### PR DESCRIPTION
…nt tests

Adds a clarifying comment to the CORS middleware explaining why requests without an Origin header are allowed through without a whitelist check — browsers always include Origin for cross-origin requests, so this path is only reachable by non-browser callers for whom CORS provides no protection.

Adds a co-located test suite (src/middleware/cors.test.ts) covering the whitelist-enforcement edge cases not already in tests/cors.test.ts: case-insensitive bypass, subdomain/port/path injection, Vary header, no-Origin passthrough, blocked preflight from unknown origins, and the guarantee that ACAO: * is never emitted.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->

close #392 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added broader CORS coverage for origin matching, preflight handling, and cache-related response headers.
  * Verified that requests without an `Origin` header do not receive cross-origin allow headers.

* **Documentation**
  * Clarified CORS origin-handling behavior with inline comments for easier maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->