### PR TITLE
fix(#381): WAL backup guard — fix test failures from merge conflicts and missing mocks

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -184,10 +184,6 @@ export const config = {
     downloadUrlTtlSeconds: parseInt(process.env.S3_DOWNLOAD_URL_TTL_SECONDS || "300", 10),
     scanWebhookSecret: process.env.S3_SCAN_WEBHOOK_SECRET || "",
   },
-  bulkTransfer: {
-    chunkSize: parseInt(process.env.BULK_TRANSFER_CHUNK_SIZE || "100", 10),
-    maxFileSizeBytes: parseInt(process.env.BULK_TRANSFER_MAX_FILE_SIZE_BYTES || "10485760", 10),
-  },
   fintech: {
     currencyProviders: ((): Record<string, string> => {
       const raw = process.env.FINTECH_CURRENCY_PROVIDERS;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,14 @@
 import { initTracing } from "./config/tracing";
 initTracing();
 
-<<<<<<< HEAD
-import express, { type NextFunction, type Request, type Response } from "express";
-=======
 import "express-async-errors";
 
+import { execSync } from "child_process";
 import express, {
   type NextFunction,
   type Request,
   type Response,
 } from "express";
->>>>>>> upstream/main
 import helmet from "helmet";
 import compression from "compression";
 import swaggerUi from "swagger-ui-express";
@@ -28,7 +25,6 @@ import { standardRateLimiter } from "./middleware/rateLimiter";
 import { swaggerSpec } from "./config/swagger";
 import routes from "./routes";
 import webhookRoutes from "./routes/webhookRoutes";
-import { AppError } from "./middleware/errorHandler";
 import { ErrorCodes } from "./types/errorCodes";
 import { registerGracefulShutdown, setHttpServer } from "./gracefulShutdown";
 

--- a/tests/walBackup.test.ts
+++ b/tests/walBackup.test.ts
@@ -12,7 +12,16 @@ const REQUIRED_ENV = {
   RABBITMQ_URL: "amqp://localhost:5672",
   JWT_SECRET: "test-secret",
   PRISMA_ACCELERATE_URL: "prisma://accelerate.prisma-data.net/?api_key=test",
+  CORS_ORIGIN: "https://app.acbu.io",
 };
+
+const mockPrismaClient = () => ({
+  $use: jest.fn(),
+  $connect: jest.fn().mockResolvedValue(undefined),
+  $disconnect: jest.fn(),
+  $on: jest.fn(),
+  $extends: jest.fn().mockReturnThis(),
+});
 
 describe("#381 WAL backup guard", () => {
   const ORIGINAL = process.env;
@@ -31,12 +40,7 @@ describe("#381 WAL backup guard", () => {
 
     // Mock PrismaClient so no real DB connection is attempted
     jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(() => ({
-        $use: jest.fn(),
-        $connect: jest.fn().mockResolvedValue(undefined),
-        $disconnect: jest.fn(),
-        $on: jest.fn(),
-      })),
+      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
       Prisma: { PrismaClientKnownRequestError: class {} },
     }));
     jest.mock("@prisma/extension-accelerate", () => ({
@@ -51,12 +55,7 @@ describe("#381 WAL backup guard", () => {
     process.env.PG_WAL_BACKUP_CONFIGURED = "false";
 
     jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(() => ({
-        $use: jest.fn(),
-        $connect: jest.fn().mockResolvedValue(undefined),
-        $disconnect: jest.fn(),
-        $on: jest.fn(),
-      })),
+      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
       Prisma: { PrismaClientKnownRequestError: class {} },
     }));
     jest.mock("@prisma/extension-accelerate", () => ({
@@ -71,14 +70,8 @@ describe("#381 WAL backup guard", () => {
     process.env.PG_WAL_BACKUP_CONFIGURED = "true";
     process.env.PG_WAL_BACKUP_PROVIDER = "pgbackrest";
 
-    const mockConnect = jest.fn().mockResolvedValue(undefined);
     jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(() => ({
-        $use: jest.fn(),
-        $connect: mockConnect,
-        $disconnect: jest.fn(),
-        $on: jest.fn(),
-      })),
+      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
       Prisma: { PrismaClientKnownRequestError: class {} },
     }));
     jest.mock("@prisma/extension-accelerate", () => ({
@@ -94,14 +87,8 @@ describe("#381 WAL backup guard", () => {
     delete process.env.PG_WAL_BACKUP_CONFIGURED;
     delete process.env.PRISMA_ACCELERATE_URL; // not required in dev
 
-    const mockConnect = jest.fn().mockResolvedValue(undefined);
     jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(() => ({
-        $use: jest.fn(),
-        $connect: mockConnect,
-        $disconnect: jest.fn(),
-        $on: jest.fn(),
-      })),
+      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
       Prisma: { PrismaClientKnownRequestError: class {} },
     }));
     jest.mock("@prisma/extension-accelerate", () => ({


### PR DESCRIPTION
## Summary

Closes #381

The WAL backup guard was already implemented in `src/config/database.ts` and `src/config/env.ts` (production startup refuses with a clear error when `PG_WAL_BACKUP_CONFIGURED` is not `true`). This PR fixes the test suite so the guard is actually verified.

## Root causes

- **Duplicate `bulkTransfer` key in `src/config/env.ts`** (TS1117) — `ts-jest` threw a `TSError` on module load; Jest swallowed it silently, producing blank error output for every test in the suite.
- **Unresolved merge conflict in `src/index.ts`** — conflict markers + duplicate `AppError` import caused a compile error; added missing `execSync` import.
- **Missing `$extends` on the PrismaClient mock** — when `PRISMA_ACCELERATE_URL` is set, `database.ts` calls `basePrisma.$extends(withAccelerate())` at module load time; the mock didn't implement it so the module threw before `connectWithRetry` was reached.
- **Missing `CORS_ORIGIN` in test `REQUIRED_ENV`** — `corsOrigins.ts` throws in production without it.

## Changes

| File | Change |
|---|---|
| `src/config/env.ts` | Remove duplicate `bulkTransfer` key |
| `src/index.ts` | Resolve merge conflict, remove duplicate import, add `execSync` import |
| `tests/walBackup.test.ts` | Add `CORS_ORIGIN`, add `$extends` mock, extract shared `mockPrismaClient` factory |

## Test result

```
PASS tests/walBackup.test.ts
  #381 WAL backup guard
    ✓ throws in production when PG_WAL_BACKUP_CONFIGURED is not set
    ✓ throws in production when PG_WAL_BACKUP_CONFIGURED=false
    ✓ connects successfully in production when PG_WAL_BACKUP_CONFIGURED=true
    ✓ does not throw in development when PG_WAL_BACKUP_CONFIGURED is not set

Tests: 4 passed, 4 total
```