### PR TITLE
fix: Retry-After-aware retry interceptor in shared HTTP client

### DIFF
--- a/src/services/flutterwave/client.ts
+++ b/src/services/flutterwave/client.ts
@@ -1,7 +1,8 @@
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { config } from "../../config/env";
 import { logger } from "../../config/logger";
-import { CircuitBreaker } from "../../utils/circuitBreaker"; // Import the class, not the instance
+import { CircuitBreaker } from "../../utils/circuitBreaker";
+import { createHttpClient } from "../http/client";
 import type {
   FintechProvider,
   DisburseRecipient,
@@ -14,14 +15,12 @@ export class FlutterwaveClient implements FintechProvider {
   private breaker: CircuitBreaker;
 
   constructor() {
-    this.client = axios.create({
+    this.client = createHttpClient({
       baseURL: config.flutterwave.baseUrl,
       headers: {
         Authorization: `Bearer ${config.flutterwave.secretKey}`,
         "Content-Type": "application/json",
       },
-      // REQUIREMENT 1: Lower the hard timeout from 30s to 5s so it fails fast
-      timeout: 5000, 
     });
 
     // REQUIREMENT 2: Create a dedicated circuit breaker for Flutterwave
@@ -67,41 +66,20 @@ export class FlutterwaveClient implements FintechProvider {
   }
 
   /**
-   * Helper method to execute requests safely through the circuit breaker with a simple retry strategy
+   * Execute a request through the circuit breaker.
+   * Retry-After-aware retries are handled by the shared HTTP client interceptor.
    */
-  private async requestWrapper<T>(requestFn: () => Promise<T>, retries = 2): Promise<T> {
-    // 1. Check if the circuit allows execution
+  private async requestWrapper<T>(requestFn: () => Promise<T>): Promise<T> {
     if (!this.breaker.canExecute()) {
       throw new Error("Flutterwave service is temporarily unavailable (Circuit Open)");
     }
-
     try {
-      let attempt = 0;
-      while (attempt <= retries) {
-        try {
-          const result = await requestFn();
-          // 2. Record success if the call completes successfully
-          this.breaker.recordSuccess();
-          return result;
-        } catch (error: any) {
-          attempt++;
-          // Only retry on temporary network errors or 5xx server issues; fail immediately on bad data/4xx
-          const isNetworkError = !error.response;
-          const isServerError = error.response?.status >= 500;
-          
-          if (attempt > retries || (!isNetworkError && !isServerError)) {
-            throw error; // Let the outer block catch and record the final failure
-          }
-          
-          // Exponential backoff delay before retrying
-          await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
-        }
-      }
-      throw new Error("Request failed after maximum retries");
-    } catch (finalError) {
-      // 3. Record failure to trip the circuit breaker if thresholds are crossed
+      const result = await requestFn();
+      this.breaker.recordSuccess();
+      return result;
+    } catch (error) {
       this.breaker.recordFailure();
-      throw finalError;
+      throw error;
     }
   }
 

--- a/src/services/http/client.ts
+++ b/src/services/http/client.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared axios factory with a Retry-After-aware retry interceptor.
+ *
+ * Retryable conditions:
+ *   - 429 Too Many Requests  → always honour Retry-After
+ *   - 503 Service Unavailable → honour Retry-After when present, else backoff
+ *   - Other 5xx              → exponential backoff, no Retry-After expected
+ *   - Network errors (no response)
+ *
+ * Retry-After header is parsed as both a delay-in-seconds integer and as an
+ * HTTP-date (RFC 7231 §7.1.3).  Capped at MAX_RETRY_AFTER_MS to avoid
+ * sleeping forever on a misconfigured header.
+ */
+import axios, {
+  AxiosInstance,
+  AxiosRequestConfig,
+  InternalAxiosRequestConfig,
+  AxiosError,
+} from "axios";
+import { logger } from "../../config/logger";
+
+const MAX_RETRIES = 3;
+const BASE_BACKOFF_MS = 1_000;
+const MAX_RETRY_AFTER_MS = 60_000; // never wait more than 60 s
+
+/** Parse Retry-After header → milliseconds to wait (0 if unparseable). */
+function parseRetryAfterMs(header: string | undefined): number {
+  if (!header) return 0;
+  const secs = Number(header);
+  if (!Number.isNaN(secs)) return Math.min(secs * 1_000, MAX_RETRY_AFTER_MS);
+  const date = Date.parse(header);
+  if (!Number.isNaN(date)) return Math.min(Math.max(date - Date.now(), 0), MAX_RETRY_AFTER_MS);
+  return 0;
+}
+
+function isRetryable(status: number): boolean {
+  return status === 429 || status === 503 || (status >= 500 && status < 600);
+}
+
+function backoffMs(attempt: number): number {
+  // 1 s, 2 s, 4 s …
+  return Math.min(BASE_BACKOFF_MS * Math.pow(2, attempt - 1), MAX_RETRY_AFTER_MS);
+}
+
+/** Attach retry-with-Retry-After interceptor to an existing AxiosInstance. */
+export function attachRetryInterceptor(instance: AxiosInstance): void {
+  instance.interceptors.response.use(undefined, async (error: AxiosError) => {
+    const config = error.config as InternalAxiosRequestConfig & { _retryCount?: number };
+    if (!config) return Promise.reject(error);
+
+    const status = error.response?.status ?? 0;
+    const hasResponse = !!error.response;
+
+    // Don't retry non-retryable 4xx (except 429) or if we have no error.config
+    if (hasResponse && !isRetryable(status)) return Promise.reject(error);
+
+    config._retryCount = (config._retryCount ?? 0) + 1;
+    if (config._retryCount > MAX_RETRIES) return Promise.reject(error);
+
+    const retryAfterHeader = error.response?.headers?.["retry-after"] as string | undefined;
+    const waitMs =
+      retryAfterHeader
+        ? parseRetryAfterMs(retryAfterHeader)
+        : backoffMs(config._retryCount);
+
+    logger.warn("HTTP retry scheduled", {
+      url: config.url,
+      status: status || "network_error",
+      attempt: config._retryCount,
+      waitMs,
+    });
+
+    await new Promise((r) => setTimeout(r, waitMs));
+    return instance.request(config);
+  });
+}
+
+/**
+ * Create an axios instance pre-configured with the Retry-After-aware interceptor.
+ * All fintech clients should use this instead of `axios.create()` directly.
+ */
+export function createHttpClient(options?: AxiosRequestConfig): AxiosInstance {
+  const instance = axios.create({ timeout: 5_000, ...options });
+  attachRetryInterceptor(instance);
+  return instance;
+}

--- a/src/services/mtn-momo/client.ts
+++ b/src/services/mtn-momo/client.ts
@@ -2,10 +2,11 @@
  * MTN Mobile Money API client (RWF, UGX, etc.). Implements FintechProvider for balance and disbursement.
  * FX (convertCurrency) does not have a generic API; use getProviderById('flutterwave') for rate fallback.
  */
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { config } from "../../config/env";
 import { logger } from "../../config/logger";
-import { CircuitBreaker } from "../../utils/circuitBreaker"; // Import the class
+import { CircuitBreaker } from "../../utils/circuitBreaker";
+import { createHttpClient } from "../http/client";
 import type {
   FintechProvider,
   DisburseRecipient,
@@ -38,14 +39,12 @@ export class MTNMoMoClient implements FintechProvider {
         ? "https://momodeveloper.mtn.com"
         : "https://sandbox.momodeveloper.mtn.com");
     
-    this.client = axios.create({
+    this.client = createHttpClient({
       baseURL: baseUrl,
       headers: {
         "Content-Type": "application/json",
         "Ocp-Apim-Subscription-Key": this.subscriptionKey,
       },
-      // REQUIREMENT 1: Drop the hard timeout from 30s to 5s so it fails fast
-      timeout: 5000,
     });
 
     // REQUIREMENT 2: Create an isolated circuit breaker for MTN MoMo
@@ -57,37 +56,20 @@ export class MTNMoMoClient implements FintechProvider {
   }
 
   /**
-   * Helper method to execute requests safely through the circuit breaker with a simple retry strategy
+   * Execute a request through the circuit breaker.
+   * Retry-After-aware retries are handled by the shared HTTP client interceptor.
    */
-  private async requestWrapper<T>(requestFn: () => Promise<T>, retries = 2): Promise<T> {
+  private async requestWrapper<T>(requestFn: () => Promise<T>): Promise<T> {
     if (!this.breaker.canExecute()) {
       throw new Error("MTN MoMo service is temporarily unavailable (Circuit Open)");
     }
-
     try {
-      let attempt = 0;
-      while (attempt <= retries) {
-        try {
-          const result = await requestFn();
-          this.breaker.recordSuccess();
-          return result;
-        } catch (error: any) {
-          attempt++;
-          const isNetworkError = !error.response;
-          const isServerError = error.response?.status >= 500;
-          
-          if (attempt > retries || (!isNetworkError && !isServerError)) {
-            throw error;
-          }
-          
-          // Exponential backoff delay
-          await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
-        }
-      }
-      throw new Error("Request failed after maximum retries");
-    } catch (finalError) {
+      const result = await requestFn();
+      this.breaker.recordSuccess();
+      return result;
+    } catch (error) {
       this.breaker.recordFailure();
-      throw finalError;
+      throw error;
     }
   }
 

--- a/src/services/paystack/client.ts
+++ b/src/services/paystack/client.ts
@@ -2,10 +2,11 @@
  * Paystack API client (Nigeria/NGN). Implements FintechProvider for balance and disbursement.
  * FX (convertCurrency) delegates to Flutterwave; use getProviderById('flutterwave') for rate fallback.
  */
-import axios, { AxiosInstance } from "axios";
+import { AxiosInstance } from "axios";
 import { config } from "../../config/env";
 import { logger } from "../../config/logger";
-import { CircuitBreaker } from "../../utils/circuitBreaker"; // Import the class
+import { CircuitBreaker } from "../../utils/circuitBreaker";
+import { createHttpClient } from "../http/client";
 import type {
   FintechProvider,
   DisburseRecipient,
@@ -34,14 +35,12 @@ export class PaystackClient implements FintechProvider {
       options?.baseUrl ?? paystackConfig?.baseUrl ?? "https://api.paystack.co";
     this.fxFallback = options?.fxFallback ?? null;
     
-    this.client = axios.create({
+    this.client = createHttpClient({
       baseURL: baseUrl,
       headers: {
         Authorization: `Bearer ${secretKey}`,
         "Content-Type": "application/json",
       },
-      // REQUIREMENT 1: Lower the hard timeout from 30s to 5s so it fails fast
-      timeout: 5000,
     });
 
     // REQUIREMENT 2: Create an isolated circuit breaker for Paystack
@@ -53,37 +52,20 @@ export class PaystackClient implements FintechProvider {
   }
 
   /**
-   * Helper method to execute requests safely through the circuit breaker with a simple retry strategy
+   * Execute a request through the circuit breaker.
+   * Retry-After-aware retries are handled by the shared HTTP client interceptor.
    */
-  private async requestWrapper<T>(requestFn: () => Promise<T>, retries = 2): Promise<T> {
+  private async requestWrapper<T>(requestFn: () => Promise<T>): Promise<T> {
     if (!this.breaker.canExecute()) {
       throw new Error("Paystack service is temporarily unavailable (Circuit Open)");
     }
-
     try {
-      let attempt = 0;
-      while (attempt <= retries) {
-        try {
-          const result = await requestFn();
-          this.breaker.recordSuccess();
-          return result;
-        } catch (error: any) {
-          attempt++;
-          const isNetworkError = !error.response;
-          const isServerError = error.response?.status >= 500;
-          
-          if (attempt > retries || (!isNetworkError && !isServerError)) {
-            throw error;
-          }
-          
-          // Exponential backoff delay
-          await new Promise((resolve) => setTimeout(resolve, Math.pow(2, attempt) * 1000));
-        }
-      }
-      throw new Error("Request failed after maximum retries");
-    } catch (finalError) {
+      const result = await requestFn();
+      this.breaker.recordSuccess();
+      return result;
+    } catch (error) {
       this.breaker.recordFailure();
-      throw finalError;
+      throw error;
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes immediate-retry behaviour on 429/503 responses that was hammering degraded services and violating rate-limit policies.

## Changes

- **New** `src/services/http/client.ts` — `createHttpClient()` factory with a shared Retry-After-aware response interceptor
- **Modified** `src/services/flutterwave/client.ts` — uses `createHttpClient()`, duplicated retry loop removed
- **Modified** `src/services/paystack/client.ts` — same
- **Modified** `src/services/mtn-momo/client.ts` — same

## Retry behaviour

| Condition | Wait |
|---|---|
| 429 / 503 with `Retry-After` (seconds) | exact header value |
| 429 / 503 with `Retry-After` (HTTP-date) | derived from header |
| 429 / 503 without header | exponential backoff |
| Other 5xx / network error | exponential backoff (1 s, 2 s, 4 s…) |
| 4xx (not 429) | not retried |

Hard caps: MAX_RETRIES = 3, MAX_RETRY_AFTER_MS = 60 s.  
Circuit-breaker logic in each client is unchanged.

## Testing

Type-checks cleanly for all modified files. No new type errors introduced.

Closes #430