### PR TITLE
fix(investment): parameterize timezone in withdrawal timing raw query…

### DIFF
--- a/src/services/investment/withdrawalTimingService.test.ts
+++ b/src/services/investment/withdrawalTimingService.test.ts
@@ -35,4 +35,23 @@ describe("getInvestmentWithdrawalTiming", () => {
       isBusinessWithdrawalAllowedDate: true,
     });
   });
+
+  it("passes timezone as a parameterized SQL value rather than raw string interpolation", async () => {
+    const requestedAt = new Date("2026-05-15T09:30:00.000Z");
+    const availableAt = new Date("2026-05-16T09:30:00.000Z");
+    mockQueryRaw.mockResolvedValue([
+      {
+        requestedAt,
+        availableAt,
+        businessCalendarDay: 15,
+      },
+    ]);
+
+    await getInvestmentWithdrawalTiming("Africa/Lagos");
+
+    expect(mockQueryRaw).toHaveBeenCalledTimes(1);
+    const sqlQuery = mockQueryRaw.mock.calls[0][0];
+    expect(sqlQuery.values).toContain("Africa/Lagos");
+    expect(sqlQuery.strings.join("")).not.toContain("'Africa/Lagos'");
+  });
 });

--- a/src/services/investment/withdrawalTimingService.ts
+++ b/src/services/investment/withdrawalTimingService.ts
@@ -54,23 +54,20 @@ export async function getInvestmentWithdrawalTiming(
       SELECT
         trusted_now AS "requestedAt",
         trusted_now + ${Prisma.sql`make_interval(hours => ${WITHDRAWAL_DELAY_HOURS})`} AS "availableAt",
-        EXTRACT(DAY FROM (trusted_now AT TIME ZONE ${Prisma.raw(`'${businessTimeZone.replace(/'/g, "''")}'`)}))::int AS "businessCalendarDay"
+        EXTRACT(DAY FROM (trusted_now AT TIME ZONE ${businessTimeZone}))::int AS "businessCalendarDay"
       FROM trusted_clock
     `,
   );
 
   const requestedAt = assertDate(row?.requestedAt, "requestedAt");
   const availableAt = assertDate(row?.availableAt, "availableAt");
-  const businessCalendarDay = assertBusinessCalendarDay(
-    row?.businessCalendarDay,
-  );
+  const businessCalendarDay = assertBusinessCalendarDay(row?.businessCalendarDay);
 
   return {
     requestedAt,
     availableAt,
     businessCalendarDay,
-    isBusinessWithdrawalAllowedDate:
-      isBusinessWithdrawalAllowedDay(businessCalendarDay),
+    isBusinessWithdrawalAllowedDate: isBusinessWithdrawalAllowedDay(businessCalendarDay),
   };
 }
 
@@ -91,7 +88,7 @@ export async function getReadyInvestmentWithdrawalBatch(
 
 async function getTrustedDatabaseTime(): Promise<Date> {
   const [row] = await prisma.$queryRaw<TrustedClockRow[]>(
-    Prisma.sql`SELECT clock_timestamp() AS "trustedNow"`
+    Prisma.sql`SELECT clock_timestamp() AS "trustedNow"`,
   );
 
   return assertDate(row?.trustedNow, "trustedNow");


### PR DESCRIPTION
Closes #636

## Summary
- Parameterized the PostgreSQL `AT TIME ZONE` value in `withdrawalTimingService.ts` by replacing `Prisma.raw()` string interpolation with standard Prisma SQL parameter binding (`${businessTimeZone}`).
- Retained strict timezone validation with `assertSafeSqlTimeZone()` to validate IANA timezone strings before query construction.
- Added unit regression test in `withdrawalTimingService.test.ts` asserting that `businessTimeZone` is passed as a parameterized query value and not embedded in the SQL template fragment.

## Verification & Testing
- **ESLint**: Passed cleanly on `src/services/investment/withdrawalTimingService.ts` and `src/services/investment/withdrawalTimingService.test.ts`.
- **Prettier**: Passed formatting check on modified files.
- **Jest**: Passed 2/2 unit tests in `src/services/investment/withdrawalTimingService.test.ts`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of investment withdrawal timing across time zones.
  * Strengthened validation of business calendar dates before determining withdrawal eligibility.
  * Enhanced database query safety by using parameterized time zone values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->