### PR TITLE
fix(burn): import missing extractIdempotencyKey in BurnController

### DIFF
--- a/src/controllers/burnController.ts
+++ b/src/controllers/burnController.ts
@@ -25,6 +25,7 @@ import {
 } from "../utils/decimalUtils";
 import { AppError } from "../middleware/errorHandler";
 import { getLatestAcbuRate } from "../services/rates/acbuRateCache";
+import { extractIdempotencyKey } from "../utils/idempotency";
 
 /** Best-effort stringify for Decimal-like values in Prisma models. */
 function toNullableStringDecimal(v: unknown): string | null {


### PR DESCRIPTION
## Summary
- Fixes the missing `extractIdempotencyKey` import in `burnController.ts` that caused a `ReferenceError` at runtime, making `/burn/acbu` completely non-functional.

## Test plan
- [x] Added `import { extractIdempotencyKey } from "../utils/idempotency";` to `src/controllers/burnController.ts`
- [x] Verified the function signature matches the call site at line 98
- [ ] Run full test suite / manual `/burn/acbu` smoke test in an environment with Node >=22 (this sandbox has Node 20, below the project's engine requirement, so `pnpm install`/`tsc` could not be run here)

Closes #568
Closes #571
Closes #573
Closes #576

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue that prevented burn operations from compiling and running correctly when using idempotency keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->