### PR TITLE
.env.local loaded in test environment causes test flakiness

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -1,8 +1,24 @@
 import dotenv from "dotenv";
+import path from "path";
 import { z } from "zod";
 import { parseCorsOrigins } from "./corsOrigins";
 
-dotenv.config();
+// Load dotenv files in proper order, avoiding .env.local in test environments
+const nodeEnv = process.env.NODE_ENV || "development";
+const isTest = nodeEnv === "test";
+
+// Files to load, in order (later files override earlier ones)
+const envFiles = [
+  ".env",
+  ...(isTest ? [] : [".env.local"]),
+  `.env.${nodeEnv}`,
+  ...(isTest ? [] : [`.env.${nodeEnv}.local`]),
+];
+
+envFiles.forEach((file) => {
+  const filePath = path.resolve(process.cwd(), file);
+  dotenv.config({ path: filePath, override: false });
+});
 
 const envSchema = z.object({
   NODE_ENV: z.string().default("development"),

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
-import "dotenv/config";
+// Load environment variables first (handles dotenv loading with proper order)
+import "./config/env";
 
 import { initTracing } from "./config/tracing";
 initTracing();

--- a/tests/dotenv-order.test.ts
+++ b/tests/dotenv-order.test.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import path from "path";
 
 describe("src/index dotenv bootstrap order", () => {
-  it("loads dotenv before any other imports", () => {
+  it("loads env config before any other imports", () => {
     const indexPath = path.resolve(__dirname, "../src/index.ts");
     const source = fs.readFileSync(indexPath, "utf8");
     const firstMeaningfulLine = source
@@ -10,6 +10,6 @@ describe("src/index dotenv bootstrap order", () => {
       .map((line) => line.trim())
       .find((line) => line.length > 0 && !line.startsWith("//"));
 
-    expect(firstMeaningfulLine).toBe('import "dotenv/config";');
+    expect(firstMeaningfulLine).toBe('import "./config/env";');
   });
 });


### PR DESCRIPTION
Close: #466 
## Summary of Changes
1. Development/Production : .env → .env.local → .env.[NODE_ENV] → .env.[NODE_ENV].local
2. Test : .env → .env.test (skips all .local files entirely, which prevents developers' local overrides from breaking the tests)
### Files Modified:
1. src/config/env.ts - Replaced simple dotenv.config() with explicit loading of env files in proper order, skipping local files in test environments
2. src/index.ts - Changed first import from "dotenv/config" to "./config/env" to use the proper dotenv loading
3. tests/dotenv-order.test.ts - Updated the test to check that import "./config/env" is the first meaningful line
## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added stricter request security controls, including supported content-encoding validation and GraphQL endpoint/introspection blocking.
  - Improved webhook handling with JSON content-type enforcement and signature-verification support.
  - Added structured error responses for oversized payloads and unsupported encodings.
  - Enhanced startup reliability with database migrations, connection retries, and conditional service initialization.

- **Bug Fixes**
  - Prevented local environment settings from affecting test environments.
  - Restricted API documentation access in production.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->