### PR TITLE
millicentokaa/acbu-backend

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 @jsr:registry=https://npm.jsr.io/
+engine-strict=true


### PR DESCRIPTION
## Summary
Added engine-strict=true to .npmrc to enforce Node version compatibility during pnpm install. Without this flag, installation succeeds on incompatible Node versions, deferring failures to runtime with cryptic errors from unsupported syntax features. This change ensures early detection of version mismatches before deployment. Additionally verified that tsconfig.build.json already has sourceMap: false to prevent shipping source maps to production (#469), and confirmed that seed files contain no hardcoded user IDs that could collide with production data (#467).

## Scope
- [ ] Backend API behavior
- [x] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [x] `pnpm run build`
- [x] `pnpm test`
- [x] `pnpm lint`

## Links
Closes #475 
Closes #469 
Closes #467 

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Strengthened Node.js version enforcement during install to help prevent unsupported environments from being used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->