### PR TITLE
feat: add report export endpoint with Content-Disposition header for …

### DIFF
--- a/src/controllers/reportController.test.ts
+++ b/src/controllers/reportController.test.ts
@@ -1,0 +1,119 @@
+import { Request, Response } from "express";
+import { exportTransactionReport } from "./reportController";
+import { AppError } from "../middleware/errorHandler";
+import { getMonthlyStatements } from "../services/reports/reportService";
+
+jest.mock("../services/reports/reportService", () => ({
+  getMonthlyStatements: jest.fn(),
+}));
+
+type MockResponse = {
+  status: jest.Mock;
+  setHeader: jest.Mock;
+  send: jest.Mock;
+  json: jest.Mock;
+};
+
+const makeRes = (): MockResponse => {
+  const res = {
+    status: jest.fn().mockReturnThis(),
+    setHeader: jest.fn().mockReturnThis(),
+    send: jest.fn().mockReturnThis(),
+    json: jest.fn().mockReturnThis(),
+  };
+  return res as unknown as MockResponse;
+};
+
+const makeNext = (): jest.MockedFunction<(err?: unknown) => void> =>
+  jest.fn() as jest.MockedFunction<(err?: unknown) => void>;
+
+const makeReq = (query: Record<string, unknown> = {}, apiKey?: any) =>
+  ({ query, apiKey: apiKey ?? { userId: "user-1" } } as unknown as Request & { apiKey?: any });
+
+describe("reportController", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns JSON statements by default", async () => {
+    (getMonthlyStatements as jest.Mock).mockResolvedValue([
+      {
+        id: "tx-1",
+        type: "mint",
+        status: "completed",
+        acbuAmount: 100,
+        acbuAmountBurned: null,
+        usdcAmount: 10,
+        localCurrency: "NGN",
+        localAmount: 5000,
+        fee: 2,
+        createdAt: new Date("2025-06-01T00:00:00Z"),
+        completedAt: new Date("2025-06-01T01:00:00Z"),
+      },
+    ]);
+
+    const res = makeRes();
+    await exportTransactionReport(makeReq({}), res as unknown as Response, makeNext());
+
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      statements: [
+        expect.objectContaining({
+          id: "tx-1",
+          type: "mint",
+          status: "completed",
+        }),
+      ],
+      limit: 20,
+    });
+  });
+
+  it("returns a CSV attachment when format=csv", async () => {
+    (getMonthlyStatements as jest.Mock).mockResolvedValue([
+      {
+        id: "tx-1",
+        type: "burn",
+        status: "completed",
+        acbuAmount: null,
+        acbuAmountBurned: 50,
+        usdcAmount: 5,
+        localCurrency: "KES",
+        localAmount: 300,
+        fee: 1,
+        createdAt: new Date("2025-06-01T00:00:00Z"),
+        completedAt: new Date("2025-06-01T01:00:00Z"),
+      },
+    ]);
+
+    const res = makeRes();
+    await exportTransactionReport(
+      makeReq({ format: "csv", limit: "10" }),
+      res as unknown as Response,
+      makeNext(),
+    );
+
+    expect(res.setHeader).toHaveBeenCalledWith("Content-Type", "text/csv; charset=utf-8");
+    expect(res.setHeader).toHaveBeenCalledWith(
+      "Content-Disposition",
+      expect.stringContaining("attachment; filename=\"acbu_statement_"),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalledWith(expect.stringContaining("transaction_id,type,status"));
+  });
+
+  it("returns 400 for unsupported format", async () => {
+    const res = makeRes();
+    const next = makeNext();
+
+    await exportTransactionReport(
+      makeReq({ format: "xml" }),
+      res as unknown as Response,
+      next,
+    );
+
+    expect(next).toHaveBeenCalled();
+    const error = next.mock.calls[0][0] as Error;
+    expect(error).toBeInstanceOf(AppError);
+    expect(error.message).toContain("Unsupported format");
+  });
+});

