### PR TITLE
chore: optimize build context by ignoring .github, submodules, and ma…

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,7 +6,7 @@ node_modules/
 dist/
 build/
 
-#Logs
+# Logs
 logs/
 *.log
 npm-debug.log*
@@ -14,27 +14,32 @@ yarn-debug.log*
 yarn-error.log*
 pnpm-debug.log*
 
-#Environment variables & Secrets
+# Environment variables & Secrets
 .env
 .env.*
 !.env.example
 !.env.test
 
-#Git and IDE configurations
+# Git, CI/CD, and IDE configurations
 .git
 .gitignore
+.github/
 .idea/
 .vscode/
 
-#Testing and Coverage
+# Testing and Coverage
 coverage/
 .nyc_output/
 
-#OS generated files
+# OS generated files
 .DS_Store
 Thumbs.db
 
-#Misc project directories not needed in production container
-scratch/
+# Documentation
 docs/
+*.md
+
+# Misc project directories not needed in production container
+scratch/
 tests/
+acbu-frontend/

--- a/.dockerignore
+++ b/.dockerignore
@@ -37,7 +37,7 @@ Thumbs.db
 
 # Documentation
 docs/
-*.md
+/*.md
 
 # Misc project directories not needed in production container
 scratch/


### PR DESCRIPTION
## Summary
- Excluded the `.github/` folder, root-level markdown documentation (`*.md`), and the `acbu-frontend/` directory from the Docker build context. This prevents documentation edits and CI/CD workflow changes from unnecessarily invalidating the Docker layer cache, while keeping the overall build context lightweight. Closes #465 

## Scope
- [ ] Backend API behavior
- [x] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [x] `pnpm run build`
- [x] `pnpm test`
- [x] `pnpm lint`

## Links
- Issue(s): #465
- Related PR(s): #

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container ignore rules to skip additional repository files and folders during builds.
  * Expanded ignored paths for production container packaging, including a frontend directory and GitHub-related files.
  * Excluded Markdown files from the container context, helping keep build inputs leaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->