### PR TITLE
fix: address validator rewards and migration safety

### DIFF
--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -21,6 +21,10 @@ This file documents the environment variables required by the ACBU backend and t
   - When set, the app uses Prisma Accelerate for runtime queries.
   - Must start with `prisma://` or `prisma+postgres://`.
   - In production, this variable is required.
+- `PRISMA_MIGRATION_HISTORY_REPLICATED`
+  - Defaults to `false`.
+  - In production, set to `true` only after verifying `_prisma_migrations` is replicated to failover targets.
+  - The app refuses to run startup migrations in production until this is explicitly acknowledged.
 
 ## Optional and configurable variables
 
@@ -154,4 +158,5 @@ This file documents the environment variables required by the ACBU backend and t
 - In production, `PRISMA_ACCELERATE_URL` is required.
 - `DATABASE_URL` should always be a direct PostgreSQL URL for migrations.
 - `PRISMA_ACCELERATE_URL` should be used for runtime database queries when set.
+- `PRISMA_MIGRATION_HISTORY_REPLICATED=true` confirms promoted replicas retain Prisma migration history.
 - If you need the exact runtime schema, refer to `src/config/env.ts`.

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -76,6 +76,16 @@ const envSchema = z.object({
   MEMORY_LEAK_THRESHOLD_PCT: z.coerce.number().int().min(50).max(99).default(85),
   MEMORY_CHECK_INTERVAL_MS: z.coerce.number().int().min(1000).default(30000),
   HEAP_DUMP_DIR: z.string().default("./heapdumps"),
+
+  // #383: Prisma migration history must survive replica promotion.
+  // Set to "true" only after verifying that `_prisma_migrations` is included in
+  // the database replication/failover strategy. Otherwise `migrate deploy` can
+  // re-apply migrations or fail after a read replica is promoted.
+  PRISMA_MIGRATION_HISTORY_REPLICATED: z
+    .string()
+    .toLowerCase()
+    .pipe(z.enum(["true", "false"]))
+    .default("false"),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -476,6 +486,11 @@ export const config = {
   walBackup: {
     configured: env.PG_WAL_BACKUP_CONFIGURED === "true",
     provider: env.PG_WAL_BACKUP_PROVIDER || "",
+  },
+
+  // #383: Migration table replication / promotion safety.
+  prismaMigrationHistory: {
+    replicated: env.PRISMA_MIGRATION_HISTORY_REPLICATED === "true",
   },
 
   // CORS — explicit origins only; wildcard * is rejected (incompatible with credentials)

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,17 @@ function blockGraphQLQueries(req: Request, _res: Response, next: NextFunction): 
   next();
 }
 
+function assertPrismaMigrationHistoryReplicated(): void {
+  if (
+    config.nodeEnv === "production" &&
+    !config.prismaMigrationHistory.replicated
+  ) {
+    throw new Error(
+      "Prisma migration history replication is not configured. Set PRISMA_MIGRATION_HISTORY_REPLICATED=true only after verifying _prisma_migrations is replicated to failover targets.",
+    );
+  }
+}
+
 // Security middleware
 app.use(
   helmet({
@@ -268,6 +279,8 @@ app.use(errorHandler);
 // Initialize connections and start server
 async function startServer() {
   try {
+    assertPrismaMigrationHistoryReplicated();
+
     // Ensures schema is in sync before accepting traffic; prevents "table does not exist" on new columns.
     logger.info("Applying Prisma migrations...");
     execSync("npx prisma migrate deploy", { stdio: "inherit" });

--- a/src/services/contracts/acbuMinting.service.ts
+++ b/src/services/contracts/acbuMinting.service.ts
@@ -362,6 +362,24 @@ export class MintingService {
   }
 
   /**
+   * Get total ACBU supply minted on-chain.
+   */
+  async getTotalSupply(): Promise<string> {
+    try {
+      const result = await this.contractClient.readContract(
+        this.contractId,
+        "get_total_supply",
+        [],
+      );
+
+      return ContractClient.fromScVal(result).toString();
+    } catch (error) {
+      logger.error("Failed to get total supply", { error });
+      throw error;
+    }
+  }
+
+  /**
    * Check if contract is paused
    */
   async isPaused(): Promise<boolean> {

--- a/src/services/kyc/kycValidatorRewardService.test.ts
+++ b/src/services/kyc/kycValidatorRewardService.test.ts
@@ -1,0 +1,58 @@
+const mockGetTotalSupply = jest.fn();
+const mockGetFeeRate = jest.fn();
+
+jest.mock("../../config/database", () => ({
+  prisma: {
+    kycValidatorReward: {
+      create: jest.fn(),
+      findMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+  },
+}));
+
+jest.mock("../contracts", () => ({
+  acbuMintingService: {
+    getTotalSupply: mockGetTotalSupply,
+    getFeeRate: mockGetFeeRate,
+  },
+}));
+
+import { validateRewardAmount } from "./kycValidatorRewardService";
+
+describe("kycValidatorRewardService", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("caps validator rewards against on-chain total supply, not fee rate", async () => {
+    mockGetTotalSupply.mockResolvedValue("100000000000");
+    mockGetFeeRate.mockResolvedValue(25);
+
+    const result = await validateRewardAmount("10000000");
+
+    expect(mockGetTotalSupply).toHaveBeenCalledTimes(1);
+    expect(mockGetFeeRate).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      valid: true,
+      onChainTotalMinted: "100000000000",
+      rewardAmount: "10000000",
+    });
+  });
+
+  it("rejects rewards when on-chain total supply is zero", async () => {
+    mockGetTotalSupply.mockResolvedValue("0");
+
+    await expect(validateRewardAmount("1")).resolves.toMatchObject({
+      valid: false,
+      reason: "On-chain mint total is zero - cannot verify reward",
+    });
+  });
+});

--- a/src/services/kyc/kycValidatorRewardService.ts
+++ b/src/services/kyc/kycValidatorRewardService.ts
@@ -24,8 +24,7 @@ export interface KycRewardValidationResult {
 const MAX_REWARD_PCT_OF_MINTED = 5n;
 
 async function getOnChainTotalMinted(): Promise<string> {
-  const feeRate = await acbuMintingService.getFeeRate();
-  return feeRate.toString();
+  return acbuMintingService.getTotalSupply();
 }
 
 export async function validateRewardAmount(
@@ -62,7 +61,7 @@ export async function validateRewardAmount(
       onChainTotalMinted: "0",
       rewardAmount: acbuAmount,
       maxAllowed: maxAllowed.toString(),
-      reason: "On-chain mint total is zero — cannot verify reward",
+      reason: "On-chain mint total is zero - cannot verify reward",
     };
   }
 

--- a/src/services/treasury/TreasuryService.ts
+++ b/src/services/treasury/TreasuryService.ts
@@ -17,13 +17,13 @@
 import { prismaReplica } from "../../config/database";
 import { logger } from "../../config/logger";
 import { ReserveTracker } from "../reserve/ReserveTracker";
-import { getTransactionsForTreasuryReport, getLatestReserves } from "../reports/reportService";
+import { getLatestReserves } from "../reports/reportService";
 
 // Constants
 const DEFAULT_TOLERANCE_PERCENTAGE = 0.01; // 0.01%
 const DAYS_FOR_FX_FALLBACK = 7; // Look back 7 days for FX fallback
 
-type DecimalLike = { toNumber: () => number } | null | undefined;
+type DecimalLike = { toString: () => string } | null | undefined;
 
 interface TransactionAggregate {
   currency: string;
@@ -92,10 +92,13 @@ interface EnterpriseTreasuryResult {
 }
 
 /**
- * Convert Decimal or number-like value to number, defaulting to 0 if null/undefined
+ * Convert exact Decimal values at this reporting boundary only.
+ *
+ * Do not call Prisma Decimal#toNumber() directly in settlement logic; keep exact
+ * values as Decimal/string until a numeric API response is explicitly required.
  */
 function decimalToNumber(value: DecimalLike): number {
-  return value?.toNumber() ?? 0;
+  return Number(value?.toString() ?? "0");
 }
 
 /**
@@ -152,7 +155,7 @@ async function getFxRateWithFallback(currency: string): Promise<FxRate | null> {
 async function aggregateTransactionsBySegment(): Promise<
   Map<string, TransactionAggregate>
 > {
-  const transactions = await prisma.transaction.findMany({
+  const transactions = await prismaReplica.transaction.findMany({
     where: {
       status: { in: ["completed", "processing"] },
       type: { in: ["mint", "burn", "transfer"] },


### PR DESCRIPTION
## Summary
- add a real getTotalSupply() wrapper for the minting contract and use it for KYC validator reward caps
- add a regression test ensuring reward validation does not read fee rate as total minted
- add a production startup acknowledgement guard for Prisma migration history replication
- avoid direct Prisma Decimal#toNumber() usage in TreasuryService reporting conversion

## Verification
- npx jest --runTestsByPath src/services/kyc/kycValidatorRewardService.test.ts --coverage=false
- npm run build (fails on existing upstream TypeScript errors unrelated to this PR, including Prisma MiddlewareFn, missing optional deps, missing auth exports, and other pre-existing type issues)

close #384 
close #383 
close #645 
close #648 