### PR TITLE
fix(webhook): implement non-blocking exponential backoff for retries

### DIFF
--- a/src/jobs/webhookConsumer.ts
+++ b/src/jobs/webhookConsumer.ts
@@ -55,55 +55,40 @@ export async function startWebhookConsumer(): Promise<void> {
 
         //  Failed delivery
         if (result.terminal || retries >= MAX_RETRIES) {
-          logger.error("Webhook failed permanently", {
-            webhookId,
-            retries,
-          });
-
-          // send to DLQ explicitly
+          logger.error("Webhook failed permanently", { webhookId, retries });
           ch.sendToQueue(QUEUES.WEBHOOKS_DLQ, msg.content, { persistent: true });
           ch.ack(msg);
           return;
         }
 
-        // Exponential backoff before requeuing
-        const backoffMs = Math.pow(2, retries) * 1000;
-        await new Promise((resolve) => setTimeout(resolve, backoffMs));
-
-        // Retry with incremented header
-        ch.sendToQueue(QUEUES.WEBHOOKS, msg.content, {
-          persistent: true,
-          headers: {
-            ...headers,
-            "x-retries": retries + 1,
-          },
-        });
-
+        // Exponential backoff: ack immediately, re-enqueue after delay so the
+        // channel is not blocked and other messages can be processed.
         ch.ack(msg);
+        const backoffMs = Math.min(Math.pow(2, retries) * 1000, 60_000);
+        setTimeout(() => {
+          ch.sendToQueue(QUEUES.WEBHOOKS, msg.content, {
+            persistent: true,
+            headers: { ...headers, "x-retries": retries + 1 },
+          });
+        }, backoffMs);
+        logger.info("Webhook retry scheduled", { webhookId, retries, backoffMs });
       } catch (error) {
         logger.error("Webhook consumer error", { error });
 
+        ch.ack(msg);
+
         if (retries >= MAX_RETRIES) {
-          // send to DLQ explicitly
           ch.sendToQueue(QUEUES.WEBHOOKS_DLQ, msg.content, { persistent: true });
-          ch.ack(msg);
           return;
         }
 
-        // Exponential backoff before requeuing
-        const backoffMs = Math.pow(2, retries) * 1000;
-        await new Promise((resolve) => setTimeout(resolve, backoffMs));
-
-        // retry on processing error
-        ch.sendToQueue(QUEUES.WEBHOOKS, msg.content, {
-          persistent: true,
-          headers: {
-            ...headers,
-            "x-retries": retries + 1,
-          },
-        });
-
-        ch.ack(msg);
+        const backoffMs = Math.min(Math.pow(2, retries) * 1000, 60_000);
+        setTimeout(() => {
+          ch.sendToQueue(QUEUES.WEBHOOKS, msg.content, {
+            persistent: true,
+            headers: { ...headers, "x-retries": retries + 1 },
+          });
+        }, backoffMs);
       }
     },
     { noAck: false },

--- a/src/services/webhook/webhookService.ts
+++ b/src/services/webhook/webhookService.ts
@@ -9,7 +9,7 @@ import { logger } from "../../config/logger";
 import { connectRabbitMQ, QUEUES } from "../../config/rabbitmq";
 
 const WEBHOOK_HEADER_SIGNATURE = "x-acbu-signature";
-const MAX_ATTEMPTS = 5;
+const MAX_ATTEMPTS = 5; // terminal threshold; backoff is managed by the queue consumer
 
 export type WebhookEventType =
   | "transaction.completed"


### PR DESCRIPTION
- Replace blocking await-sleep retry with immediate ack + deferred setTimeout re-enqueue, so the channel prefetch slot is freed and other messages are not stalled during backoff
- Cap backoff at 60s (1s, 2s, 4s, 8s, 16s, 32s, 60s...)
- Clarify that MAX_ATTEMPTS is a terminal threshold; retry state is owned by the queue consumer, not the service layer

Fixes #406

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
closes #406 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved webhook delivery retry handling for better reliability.
  * Failed deliveries are now retried without delaying other processing, and retry delays are capped to avoid long waits.
  * Permanent failures are detected sooner and sent to the dead-letter path more consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->