### PR TITLE
fix: exit on uncaughtException and unhandledRejection

### DIFF
--- a/src/gracefulShutdown.ts
+++ b/src/gracefulShutdown.ts
@@ -62,4 +62,22 @@ const handleTermination = async (): Promise<void> => {
 export const registerGracefulShutdown = (): void => {
   process.on("SIGTERM", handleTermination);
   process.on("SIGINT", handleTermination);
+
+  // An uncaught exception leaves the process in an undefined state.
+  // Log it and exit immediately so the process manager (Docker/K8s) can restart cleanly.
+  process.on("uncaughtException", (error: Error) => {
+    logger.error("uncaughtException — exiting to prevent undefined state", {
+      message: error.message,
+      stack: error.stack,
+    });
+    process.exit(1);
+  });
+
+  // Unhandled promise rejections are equally unsafe to continue from.
+  process.on("unhandledRejection", (reason: unknown) => {
+    logger.error("unhandledRejection — exiting to prevent undefined state", {
+      reason: reason instanceof Error ? reason.stack : String(reason),
+    });
+    process.exit(1);
+  });
 };


### PR DESCRIPTION
## Summary

Fixes the missing / log-and-continue `uncaughtException` handler. Continuing after an uncaught exception leaves the process in an undefined state and risks data corruption or incorrect responses.

## Changes

**`src/gracefulShutdown.ts`** — two new handlers added inside `registerGracefulShutdown()`:

- `process.on('uncaughtException')` — logs error + stack, then `process.exit(1)`
- `process.on('unhandledRejection')` — logs reason, then `process.exit(1)`

Exiting with code 1 lets Docker / Kubernetes restart the process automatically. No other behaviour is changed.

Closes #435