### PR TITLE
fix(#474): add pnpm overrides for vulnerable sub-dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,5 +116,14 @@
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "zod-to-json-schema": "^3.25.2"
+  },
+  "pnpm": {
+    "overrides": {
+      "fast-xml-parser": ">=5.3.6",
+      "handlebars": ">=4.7.9",
+      "minimatch": ">=3.1.4",
+      "flatted": ">=3.4.2",
+      "path-to-regexp": ">=10.1.0"
+    }
   }
 }


### PR DESCRIPTION
- Add pnpm.overrides section to force patched versions of transitive dependencies
- Override fast-xml-parser to >=5.3.6 (fixes GHSA-m7jm-9gc2-mpf2, GHSA-37qj-frw5-hhjh, GHSA-jmr7-xgp7-cmfj, GHSA-8gc5-j5rx-235r)
- Override handlebars to >=4.7.9 (fixes GHSA-2w6w-674q-4c4q)
- Override minimatch to >=3.1.4 (fixes GHSA-3ppc-4f35-3m26, GHSA-7r86-cg39-jmmj, GHSA-23c5-xmqv-rm74)
- Override flatted to >=3.4.2 (fixes GHSA-25h7-pfq9-p65f, GHSA-rf6f-7fwh-wjgh)
- Override path-to-regexp to >=10.1.0 for additional security hardening

These overrides ensure that known CVEs in transitive dependencies are patched without waiting for upstream releases.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->

Closes #474

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package dependency settings to prefer newer compatible versions of several transitive libraries, helping improve build stability and reduce known issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->