### PR TITLE
fix(ci): remove tsc from postinstall to prevent double build

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "backfill:org-limits": "ts-node --transpile-only prisma/backfillOrgTransactionContext.ts",
     "stellar:create-wallet": "ts-node --transpile-only scripts/create-stellar-wallet.ts",
     "compute:basket-weights": "ts-node --transpile-only scripts/compute-basket-weights.ts",
-    "postinstall": "prisma generate && tsc -p tsconfig.build.json"
+    "postinstall": "prisma generate"
   },
   "keywords": [
     "acbu",


### PR DESCRIPTION
## Summary

Removes `tsc -p tsconfig.build.json` from the `postinstall` hook in `package.json`.

## Problem

`postinstall` was running `prisma generate && tsc -p tsconfig.build.json` on every `pnpm install`. In CI this meant:

- Full TypeScript build ran during `pnpm install --frozen-lockfile` (postinstall)
- Then ran again in the explicit **Build** step — double build, wasted time
- `pnpm install` would fail on pre-existing type errors unrelated to dependencies, making the error confusing to diagnose

## Fix

Kept `prisma generate` in postinstall (legitimate — regenerates the client after lockfile changes). Removed `tsc` — it belongs only in the explicit build step.

## What was tested

- `pnpm install --frozen-lockfile` is confirmed in CI (line 55 of `ci.yml`) — stale lockfile PRs still fail fast
- `pnpm-lock.yaml` is tracked in git
- pnpm version pinned to `10.33.1` in both `packageManager` field and the CI action
Closes #459 