### PR TITLE
[LOW] Unused import: BytesN<32> vs Bytes in minting contract service

### DIFF
--- a/src/services/contracts/acbuMinting.service.ts
+++ b/src/services/contracts/acbuMinting.service.ts
@@ -1,6 +1,5 @@
-import { PrismaClient } from "@prisma/client";
-const prisma = new PrismaClient();
 import { xdr } from "@stellar/stellar-sdk";
+import { prisma } from "../../config/database";
 import { contractClient, ContractClient } from "../stellar/contractClient";
 import { stellarClient } from "../stellar/client";
 import { logger } from "../../config/logger";

--- a/tests/acbuMintingCompensation.test.ts
+++ b/tests/acbuMintingCompensation.test.ts
@@ -1,38 +1,45 @@
 import { MintingService } from "../src/services/contracts/acbuMinting.service";
-import { contractClient } from "../src/stellar/contractClient";
-import { stellarClient } from "../src/stellar/client";
-import { PrismaClient } from "@prisma/client";
+import { contractClient } from "../src/services/stellar/contractClient";
+import { stellarClient } from "../src/services/stellar/client";
 
-jest.mock("../src/stellar/contractClient", () => ({
+jest.mock("../src/services/stellar/contractClient", () => ({
   contractClient: { invokeContract: jest.fn() },
-  ContractClient: { toScVal: jest.fn(), fromScVal: jest.fn() }
+  ContractClient: { toScVal: jest.fn(), fromScVal: jest.fn() },
 }));
 
-jest.mock("../src/stellar/client", () => ({
-  stellarClient: { getKeypair: jest.fn(() => ({ publicKey: () => "test-pub-key" })) }
+jest.mock("../src/services/stellar/client", () => ({
+  stellarClient: { getKeypair: jest.fn(() => ({ publicKey: () => "test-pub-key" })) },
 }));
 
-jest.mock("@prisma/client", () => {
-  const mPrisma = { transaction: { update: jest.fn() } };
-  return { PrismaClient: jest.fn(() => mPrisma) };
-});
+// Mock the shared database singleton — the one the service now imports.
+const mockTransactionUpdate = jest.fn();
+jest.mock("../src/config/database", () => ({
+  prisma: {
+    transaction: { update: mockTransactionUpdate },
+  },
+}));
 
 describe("MintingService Compensation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("marks tx FAILED if stellar throws", async () => {
     const service = new MintingService("contract-id");
     (contractClient.invokeContract as jest.Mock).mockRejectedValue(new Error("Stellar Fail"));
-    
-    const prisma = new PrismaClient();
-    
-    try {
-      await service.mintFromUsdc({
-        user: "user", usdcAmount: "100", recipient: "rec", txId: "123"
-      } as any);
-    } catch (e) {}
 
-    expect(prisma.transaction.update).toHaveBeenCalledWith({
+    await expect(
+      service.mintFromUsdc({
+        user: "user",
+        usdcAmount: "100",
+        recipient: "rec",
+        txId: "123",
+      } as any),
+    ).rejects.toThrow("Stellar Fail");
+
+    expect(mockTransactionUpdate).toHaveBeenCalledWith({
       where: { id: "123" },
-      data: { status: "FAILED" }
+      data: { status: "FAILED" },
     });
   });
 });


### PR DESCRIPTION
## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
Closes #596 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction failure handling so failed minting operations are correctly marked as **FAILED**.

* **Tests**
  * Updated coverage to verify error propagation and database status updates during minting failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->