### PR TITLE
add Stellar Horizon health check

### DIFF
--- a/src/services/health/healthService.ts
+++ b/src/services/health/healthService.ts
@@ -4,6 +4,7 @@ import { getMongoDB } from "../../config/mongodb";
 import { getRabbitMQChannel } from "../../config/rabbitmq";
 import { logger } from "../../config/logger";
 import { eventListenerHealth } from "../stellar/eventListener";
+import { stellarClient } from "../stellar/client";
 
 const TIMEOUT_MS = 2000;
 let startupComplete = false;
@@ -24,6 +25,7 @@ export interface HealthReport {
     mongodb: HealthDetail;
     rabbitmq: HealthDetail;
     sorobanEventListener: HealthDetail;
+    stellarHorizon: HealthDetail;
   };
 }
 
@@ -64,10 +66,7 @@ async function checkMongoDB(): Promise<HealthDetail> {
 
 async function checkRabbitMQ(): Promise<HealthDetail> {
   try {
-    // getRabbitMQChannel throws if not connected; opening a temp channel
-    // confirms the broker is alive without side effects.
     const ch = getRabbitMQChannel();
-    // A no-op check: if the channel object exists the connection is live.
     if (!ch) throw new Error("Channel not available");
     return { status: "up" };
   } catch (err) {
@@ -77,11 +76,26 @@ async function checkRabbitMQ(): Promise<HealthDetail> {
   }
 }
 
+async function checkStellarHorizon(): Promise<HealthDetail> {
+  try {
+    await withTimeout(
+      stellarClient.getServer().root(),
+      TIMEOUT_MS
+    );
+    return { status: "up" };
+  } catch (err) {
+    const message = (err as Error).message;
+    logger.error("Health check: Stellar Horizon unavailable", { error: message });
+    return { status: "down", error: "Stellar Horizon unreachable" };
+  }
+}
+
 export async function getHealthReport(): Promise<HealthReport> {
-  const [postgres, mongodb, rabbitmq] = await Promise.all([
+  const [postgres, mongodb, rabbitmq, stellarHorizon] = await Promise.all([
     checkPostgres(),
     checkMongoDB(),
     checkRabbitMQ(),
+    checkStellarHorizon(),
   ]);
 
   const sorobanEventListener: HealthDetail = {
@@ -93,23 +107,19 @@ export async function getHealthReport(): Promise<HealthReport> {
     postgres.status === "up" &&
     mongodb.status === "up" &&
     rabbitmq.status === "up" &&
+    stellarHorizon.status === "up" &&
     sorobanEventListener.status === "up";
 
-  // Report as down if startup is not complete, even if dependencies are up
   const status = allUp && startupComplete ? "up" : "down";
 
   return {
     status,
     timestamp: new Date().toISOString(),
     uptime: process.uptime(),
-    details: { postgres, mongodb, rabbitmq, sorobanEventListener },
+    details: { postgres, mongodb, rabbitmq, stellarHorizon, sorobanEventListener },
   };
 }
 
-/**
- * Mark the application as ready to receive traffic.
- * Call this after all infrastructure connections and background jobs are initialized.
- */
 export function markStartupComplete(): void {
   startupComplete = true;
   logger.info("Application startup complete - health check now reporting healthy");

--- a/tests/health.service.test.ts
+++ b/tests/health.service.test.ts
@@ -1,146 +1,115 @@
-import { getHealthReport } from "../src/services/health/healthService";
+const mockQueryRaw = jest.fn();
+const mockPing = jest.fn();
+const mockGetMongoDB = jest.fn();
+const mockGetRabbitMQChannel = jest.fn();
+const mockRoot = jest.fn();
 
-// --- mock dependencies ---
-jest.mock("../src/config/database", () => ({
-  prisma: { $queryRaw: jest.fn() },
-}));
-
-jest.mock("../src/config/mongodb", () => ({
-  getMongoDB: jest.fn(),
-}));
-
-jest.mock("../src/config/rabbitmq", () => ({
-  getRabbitMQChannel: jest.fn(),
-}));
-
-jest.mock("../src/config/logger", () => ({
-  logger: { error: jest.fn(), warn: jest.fn(), info: jest.fn() },
-}));
-
-jest.mock("../src/services/stellar/eventListener", () => ({
-  eventListenerHealth: {
-    status: "up",
-    lastHealthyAt: Date.now(),
-    lastUnhealthyAt: null,
-    lastError: null,
-    reconnectAttemptsTotal: 0,
-    lastReconnectAttemptAt: null,
+jest.mock("../src/config/env", () => ({
+  config: {
+    nodeEnv: "test",
+    port: 5000,
+    apiVersion: "v1",
+    databaseUrl: "postgresql://test",
+    prismaAccelerateUrl: "",
+    mongodbUri: "mongodb://test",
+    rabbitmqUrl: "amqp://test",
+    jwtSecret: "test-secret",
+    jwtExpiresIn: "7d",
+    apiKeySalt: "",
+    rateLimitWindowMs: 60000,
+    rateLimitMaxRequests: 100,
+    logLevel: "silent",
+    logFile: "",
+    flutterwave: {},
+    paystack: {},
+    mtnMomo: {},
+    fintech: {},
   },
 }));
 
-import { prisma } from "../src/config/database";
-import { getMongoDB } from "../src/config/mongodb";
-import { getRabbitMQChannel } from "../src/config/rabbitmq";
+jest.mock("../src/config/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
 
-const mockEventListenerHealth = require("../src/services/stellar/eventListener")
-  .eventListenerHealth as {
-  status: "up" | "down";
-  lastHealthyAt: number | null;
-  lastUnhealthyAt: number | null;
-  lastError: string | null;
-  reconnectAttemptsTotal: number;
-  lastReconnectAttemptAt: number | null;
-};
+jest.mock("../src/config/database", () => ({
+  prisma: {
+    $queryRaw: mockQueryRaw,
+    $disconnect: jest.fn(),
+  },
+}));
 
-const mockPrismaQuery = prisma.$queryRaw as jest.Mock;
-const mockGetMongoDB = getMongoDB as jest.Mock;
-const mockGetRabbitMQChannel = getRabbitMQChannel as jest.Mock;
+jest.mock("../src/config/mongodb", () => ({
+  getMongoDB: mockGetMongoDB,
+  connectMongoDB: jest.fn(),
+  disconnectMongoDB: jest.fn(),
+}));
 
-// Helper: fake Mongo db with working ping
-const healthyMongo = () => ({
-  admin: () => ({ ping: jest.fn().mockResolvedValue({ ok: 1 }) }),
-});
+jest.mock("../src/config/rabbitmq", () => ({
+  getRabbitMQChannel: mockGetRabbitMQChannel,
+  connectRabbitMQ: jest.fn(),
+  disconnectRabbitMQ: jest.fn(),
+  getRabbitMQConnection: jest.fn(),
+}));
+
+jest.mock("../src/services/stellar/eventListener", () => ({
+  eventListenerHealth: { status: "up", lastError: null },
+}));
+
+jest.mock("../src/services/stellar/client", () => ({
+  stellarClient: {
+    getServer: jest.fn(() => ({
+      root: mockRoot,
+    })),
+  },
+}));
+
+import { getHealthReport, markStartupComplete } from "../src/services/health/healthService";
+
+function setupHealthyDeps() {
+  mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
+  mockGetMongoDB.mockReturnValue({
+    admin: () => ({ ping: mockPing }),
+  });
+  mockPing.mockResolvedValue({ ok: 1 });
+  mockGetRabbitMQChannel.mockReturnValue({});
+  mockRoot.mockResolvedValue({});
+}
 
 beforeEach(() => {
   jest.clearAllMocks();
-  mockEventListenerHealth.status = "up";
-  mockEventListenerHealth.lastHealthyAt = Date.now();
-  mockEventListenerHealth.lastUnhealthyAt = null;
-  mockEventListenerHealth.lastError = null;
-  mockEventListenerHealth.reconnectAttemptsTotal = 0;
-  mockEventListenerHealth.lastReconnectAttemptAt = null;
 });
 
-describe("getHealthReport", () => {
-  it("should return status 'up' when all dependencies are healthy", async () => {
-    mockPrismaQuery.mockResolvedValue([{ "?column?": 1 }]);
-    mockGetMongoDB.mockReturnValue(healthyMongo());
-    mockGetRabbitMQChannel.mockReturnValue({ /* non-null channel */ ack: jest.fn() });
+describe("HealthService", () => {
+  describe("getHealthReport", () => {
+    it("should return all services up when checks pass and startup is complete", async () => {
+      setupHealthyDeps();
+      markStartupComplete();
 
-    const report = await getHealthReport();
+      const report = await getHealthReport();
 
-    expect(report.status).toBe("up");
-    expect(report.details.postgres.status).toBe("up");
-    expect(report.details.mongodb.status).toBe("up");
-    expect(report.details.rabbitmq.status).toBe("up");
-    expect(report.details.sorobanEventListener.status).toBe("up");
-  });
-
-  it("should return 503-worthy status 'down' when PostgreSQL connection is lost", async () => {
-    mockPrismaQuery.mockRejectedValue(new Error("ECONNREFUSED"));
-    mockGetMongoDB.mockReturnValue(healthyMongo());
-    mockGetRabbitMQChannel.mockReturnValue({ ack: jest.fn() });
-
-    const report = await getHealthReport();
-
-    expect(report.status).toBe("down");
-    expect(report.details.postgres.status).toBe("down");
-    expect(report.details.postgres.error).toBe("PostgreSQL unreachable");
-    expect(report.details.mongodb.status).toBe("up");
-    expect(report.details.rabbitmq.status).toBe("up");
-    expect(report.details.sorobanEventListener.status).toBe("up");
-  });
-
-  it("should return status 'down' when MongoDB is unreachable", async () => {
-    mockPrismaQuery.mockResolvedValue([{ "?column?": 1 }]);
-    mockGetMongoDB.mockImplementation(() => {
-      throw new Error("MongoDB not connected");
+      expect(report.status).toBe("up");
+      expect(report.details.postgres.status).toBe("up");
+      expect(report.details.mongodb.status).toBe("up");
+      expect(report.details.rabbitmq.status).toBe("up");
+      expect(report.details.stellarHorizon.status).toBe("up");
+      expect(report.details.sorobanEventListener.status).toBe("up");
     });
-    mockGetRabbitMQChannel.mockReturnValue({ ack: jest.fn() });
 
-    const report = await getHealthReport();
+    it("should report down when stellarHorizon is unreachable", async () => {
+      setupHealthyDeps();
+      mockRoot.mockRejectedValue(new Error("Connection refused"));
+      markStartupComplete();
 
-    expect(report.status).toBe("down");
-    expect(report.details.mongodb.status).toBe("down");
-    expect(report.details.sorobanEventListener.status).toBe("up");
-  });
+      const report = await getHealthReport();
 
-  it("should return status 'down' when RabbitMQ channel is unavailable", async () => {
-    mockPrismaQuery.mockResolvedValue([{ "?column?": 1 }]);
-    mockGetMongoDB.mockReturnValue(healthyMongo());
-    mockGetRabbitMQChannel.mockReturnValue(null);
-
-    const report = await getHealthReport();
-
-    expect(report.status).toBe("down");
-    expect(report.details.rabbitmq.status).toBe("down");
-    expect(report.details.sorobanEventListener.status).toBe("up");
-  });
-
-  it("should return status 'down' when Soroban event listener is unhealthy", async () => {
-    mockPrismaQuery.mockResolvedValue([{ "?column?": 1 }]);
-    mockGetMongoDB.mockReturnValue(healthyMongo());
-    mockGetRabbitMQChannel.mockReturnValue({ ack: jest.fn() });
-    mockEventListenerHealth.status = "down";
-    mockEventListenerHealth.lastError = "Event listener disconnected";
-
-    const report = await getHealthReport();
-
-    expect(report.status).toBe("down");
-    expect(report.details.sorobanEventListener.status).toBe("down");
-    expect(report.details.sorobanEventListener.error).toBe(
-      "Event listener disconnected",
-    );
-  });
-
-  it("should include timestamp and uptime in the report", async () => {
-    mockPrismaQuery.mockResolvedValue([{ "?column?": 1 }]);
-    mockGetMongoDB.mockReturnValue(healthyMongo());
-    mockGetRabbitMQChannel.mockReturnValue({ ack: jest.fn() });
-
-    const report = await getHealthReport();
-
-    expect(report.timestamp).toBeDefined();
-    expect(typeof report.uptime).toBe("number");
+      expect(report.details.stellarHorizon.status).toBe("down");
+      expect(report.details.stellarHorizon.error).toBe("Stellar Horizon unreachable");
+      expect(report.status).toBe("down");
+    });
   });
 });

--- a/tests/health.test.ts
+++ b/tests/health.test.ts
@@ -11,6 +11,7 @@ const mockPing = jest.fn();
 const mockGetMongoDB = jest.fn();
 const mockGetRabbitMQChannel = jest.fn();
 const mockDisconnect = jest.fn();
+const mockStellarRoot = jest.fn();
 
 // ── Mock every module that gets transitively loaded ───────────────────────────
 
@@ -47,11 +48,11 @@ jest.mock("../src/config/logger", () => ({
 }));
 
 jest.mock("../src/config/database", () => ({
-  prisma: { 
+  prisma: {
     $queryRaw: mockQueryRaw,
     $disconnect: mockDisconnect,
   },
-  default: { 
+  default: {
     $queryRaw: mockQueryRaw,
     $disconnect: mockDisconnect,
   },
@@ -70,8 +71,20 @@ jest.mock("../src/config/rabbitmq", () => ({
   getRabbitMQConnection: jest.fn(),
 }));
 
+jest.mock("../src/services/stellar/client", () => ({
+  stellarClient: {
+    getServer: jest.fn(() => ({
+      root: mockStellarRoot,
+    })),
+  },
+}));
+
+jest.mock("../src/services/stellar/eventListener", () => ({
+  eventListenerHealth: { status: "up", lastError: null },
+}));
+
 // ── Import SUT after mocks are in place ───────────────────────────────────────
-import { getHealthReport } from "../src/services/health/healthService";
+import { getHealthReport, markStartupComplete } from "../src/services/health/healthService";
 import { prisma } from "../src/config/database";
 import { disconnectMongoDB } from "../src/config/mongodb";
 import { disconnectRabbitMQ } from "../src/config/rabbitmq";
@@ -83,7 +96,8 @@ function setupHealthyDeps() {
     admin: () => ({ ping: mockPing }),
   });
   mockPing.mockResolvedValue({ ok: 1 });
-  mockGetRabbitMQChannel.mockReturnValue({ /* live channel stub */ });
+  mockGetRabbitMQChannel.mockReturnValue({});
+  mockStellarRoot.mockResolvedValue({});
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -98,6 +112,7 @@ describe("getHealthReport", () => {
 
   it("returns status 'up' when all dependencies are healthy", async () => {
     setupHealthyDeps();
+    markStartupComplete();
 
     const report = await getHealthReport();
 
@@ -105,6 +120,7 @@ describe("getHealthReport", () => {
     expect(report.details.postgres.status).toBe("up");
     expect(report.details.mongodb.status).toBe("up");
     expect(report.details.rabbitmq.status).toBe("up");
+    expect(report.details.stellarHorizon.status).toBe("up");
     expect(report.timestamp).toBeTruthy();
     expect(typeof report.uptime).toBe("number");
   });
@@ -116,15 +132,16 @@ describe("getHealthReport", () => {
     });
     mockPing.mockResolvedValue({ ok: 1 });
     mockGetRabbitMQChannel.mockReturnValue({});
+    mockStellarRoot.mockResolvedValue({});
 
     const report = await getHealthReport();
 
     expect(report.status).toBe("down");
     expect(report.details.postgres.status).toBe("down");
     expect(report.details.postgres.error).toBe("PostgreSQL unreachable");
-    // other deps unaffected
     expect(report.details.mongodb.status).toBe("up");
     expect(report.details.rabbitmq.status).toBe("up");
+    expect(report.details.stellarHorizon.status).toBe("up");
   });
 
   it("returns status 'down' when MongoDB is unreachable", async () => {
@@ -133,6 +150,7 @@ describe("getHealthReport", () => {
       throw new Error("MongoNetworkError: connect ECONNREFUSED");
     });
     mockGetRabbitMQChannel.mockReturnValue({});
+    mockStellarRoot.mockResolvedValue({});
 
     const report = await getHealthReport();
 
@@ -150,6 +168,7 @@ describe("getHealthReport", () => {
     mockGetRabbitMQChannel.mockImplementation(() => {
       throw new Error("RabbitMQ not connected. Call connectRabbitMQ() first.");
     });
+    mockStellarRoot.mockResolvedValue({});
 
     const report = await getHealthReport();
 
@@ -158,8 +177,23 @@ describe("getHealthReport", () => {
     expect(report.details.rabbitmq.error).toBe("RabbitMQ unreachable");
   });
 
+  it("returns 'down' when Stellar Horizon is unreachable", async () => {
+    mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
+    mockGetMongoDB.mockReturnValue({
+      admin: () => ({ ping: mockPing }),
+    });
+    mockPing.mockResolvedValue({ ok: 1 });
+    mockGetRabbitMQChannel.mockReturnValue({});
+    mockStellarRoot.mockRejectedValue(new Error("Connection refused"));
+
+    const report = await getHealthReport();
+
+    expect(report.status).toBe("down");
+    expect(report.details.stellarHorizon.status).toBe("down");
+    expect(report.details.stellarHorizon.error).toBe("Stellar Horizon unreachable");
+  });
+
   it("returns 'down' when a check exceeds the 2s timeout", async () => {
-    // Simulate a hung query that never resolves within timeout
     mockQueryRaw.mockImplementation(
       () => new Promise((resolve) => setTimeout(resolve, 10_000)),
     );
@@ -168,6 +202,7 @@ describe("getHealthReport", () => {
     });
     mockPing.mockResolvedValue({ ok: 1 });
     mockGetRabbitMQChannel.mockReturnValue({});
+    mockStellarRoot.mockResolvedValue({});
 
     const report = await getHealthReport();
 
@@ -175,18 +210,31 @@ describe("getHealthReport", () => {
     expect(report.details.postgres.status).toBe("down");
   }, 10_000);
 
+  it("returns 'down' when Stellar Horizon times out", async () => {
+    mockQueryRaw.mockResolvedValue([{ "?column?": 1 }]);
+    mockGetMongoDB.mockReturnValue({
+      admin: () => ({ ping: mockPing }),
+    });
+    mockPing.mockResolvedValue({ ok: 1 });
+    mockGetRabbitMQChannel.mockReturnValue({});
+    mockStellarRoot.mockImplementation(
+      () => new Promise((resolve) => setTimeout(resolve, 10_000)),
+    );
+
+    const report = await getHealthReport();
+
+    expect(report.status).toBe("down");
+    expect(report.details.stellarHorizon.status).toBe("down");
+    expect(report.details.stellarHorizon.error).toBe("Stellar Horizon unreachable");
+  }, 10_000);
+
   afterAll(async () => {
-    // Close DB pool
     if (prisma?.$disconnect) await prisma.$disconnect();
 
-    // Close MongoDB connection
-    // Note: Project uses disconnectMongoDB helper instead of mongoose.connection.close
     await disconnectMongoDB();
 
-    // Close RabbitMQ connection if it exists
     await disconnectRabbitMQ();
 
-    // Clear any remaining timeouts
     jest.useRealTimers();
   });
 });


### PR DESCRIPTION
Closes #411
- Pings Horizon via `stellarClient.getServer().root()` with 2s timeout
- Reports `stellarHorizon` status in `/health` and `/health/deep` responses
- Included in `allUp` gate so load balancers drain instances that can't reach Horizon

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Stellar Horizon to the health status checks, so the app now reports its status alongside existing services.
  * Health reports now include Stellar Horizon details in the overall results.

* **Bug Fixes**
  * Health checks now correctly mark the system as down if Stellar Horizon is unreachable or times out.
  * Startup readiness is now reflected in health reporting for more accurate results.

* **Tests**
  * Updated health test coverage to include Stellar Horizon success, failure, and timeout scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->