### PR TITLE
fix(#577): remove prisma migrate deploy from server startup

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,6 @@ initTracing();
 
 import "express-async-errors";
 
-import { execSync } from "child_process";
 import express, {
   type NextFunction,
   type Request,
@@ -281,11 +280,6 @@ app.use(errorHandler);
 async function startServer() {
   try {
     assertPrismaMigrationHistoryReplicated();
-
-    // Ensures schema is in sync before accepting traffic; prevents "table does not exist" on new columns.
-    logger.info("Applying Prisma migrations...");
-    execSync("npx prisma migrate deploy", { stdio: "inherit" });
-    logger.info("Prisma migrations applied successfully");
 
     // Establish the DB connection with backoff + jitter so coordinated restarts
     // don't stampede the database's connection slots (#402).


### PR DESCRIPTION
Running migrations synchronously on every server start violates 12-factor principles and causes problems:
- Blocks the Node.js event loop during migration
- Server fails to start if the migration endpoint is unreachable
- Unintended migrations in rolling deployments where multiple pods start

Migrations should be run as a separate CI/CD lifecycle step (pnpm prisma:migrate) before the server binary is executed.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
closes  #577 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server startup by removing an unnecessary database migration command.
  * Startup now proceeds directly to database connectivity checks and service initialization after validating migration history.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->