--- a/src/controllers/reportController.ts
+++ b/src/controllers/reportController.ts
@@ -1,0 +1,154 @@
+import { Response, NextFunction } from "express";
+import { AuthRequest } from "../middleware/auth";
+import { AppError } from "../middleware/errorHandler";
+import { getMonthlyStatements } from "../services/reports/reportService";
+
+type StatementRow = {
+  id: string;
+  type: string;
+  status: string;
+  acbuAmount: string | null;
+  acbuAmountBurned: string | null;
+  usdcAmount: string | null;
+  localCurrency: string | null;
+  localAmount: string | null;
+  fee: string | null;
+  createdAt: string;
+  completedAt: string | null;
+};
+
+function sanitizeCsvValue(value: unknown): string {
+  if (value === undefined || value === null) {
+    return "";
+  }
+
+  const stringValue = String(value);
+  if (/[",\r\n]/.test(stringValue)) {
+    return `"${stringValue.replace(/"/g, '""')}"`;
+  }
+
+  return stringValue;
+}
+
+function formatStatementsAsCsv(statements: StatementRow[]): string {
+  const header = [
+    "transaction_id",
+    "type",
+    "status",
+    "acbu_amount",
+    "acbu_amount_burned",
+    "usdc_amount",
+    "local_currency",
+    "local_amount",
+    "fee",
+    "created_at",
+    "completed_at",
+  ];
+
+  const rows = statements.map((statement) => [
+    statement.id,
+    statement.type,
+    statement.status,
+    statement.acbuAmount,
+    statement.acbuAmountBurned,
+    statement.usdcAmount,
+    statement.localCurrency,
+    statement.localAmount,
+    statement.fee,
+    statement.createdAt,
+    statement.completedAt,
+  ]);
+
+  return [header, ...rows]
+    .map((row) => row.map(sanitizeCsvValue).join(","))
+    .join("\r\n");
+}
+
+function getStatementFilename(): string {
+  const now = new Date();
+  const year = now.getUTCFullYear();
+  const month = String(now.getUTCMonth() + 1).padStart(2, "0");
+  return `acbu_statement_${year}-${month}.csv`;
+}
+
+export async function exportTransactionReport(
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> {
+  try {
+    const userId = req.apiKey?.userId;
+    if (!userId) {
+      throw new AppError("User-scoped API key required", 401, "UNAUTHORIZED");
+    }
+
+    const rawLimit = req.query.limit;
+    let limit = 20;
+    if (rawLimit !== undefined) {
+      const parsed = Number(rawLimit);
+      if (!Number.isNaN(parsed) && parsed > 0) {
+        limit = Math.min(100, Math.max(1, Math.floor(parsed)));
+      }
+    }
+
+    const format = String(req.query.format || "json").toLowerCase();
+    if (!["json", "csv"].includes(format)) {
+      throw new AppError(
+        `Unsupported format '${format}'. Supported formats are csv and json.`,
+        400,
+        "INVALID_FORMAT",
+      );
+    }
+
+    const transactions = (await getMonthlyStatements(
+      {
+        userId,
+        type: { in: ["mint", "burn", "transfer"] },
+      },
+      limit,
+    )) as Array<{
+      id: string;
+      type: string;
+      status: string;
+      acbuAmount: { toString(): string } | null;
+      acbuAmountBurned: { toString(): string } | null;
+      usdcAmount: { toString(): string } | null;
+      localCurrency: string | null;
+      localAmount: { toString(): string } | null;
+      fee: { toString(): string } | null;
+      createdAt: Date;
+      completedAt: Date | null;
+    }>;
+
+    if (format === "csv") {
+      const csv = formatStatementsAsCsv(
+        transactions.map((transaction) => ({
+          id: transaction.id,
+          type: transaction.type,
+          status: transaction.status,
+          acbuAmount: transaction.acbuAmount?.toString() ?? null,
+          acbuAmountBurned: transaction.acbuAmountBurned?.toString() ?? null,
+          usdcAmount: transaction.usdcAmount?.toString() ?? null,
+          localCurrency: transaction.localCurrency ?? null,
+          localAmount: transaction.localAmount?.toString() ?? null,
+          fee: transaction.fee?.toString() ?? null,
+          createdAt: transaction.createdAt.toISOString(),
+          completedAt: transaction.completedAt?.toISOString() ?? null,
+        })),
+      );
+
+      const filename = getStatementFilename();
+      res.setHeader("Content-Type", "text/csv; charset=utf-8");
+      res.setHeader(
+        "Content-Disposition",
+        `attachment; filename="${filename}"`,
+      );
+      res.status(200).send(csv);
+      return;
+    }
+
+    res.status(200).json({ statements: transactions, limit });
+  } catch (e) {
+    next(e);
+  }
+}

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -33,6 +33,7 @@ import configRoutes from "./configRoutes";
 import complianceRoutes from "./complianceRoutes";
 import kycRoutes from "./kycRoutes";
 import weightDriftAuditRoutes from "./weightDriftAuditRoutes";
+import reportRoutes from "./reportRoutes";
 import kycValidatorRewardRoutes from "./kycValidatorRewardRoutes";
 
 const router: ReturnType<typeof Router> = Router();
@@ -108,6 +109,7 @@ router.use("/fiat", fiatRoutes);
 router.use("/config", configRoutes);
 router.use("/kyc", kycRoutes);
 router.use("/kyc", kycValidatorRewardRoutes);
+router.use("/reports", reportRoutes);
 router.use("/webhooks", webhookRoutes);
 router.use("/compliance", complianceRoutes);
 router.use("/admin/weight-drift-audits", weightDriftAuditRoutes);

--- a/src/routes/reportRoutes.ts
+++ b/src/routes/reportRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, type IRouter } from "express";
+import { validateApiKey } from "../middleware/auth";
+import { apiKeyRateLimiter } from "../middleware/rateLimiter";
+import { exportTransactionReport } from "../controllers/reportController";
+
+const router: IRouter = Router();
+router.use(validateApiKey);
+router.use(apiKeyRateLimiter);
+
+router.get("/transactions", exportTransactionReport);
+
+export default router;


### PR DESCRIPTION
Add report export endpoint with Content-Disposition header for CSV downloads

Implemented a new transaction report export endpoint and attached CSV downloads with a Content-Disposition header so browser clients receive acbu_statement_YYYY-MM.csv instead of inline/generic download behavior.

Closes #442

Changed files:
- src/controllers/reportController.ts
- src/routes/reportRoutes.ts
- src/routes/index.ts
- src/controllers/reportController.test.ts" 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new reports endpoint for exporting monthly transaction statements.
  * Supports both JSON and CSV output, with downloadable CSV headers and filename handling.
  * Added support for an optional limit setting with sensible bounds.

* **Bug Fixes**
  * Improved validation for missing user context and unsupported export formats.

* **Tests**
  * Added coverage for default JSON responses, CSV exports, and validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->