### PR TITLE
fix(#381): add WAL backup configuration guard

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -151,10 +151,10 @@ export const config = {
   logLevel: env.LOG_LEVEL,
   // Per-transport levels keep debug noise out of production aggregators (#398).
   logConsoleLevel:
-    env.LOG_LEVEL_CONSOLE ??
+    process.env.LOG_LEVEL_CONSOLE ??
     (env.NODE_ENV === "production" ? "info" : env.LOG_LEVEL),
   logFileLevel:
-    env.LOG_LEVEL_FILE ?? (env.NODE_ENV === "production" ? "info" : env.LOG_LEVEL),
+    process.env.LOG_LEVEL_FILE ?? (env.NODE_ENV === "production" ? "info" : env.LOG_LEVEL),
   logFile: process.env.LOG_FILE || "logs/app.log",
 
   // Business calendar timezone for salary runs and withdrawal windows (#408)

--- a/tests/walBackup.test.ts
+++ b/tests/walBackup.test.ts
@@ -23,11 +23,31 @@ const mockPrismaClient = () => ({
   $extends: jest.fn().mockReturnThis(),
 });
 
+/** Load database module in an isolated module registry with current process.env. */
+async function loadDatabase(): Promise<{ connectWithRetry: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    jest.isolateModules(() => {
+      try {
+        jest.doMock("@prisma/client", () => ({
+          PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
+          Prisma: { PrismaClientKnownRequestError: class {} },
+        }));
+        jest.doMock("@prisma/extension-accelerate", () => ({
+          withAccelerate: jest.fn(() => ({})),
+        }));
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        resolve(require("../src/config/database"));
+      } catch (e) {
+        reject(e);
+      }
+    });
+  });
+}
+
 describe("#381 WAL backup guard", () => {
   const ORIGINAL = process.env;
 
   beforeEach(() => {
-    jest.resetModules();
     process.env = { ...ORIGINAL, ...REQUIRED_ENV };
   });
 
@@ -37,65 +57,28 @@ describe("#381 WAL backup guard", () => {
 
   it("throws in production when PG_WAL_BACKUP_CONFIGURED is not set", async () => {
     delete process.env.PG_WAL_BACKUP_CONFIGURED;
-
-    // Mock PrismaClient so no real DB connection is attempted
-    jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
-      Prisma: { PrismaClientKnownRequestError: class {} },
-    }));
-    jest.mock("@prisma/extension-accelerate", () => ({
-      withAccelerate: jest.fn(() => ({})),
-    }));
-
-    const { connectWithRetry } = require("../src/config/database");
+    const { connectWithRetry } = await loadDatabase();
     await expect(connectWithRetry()).rejects.toThrow(/WAL backup is not configured/);
   });
 
   it("throws in production when PG_WAL_BACKUP_CONFIGURED=false", async () => {
     process.env.PG_WAL_BACKUP_CONFIGURED = "false";
-
-    jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
-      Prisma: { PrismaClientKnownRequestError: class {} },
-    }));
-    jest.mock("@prisma/extension-accelerate", () => ({
-      withAccelerate: jest.fn(() => ({})),
-    }));
-
-    const { connectWithRetry } = require("../src/config/database");
+    const { connectWithRetry } = await loadDatabase();
     await expect(connectWithRetry()).rejects.toThrow(/WAL backup is not configured/);
   });
 
   it("connects successfully in production when PG_WAL_BACKUP_CONFIGURED=true", async () => {
     process.env.PG_WAL_BACKUP_CONFIGURED = "true";
     process.env.PG_WAL_BACKUP_PROVIDER = "pgbackrest";
-
-    jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
-      Prisma: { PrismaClientKnownRequestError: class {} },
-    }));
-    jest.mock("@prisma/extension-accelerate", () => ({
-      withAccelerate: jest.fn(() => ({})),
-    }));
-
-    const { connectWithRetry } = require("../src/config/database");
+    const { connectWithRetry } = await loadDatabase();
     await expect(connectWithRetry()).resolves.toBeUndefined();
   });
 
   it("does not throw in development when PG_WAL_BACKUP_CONFIGURED is not set", async () => {
     process.env.NODE_ENV = "development";
     delete process.env.PG_WAL_BACKUP_CONFIGURED;
-    delete process.env.PRISMA_ACCELERATE_URL; // not required in dev
-
-    jest.mock("@prisma/client", () => ({
-      PrismaClient: jest.fn().mockImplementation(mockPrismaClient),
-      Prisma: { PrismaClientKnownRequestError: class {} },
-    }));
-    jest.mock("@prisma/extension-accelerate", () => ({
-      withAccelerate: jest.fn(() => ({})),
-    }));
-
-    const { connectWithRetry } = require("../src/config/database");
+    delete process.env.PRISMA_ACCELERATE_URL;
+    const { connectWithRetry } = await loadDatabase();
     await expect(connectWithRetry()).resolves.toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

Adds a startup guard that enforces WAL archiving is confirmed before the production server boots, preventing permanent data loss from storage failures on the primary database.

## Changes

- **`src/config/env.ts`** — adds `PG_WAL_BACKUP_CONFIGURED` (required `true` in prod) and `PG_WAL_BACKUP_PROVIDER` (optional label) to the Zod schema; exposes `config.walBackup`. Also fixes a pre-existing TS compile error where `LOG_LEVEL_CONSOLE` / `LOG_LEVEL_FILE` were read off the typed Zod output instead of `process.env`.
- **`src/config/database.ts`** — `connectWithRetry()` throws in production when `config.walBackup.configured` is `false`, logs provider on success, and logs a warning in non-production environments.
- **`.env.example`** — documents the two new vars with usage instructions.
- **`tests/walBackup.test.ts`** — 4 test cases (prod unconfigured, prod false, prod true, dev unconfigured). Fixed test isolation by replacing `jest.mock()` inside `it()` blocks (not hoisted by ts-jest) with `jest.isolateModules()` + `jest.doMock()`.

## How to enable

Set in your environment once WAL archiving is active:
```
PG_WAL_BACKUP_CONFIGURED=true
PG_WAL_BACKUP_PROVIDER=pgbackrest   # or rds-automated, supabase-pitr, barman, etc.
```

## Tests

```
PASS tests/walBackup.test.ts
  ✓ throws in production when PG_WAL_BACKUP_CONFIGURED is not set
  ✓ throws in production when PG_WAL_BACKUP_CONFIGURED=false
  ✓ connects successfully in production when PG_WAL_BACKUP_CONFIGURED=true
  ✓ does not throw in development when PG_WAL_BACKUP_CONFIGURED is not set
```

Closes #381