### PR TITLE
fix: enable case-sensitive routing on Express app and router

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,6 +36,7 @@ const trustProxyValue = process.env.TRUST_PROXY
   : 0;
 
 app.set("trust proxy", trustProxyValue);
+app.set("case sensitive routing", true);
 
 const MAX_REQUEST_BODY_SIZE = "1mb";
 const SUPPORTED_REQUEST_ENCODINGS = new Set(["identity", "gzip"]);

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -36,7 +36,7 @@ import weightDriftAuditRoutes from "./weightDriftAuditRoutes";
 import reportRoutes from "./reportRoutes";
 import kycValidatorRewardRoutes from "./kycValidatorRewardRoutes";
 
-const router: ReturnType<typeof Router> = Router();
+const router: ReturnType<typeof Router> = Router({ caseSensitive: true });
 
 // Shallow health check — always 200, no dependency probing (used by load balancers)
 router.get("/health", (_req, res) => {


### PR DESCRIPTION
Prevents path variants like /API/V1/Mint from bypassing middleware mounted on the lowercase /api/v1/mint path.
closes #443 

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Route matching is now case-sensitive across the app, so URL path casing must match exactly.
  * This provides more precise handling of endpoint paths and avoids accidental matches from differently cased URLs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->