### PR TITLE
fix: remove stale `.env.example` entries and align S3 env vars with code

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,21 +60,22 @@ USDC_ISSUER_MAINNET=GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN
 # Slippage tolerance for USDC→XLM DEX swap (basis points; 50 = 0.5%)
 USDC_XLM_SLIPPAGE_BPS=50
 # Bulk transfer CSV chunk size (rows per transaction chunk; default 100)
-BULK_TRANSFER_CHUNK_SIZE=100
+# BULK_TRANSFER_CHUNK_SIZE=100
 # Bulk transfer upload limit in bytes (default 10485760 = 10 MiB)
-BULK_TRANSFER_MAX_FILE_SIZE_BYTES=10485760
+# BULK_TRANSFER_MAX_FILE_SIZE_BYTES=10485760
 # Minting contract: initialize with the SAC contract address for this issuer+code so mint_from_usdc matches the DEX asset; ensure a testnet path from that asset to XLM exists.
 
 # ── S3 / KYC document storage (B-062) ────────────────────────────────────────
 # S3 bucket for KYC document uploads (must be private — no public access)
-AWS_S3_KYC_BUCKET=acbu-kyc-documents
+# S3_BUCKET=acbu-kyc-documents
 # AWS region for S3 (defaults to AWS_REGION if set)
-AWS_S3_REGION=us-east-1
+# AWS_REGION=us-east-1
+# S3_REGION=us-east-1
 # Explicit credentials — omit to use IAM role / instance profile in production
 AWS_ACCESS_KEY_ID=your-access-key-id
 AWS_SECRET_ACCESS_KEY=your-secret-access-key
 # Optional: S3-compatible endpoint for local dev (e.g. MinIO)
-# AWS_S3_ENDPOINT=http://localhost:9000
+# S3_ENDPOINT=http://localhost:9000
 # Presigned URL TTLs (seconds). Defaults: 900 upload, 300 download
 # S3_UPLOAD_URL_TTL_SECONDS=900
 # S3_DOWNLOAD_URL_TTL_SECONDS=300


### PR DESCRIPTION
Closes #453 


This PR removes stale environment variable entries from `.env.example` and aligns the S3/KYC configuration section with the env names actually consumed by the backend code.

Changes:
- commented out unused `BULK_TRANSFER_*` variables
- replaced unsupported `AWS_S3_*` config names with the supported `S3_*` / `AWS_*` variants used by `src/config/env.ts`
- preserved only environment variables that are currently referenced by the codebase

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated example environment settings to reflect the latest configuration names.
  * Bulk transfer defaults are now shown as optional commented examples instead of active values.
  * S3/KYC setup examples now use shorter, renamed bucket, region, and endpoint keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->