### PR TITLE
fix(security): harden JWT/challenge secrets, passcode length, bills w…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,7 +13,14 @@ DATABASE_URL="postgresql://acbu_user:acbu_pass@localhost:5432/acbu_db"
 # PRISMA_ACCELERATE_URL="prisma://accelerate.prisma-data.net/?api_key=..."
 MONGODB_URI="mongodb://localhost:27017/acbu_db"
 RABBITMQ_URL="amqp://guest:guest@localhost:5672"
-JWT_SECRET="dev-jwt-secret-change-me"
+JWT_SECRET="dev-jwt-secret-change-me-min-32-characters-long"
+# Required explicitly in production — do not let this fall back to JWT_SECRET,
+# they must be distinct trust boundaries. Generate a separate random value.
+# CHALLENGE_TOKEN_SECRET=dev-challenge-token-secret-change-me-32chars
+
+# BE-001: HMAC secret for the /v1/webhooks/bills/:provider endpoint. Required
+# in production once a real bills provider (not simulatedBillsPartner) is wired in.
+# BILLS_WEBHOOK_SECRET=change-me-in-production
 
 # CORS — comma-separated exact origins (no *; required in production).
 # Unset in development defaults to http://localhost:3000

--- a/.env.test
+++ b/.env.test
@@ -1,7 +1,7 @@
 DATABASE_URL="postgresql://acbu_user:acbu_pass@localhost:5432/acbu_db_test"
 MONGODB_URI="mongodb://localhost:27017/acbu_db_test"
 RABBITMQ_URL="amqp://guest:guest@localhost:5672"
-JWT_SECRET="test-jwt-secret"
+JWT_SECRET="test-jwt-secret-for-automated-tests-only-not-for-prod"
 
 # Rate Limiting
 RATE_LIMIT_WINDOW_MS=60000
@@ -23,4 +23,4 @@ LIMITS_BUSINESS=5000
 LIMITS_GOVERNMENT=10000
 
 # Challenge token secret (for security suite)
-CHALLENGE_TOKEN_SECRET=default_secret
+CHALLENGE_TOKEN_SECRET=test-challenge-token-secret-for-automated-tests-only

--- a/ENV_VARS.md
+++ b/ENV_VARS.md
@@ -33,6 +33,9 @@ This file documents the environment variables required by the ACBU backend and t
   - RabbitMQ connection string for queue-based features.
 - `JWT_SECRET`
   - Secret used for JWT signing and verification.
+  - Must be at least 32 characters and must not equal the documented `.env.example` placeholder value.
+- `BILLS_WEBHOOK_SECRET`
+  - HMAC secret for verifying `/v1/webhooks/bills/:provider` signatures. Required in production.
 
 ## Runtime database configuration
 
@@ -53,7 +56,7 @@ This file documents the environment variables required by the ACBU backend and t
 - `NODE_ENV` - defaults to `development`
 - `PORT` - defaults to `5000`
 - `API_VERSION` - defaults to `v1`
