### PR TITLE
fix(#574): add periodic eviction to treasuryCache to prevent memory leak

### DIFF
--- a/src/controllers/governmentController.ts
+++ b/src/controllers/governmentController.ts
@@ -48,6 +48,21 @@ type TreasuryResponse = {
 
 const treasuryCache = new Map<string, { expiresAt: number; value: TreasuryResponse }>();
 
+// Periodically evict expired entries so the Map does not grow unbounded under
+// heavy multi-tenant usage (#574). The interval matches the maximum allowed TTL
+// (5 minutes) so no live entry is ever removed.
+const TREASURY_CACHE_EVICTION_INTERVAL_MS = 300_000; // 5 minutes
+const treasuryCacheEvictionTimer = setInterval(() => {
+  const now = Date.now();
+  for (const [key, entry] of treasuryCache) {
+    if (entry.expiresAt <= now) {
+      treasuryCache.delete(key);
+    }
+  }
+}, TREASURY_CACHE_EVICTION_INTERVAL_MS);
+// Allow the process to exit cleanly even if this timer is still active.
+treasuryCacheEvictionTimer.unref();
+
 function decimalToNumber(value: DecimalLike): number {
   return value?.toNumber() ?? 0;
 }


### PR DESCRIPTION
The treasuryCache Map only removed entries on per-key access; under heavy multi-tenant usage stale entries accumulated indefinitely.

Added a setInterval that sweeps expired entries every 5 minutes (matching the maximum configured TTL). The timer is unref()'d so it does not prevent the process from exiting cleanly.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
closes #574 