### PR TITLE
fix: add 'unless-stopped' restart policy to infrastructure services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,6 +4,7 @@ services:
   postgres:
     image: postgres:16-alpine
     container_name: acbu-postgres
+    restart: unless-stopped
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-acbu}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-acbu_password}
@@ -21,6 +22,7 @@ services:
   mongodb:
     image: mongo:7
     container_name: acbu-mongodb
+    restart: unless-stopped
     environment:
       MONGO_INITDB_ROOT_USERNAME: ${MONGO_USER:-acbu}
       MONGO_INITDB_ROOT_PASSWORD: ${MONGO_PASSWORD:-acbu_password}
@@ -38,6 +40,7 @@ services:
   rabbitmq:
     image: rabbitmq:3-management-alpine
     container_name: acbu-rabbitmq
+    restart: unless-stopped
     environment:
       RABBITMQ_DEFAULT_USER: ${RABBITMQ_USER:-acbu}
       RABBITMQ_DEFAULT_PASS: ${RABBITMQ_PASSWORD:-acbu_password}


### PR DESCRIPTION
## Summary
- Added `restart: unless-stopped` to the `postgres`, `mongodb`, and `rabbitmq` services in `docker-compose.yml`. This addresses issue #464 by ensuring these critical infrastructure containers automatically recover from transient host failures, OOM errors, or daemon restarts without requiring manual intervention. Closes #464 

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [x] Other (Docker Infrastructure)

## Validation
- [x] `pnpm run build`
- [x] `pnpm test`
- [x] `pnpm lint`
*(Note: These CI steps are checked to confirm the base pipeline expectations, though this specific PR only modifies Docker orchestration and doesn't touch the application code).*

## Links
- Issue(s): #464
- Related PR(s): #

<img width="1834" height="733" alt="image" src="https://github.com/user-attachments/assets/8826de20-04f4-47cc-9e41-4557689c90a8" />




<img width="1834" height="186" alt="image" src="https://github.com/user-attachments/assets/45361157-2569-4d31-acd5-dfddb5a36fb6" />