-- `CHALLENGE_TOKEN_SECRET` - optional; fallback to `JWT_SECRET`
+- `CHALLENGE_TOKEN_SECRET` - required explicitly in production (distinct from `JWT_SECRET`); falls back to `JWT_SECRET` outside production
 - `JWT_EXPIRES_IN` - defaults to `7d`
 - `JWT_CLOCK_TOLERANCE_SECONDS` - defaults to `30`
 - `API_KEY_SALT` - defaults to empty string

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -28,8 +28,8 @@ const envSchema = z.object({
   DATABASE_URL_REPLICA: z.string().optional(),
   MONGODB_URI: z.string().min(1),
   RABBITMQ_URL: z.string().min(1),
-  JWT_SECRET: z.string().min(1),
-  CHALLENGE_TOKEN_SECRET: z.string().optional(),
+  JWT_SECRET: z.string().min(32, "JWT_SECRET must be at least 32 characters"),
+  CHALLENGE_TOKEN_SECRET: z.string().min(32).optional(),
   PRISMA_ACCELERATE_URL: z.string().optional(),
   JWT_EXPIRES_IN: z.string().default("7d"),
   JWT_CLOCK_TOLERANCE_SECONDS: z.coerce.number().int().nonnegative().default(30),
@@ -128,10 +128,31 @@ if (parsed.data.NODE_ENV === "production" && !parsed.data.PRISMA_ACCELERATE_URL)
   throw new Error("Missing required environment variable: PRISMA_ACCELERATE_URL");
 }
 
+// #630: JWT_SECRET must not be the documented .env.example placeholder in production.
+const JWT_SECRET_EXAMPLE_VALUES = ["dev-jwt-secret-change-me", "change-me-in-production"];
+if (
+  parsed.data.NODE_ENV === "production" &&
+  JWT_SECRET_EXAMPLE_VALUES.includes(parsed.data.JWT_SECRET)
+) {
+  throw new Error(
+    "JWT_SECRET is set to a documented example/placeholder value — generate a unique secret before deploying to production.",
+  );
+}
+
+// #632: CHALLENGE_TOKEN_SECRET must be explicit in production so a leaked
+// JWT_SECRET does not also compromise the 2FA challenge-token trust boundary.
+if (parsed.data.NODE_ENV === "production" && !parsed.data.CHALLENGE_TOKEN_SECRET) {
+  throw new Error(
+    "Missing required environment variable: CHALLENGE_TOKEN_SECRET (must be set explicitly in production, distinct from JWT_SECRET)",
+  );
+}
+
 const s3ScanWebhookSecret = process.env.S3_SCAN_WEBHOOK_SECRET?.trim() || "change-me-in-production";
 
 if (parsed.data.NODE_ENV === "production" && s3ScanWebhookSecret === "change-me-in-production") {
   throw new Error("Missing required environment variable: S3_SCAN_WEBHOOK_SECRET");
+}
+
 // #382: Fintech partner keys must never be absent in production — an empty
 // Authorization header would be silently accepted by axios and only fail at
 // the first live API call, making the error hard to trace.  Fail at boot
@@ -142,6 +163,7 @@ if (parsed.data.NODE_ENV === "production") {
   if (!process.env.FLUTTERWAVE_WEBHOOK_SECRET)
     missingFintechKeys.push("FLUTTERWAVE_WEBHOOK_SECRET");
   if (!process.env.PAYSTACK_SECRET_KEY) missingFintechKeys.push("PAYSTACK_SECRET_KEY");
+  if (!process.env.BILLS_WEBHOOK_SECRET) missingFintechKeys.push("BILLS_WEBHOOK_SECRET");
   if (missingFintechKeys.length > 0) {
     throw new Error(
       `Missing required fintech API keys in production: ${missingFintechKeys.join(", ")}. ` +
@@ -229,6 +251,10 @@ export const config = {
   paystack: {
     secretKey: process.env.PAYSTACK_SECRET_KEY || "",
     baseUrl: process.env.PAYSTACK_BASE_URL || "https://api.paystack.co",
+  },
+  // BE-001: HMAC secret for /v1/webhooks/bills/:provider signature verification.
+  bills: {
+    webhookSecret: process.env.BILLS_WEBHOOK_SECRET || "",
   },
   mtnMomo: {
     subscriptionKey: process.env.MTN_MOMO_SUBSCRIPTION_KEY || "",

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -26,7 +26,7 @@ export const signinSchema = z.object({
 
 export const signupSchema = z.object({
   username: z.string().min(1, "username is required").max(64),
-  passcode: z.string().min(4, "passcode must be at least 4 characters").max(64),
+  passcode: z.string().min(8, "passcode must be at least 8 characters").max(64),
 });
 
 export const verify2faSchema = z.object({

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -28,7 +28,7 @@ export const patchMeSchema = z.object({
     .optional()
     .nullable(),
   privacy_hide_from_search: z.boolean().optional(),
-  passcode: z.string().min(4).max(64).optional(), // set or update passcode for Tier-1 recovery
+  passcode: z.string().min(8).max(64).optional(), // set or update passcode for Tier-1 recovery
 });
 
 /**

--- a/src/controllers/webhookController.ts
+++ b/src/controllers/webhookController.ts
@@ -398,6 +398,88 @@ export async function handleFlutterwaveWebhook(
   }
 }
 
+// ── Bills Webhook ───────────────────────────────────────────────────────────
+
+/**
+ * Verify bills webhook signature using HMAC-SHA256 of the raw body.
+ * Rejects the request if BILLS_WEBHOOK_SECRET is not configured.
+ */
+export function verifyBillsWebhookSignature(
+  req: Request & { rawBody?: Buffer },
+  res: Response,
+  next: NextFunction,
+): void {
+  // Dev/stage explicit bypass — never reachable in production because env.ts
+  // throws before the server starts when BILLS_WEBHOOK_SECRET is unset.
+  if (bypassEnabled) {
+    logger.warn("Bills webhook signature check bypassed (dev/stage)");
+    next();
+    return;
+  }
+
+  const secret = config.bills.webhookSecret;
+  if (!secret) {
+    // Should never be reached in production due to boot guard in env.ts.
+    logger.error(
+      "BILLS_WEBHOOK_SECRET is not configured — rejecting webhook. " +
+        "Set the environment variable to accept bills webhooks.",
+    );
+    throw new AppError(
+      "Webhook verification unavailable: secret not configured",
+      503,
+      ErrorCodes.CONFIG_ERROR,
+    );
+  }
+
+  const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
+  if (!rawBody || !Buffer.isBuffer(rawBody)) {
+    throw new AppError(
+      "Raw body required for verification",
+      400,
+      ErrorCodes.RAW_BODY_REQUIRED,
+    );
+  }
+
+  const timestamp = req.headers["x-bills-timestamp"] as string | undefined;
+  if (!isTimestampValid(timestamp)) {
+    logger.warn("Bills webhook timestamp invalid or outside tolerance window", {
+      timestamp,
+      toleranceS: WEBHOOK_TIMESTAMP_TOLERANCE_S,
+    });
+    res.status(401).json({ error: "Webhook timestamp invalid or expired" });
+    return;
+  }
+
+  const received = req.headers["x-bills-signature"] as string | undefined;
+  if (!received) {
+    throw new AppError(
+      "Missing x-bills-signature header",
+      401,
+      ErrorCodes.MISSING_SIGNATURE,
+    );
+  }
+
+  const computed = crypto.createHmac("sha256", secret).update(rawBody).digest("hex");
+
+  const receivedBuf = Buffer.from(received, "hex");
+  const computedBuf = Buffer.from(computed, "hex");
+
+  let signatureValid = false;
+  if (receivedBuf.length === computedBuf.length) {
+    try {
+      signatureValid = crypto.timingSafeEqual(receivedBuf, computedBuf);
+    } catch {
+      signatureValid = false;
+    }
+  }
+
+  if (!signatureValid) {
+    logger.warn("Bills webhook signature mismatch");
+    throw new AppError("Invalid signature", 401, ErrorCodes.INVALID_SIGNATURE);
+  }
+  next();
+}
+
 /**
  * Handle partner bill-payment webhooks and reconcile the existing bill payment transaction.
  * This route is provider-agnostic for now; providers can be added behind the same normalizer.

--- a/src/routes/webhookRoutes.ts
+++ b/src/routes/webhookRoutes.ts
@@ -5,6 +5,7 @@ import {
   handlePaystackWebhook,
   verifyPaystackSignature,
   handleBillsWebhook,
+  verifyBillsWebhookSignature,
 } from "../controllers/webhookController";
 
 const router: IRouter = Router();
@@ -15,6 +16,6 @@ router.post(
   handleFlutterwaveWebhook,
 );
 router.post("/paystack", verifyPaystackSignature, handlePaystackWebhook);
-router.post("/bills/:provider", handleBillsWebhook);
+router.post("/bills/:provider", verifyBillsWebhookSignature, handleBillsWebhook);
 
 export default router;

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -278,10 +278,10 @@ export async function signup(params: SignupParams): Promise<SignupResult> {
   }
   if (
     !params.passcode ||
-    params.passcode.length < 4 ||
+    params.passcode.length < 8 ||
     params.passcode.length > 64
   ) {
-    throw new Error("Passcode must be 4–64 characters");
+    throw new Error("Passcode must be 8–64 characters");
   }
   const existing = await prisma.user.findFirst({
     where: { username },

--- a/tests/env.test.ts
+++ b/tests/env.test.ts
@@ -4,7 +4,7 @@ describe("env validation", () => {
     DATABASE_URL: "postgresql://u:p@localhost:5432/db",
     MONGODB_URI: "mongodb://localhost:27017/db",
     RABBITMQ_URL: "amqp://localhost:5672",
-    JWT_SECRET: "test-secret",
+    JWT_SECRET: "test-secret-that-is-at-least-32-characters-long",
     PRISMA_ACCELERATE_URL: "prisma://accelerate.prisma-data.net/?api_key=test",
     CORS_ORIGIN: "https://app.acbu.io",
   };

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,9 +10,12 @@ process.env.MONGODB_URI =
   process.env.MONGODB_URI || "mongodb://localhost:27017/acbu_test";
 process.env.RABBITMQ_URL =
   process.env.RABBITMQ_URL || "amqp://guest:guest@localhost:5672";
-process.env.JWT_SECRET = process.env.JWT_SECRET || "test-jwt-secret";
+process.env.JWT_SECRET =
+  process.env.JWT_SECRET || "test-jwt-secret-for-automated-tests-only-not-for-prod";
 process.env.API_KEY_SALT = process.env.API_KEY_SALT || "test-api-key-salt";
 process.env.FLUTTERWAVE_WEBHOOK_SECRET =
   process.env.FLUTTERWAVE_WEBHOOK_SECRET || "test-fw-webhook-secret";
 process.env.PAYSTACK_SECRET_KEY =
   process.env.PAYSTACK_SECRET_KEY || "test-ps-secret-key";
+process.env.BILLS_WEBHOOK_SECRET =
+  process.env.BILLS_WEBHOOK_SECRET || "test-bills-webhook-secret";


### PR DESCRIPTION


- Require JWT_SECRET to be at least 32 characters and reject the documented .env.example placeholder value in production (BE-003).
- Require CHALLENGE_TOKEN_SECRET explicitly in production instead of silently falling back to JWT_SECRET, keeping 2FA and API auth as separate trust domains (BE-004).
- Raise the wallet passcode minimum from 4 to 8 characters across signup, profile update, and the auth service guard, since this passcode derives the key that decrypts the user's Stellar secret (BE-002).
- Add HMAC-SHA256 signature verification (verifyBillsWebhookSignature) to POST /v1/webhooks/bills/:provider, matching the existing Flutterwave/ Paystack pattern, and require BILLS_WEBHOOK_SECRET explicitly in production (BE-001).

Closes #628
Closes #629
Closes #630
Closes #632



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Strengthened production secret requirements and validation.
  - Added signature verification for bills webhook requests.
  - Added required bills webhook secret configuration.

- **Bug Fixes**
  - Increased the minimum passcode length from 4 to 8 characters for signup and profile updates.
  - Improved test and environment configuration for secure secrets.

- **Documentation**
  - Updated environment variable guidance, including webhook and production secret requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->