### PR TITLE
fix: add .prettierignore to exclude generated files (#456)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,18 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+build/
+*.tsbuildinfo
+
+# Testing
+coverage/
+.nyc_output/
+
+# Prisma generated client
+prisma/generated/
+
+# Heap snapshots
+heapdumps/
+*.heapsnapshot


### PR DESCRIPTION
close #456 

Prevents Prettier from formatting dist/, coverage/, and other generated artifacts that ESLint already ignores. Resolves IDE format-on-save lag and failures on large generated files.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignore settings to exclude more generated files and build artifacts from formatting checks, including dependencies, build outputs, test coverage data, generated client files, and heap snapshots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->