### PR TITLE
ci: run only changed tests on PRs and feature branches (#457)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,7 +90,14 @@ jobs:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/acbu_test
 
       - name: Run tests
-        run: pnpm test
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pnpm test -- --changedSince=origin/${{ github.base_ref }}
+          elif [ "${{ github.ref }}" = "refs/heads/main" ] || [ "${{ github.ref }}" = "refs/heads/develop" ]; then
+            pnpm test
+          else
+            pnpm test -- --onlyChanged
+          fi
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/acbu_test
           MONGODB_URI: mongodb://localhost:27017/acbu_test


### PR DESCRIPTION
closes #457 

## Problem
CI runs the full test suite on every commit. Test time grows linearly with the codebase.

## Fix
Scope the Jest run based on the trigger:

| Trigger | Jest flags | Rationale |
|---|---|---|
| Pull request | `--changedSince=origin/<base_ref>` | Only tests affected by the PR diff |
| Push to `main`/`develop` | _(full suite)_ | Merge-gate must be complete |
| Push to any other branch | `--onlyChanged` | Diff against previous commit |

`fetch-depth: 0` is already set in the checkout step, so base refs are available to `--changedSince`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved CI test execution to better match the type of change being merged.
  * Pull requests now run tests scoped to the PR’s changes, while pushes to `main` and `develop` run the full suite.
  * Other branches now run only the tests affected by the current changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->