### PR TITLE
fix: add missing crypto import in userController

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,3 +1,4 @@
+import crypto from "crypto";
 import { Response, NextFunction } from "express";
 import type { Prisma } from "@prisma/client";
 import { z } from "zod";


### PR DESCRIPTION
## Summary
- Added missing `import crypto from "crypto"` in `src/controllers/userController.ts`
- `crypto.randomUUID()` was used in `deleteMe()` without importing the module, which would cause a `ReferenceError` at runtime

## Fix
The `crypto` module from Node.js stdlib is now properly imported at the top of the file, resolving the missing import.

Closes #615