### PR TITLE
feat: Fix ErrorCode typing to enforce enum values

### DIFF
--- a/src/types/errorCodes.ts
+++ b/src/types/errorCodes.ts
@@ -19,4 +19,4 @@ export enum ErrorCodes {
   INTERNAL_ERROR = "INTERNAL_ERROR",
 }
 
-export type ErrorCode = keyof typeof ErrorCodes | string;
+export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];


### PR DESCRIPTION
# Fix ErrorCode typing to enforce enum values
 closes #595 
## Summary
This PR fixes the `ErrorCode` type so it no longer accepts arbitrary strings.  
It removes the `| string` union that was weakening type safety and defeating autocomplete/type narrowing.

## Problem
`ErrorCode` was defined as:

`keyof typeof ErrorCodes | string`

Because of `| string`, any string was valid, which:
- removed meaningful compile-time validation,
- reduced editor autocomplete usefulness,
- made type narrowing ineffective for error-code handling.

## Changes
Updated `src/types/errorCodes.ts`:

- from: `export type ErrorCode = keyof typeof ErrorCodes | string;`
- to: `export type ErrorCode = (typeof ErrorCodes)[keyof typeof ErrorCodes];`

## Why this approach
Using `(typeof ErrorCodes)[keyof typeof ErrorCodes]` constrains `ErrorCode` to actual enum values only, while preserving strong IDE support and safer refactoring behavior.

## Impact
- ✅ Stronger type safety for error codes
- ✅ Better autocomplete/intellisense
- ✅ Better type narrowing in error handling paths
- ✅ No runtime behavior change (type-level fix only)

## Test Plan
- Verified the staged diff reflects only the `ErrorCode` type change.
- Checked lint diagnostics for the edited file (`src/types/errorCodes.ts`) — no lint errors.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error-code validation by restricting accepted values to recognized error codes.
  * Invalid or arbitrary error-code strings are now flagged earlier during development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->