### PR TITLE
fix(#581): memory monitor uses validated config instead of raw env

### DIFF
--- a/src/utils/memoryMonitor.ts
+++ b/src/utils/memoryMonitor.ts
@@ -3,11 +3,12 @@ import fs from "fs";
 import path from "path";
 import { logger } from "../config/logger";
 import { heapUsedRatioGauge, heapDumpCounter } from "../config/promMetrics";
+import { config } from "../config/env";
 
-const WARN_THRESHOLD_PCT = parseInt(process.env.MEMORY_LEAK_THRESHOLD_PCT || "85", 10);
+const WARN_THRESHOLD_PCT = config.memory.leakThresholdPct;
 const CRITICAL_THRESHOLD_PCT = Math.min(WARN_THRESHOLD_PCT + 10, 98);
-const CHECK_INTERVAL_MS = parseInt(process.env.MEMORY_CHECK_INTERVAL_MS || "30000", 10);
-const HEAP_DUMP_DIR = process.env.HEAP_DUMP_DIR || "./heapdumps";
+const CHECK_INTERVAL_MS = config.memory.checkIntervalMs;
+const HEAP_DUMP_DIR = config.memory.heapDumpDir;
 
 let lastDumpAt = 0;
 const MIN_DUMP_INTERVAL_MS = 5 * 60 * 1000;


### PR DESCRIPTION
## Summary
- `utils/memoryMonitor.ts` read `MEMORY_LEAK_THRESHOLD_PCT`, `MEMORY_CHECK_INTERVAL_MS`, and `HEAP_DUMP_DIR` directly from `process.env`, bypassing the Zod-validated `config.memory` object already exposed by `config/env.ts` (which validates `MEMORY_LEAK_THRESHOLD_PCT` to an int between 50-99, etc).
- Switched all three to read from `config.memory.leakThresholdPct` / `config.memory.checkIntervalMs` / `config.memory.heapDumpDir`, matching the pattern used by every other module in the codebase.

Fixes #581

## Test plan
- [x] `tsc --noEmit` on the project shows no new errors introduced by this change (pre-existing unrelated errors elsewhere in the repo are untouched)
- [x] `eslint src/utils/memoryMonitor.ts` passes with no new issues

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved memory monitoring configuration by consistently using the application’s configured memory thresholds, check intervals, and heap dump location.
  * Preserved safeguards that prevent the critical memory threshold from exceeding 98%.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->