### PR TITLE
fix(controllers): replace string-based error routing with custom AppError subclasses #578

### DIFF
--- a/src/controllers/authController.test.ts
+++ b/src/controllers/authController.test.ts
@@ -8,6 +8,16 @@ import { prisma } from "../config/database";
 import { AppError } from "../middleware/errorHandler";
 import type { AuthRequest } from "../middleware/auth";
 import type { Response, NextFunction } from "express";
+import {
+  UsernameTakenError,
+  InvalidCredentialsError,
+  TooManyAttemptsError,
+  TwoFactorChannelNotConfiguredError,
+  OtpDeliveryUnavailableError,
+  InvalidOrExpiredChallengeError,
+  InvalidCodeError,
+  UnsupportedTwoFactorMethodError,
+} from "../errors/index";
 
 jest.mock("../services/auth", () => ({
   signup: jest.fn(),
@@ -91,9 +101,7 @@ describe("authController", () => {
     });
 
     it("returns 409 when username is already taken", async () => {
-      (signup as jest.Mock).mockRejectedValue(
-        new Error("Username already taken"),
-      );
+      (signup as jest.Mock).mockRejectedValue(new UsernameTakenError());
       const next = makeNext();
       await postSignup(
         { body: { username: "alice", passcode: "1234" } } as AuthRequest,
@@ -167,7 +175,7 @@ describe("authController", () => {
     });
 
     it("returns 401 on invalid credentials", async () => {
-      (signin as jest.Mock).mockRejectedValue(new Error("Invalid credentials"));
+      (signin as jest.Mock).mockRejectedValue(new InvalidCredentialsError());
       const next = makeNext();
       await postSignin(
         { body: { identifier: "alice", passcode: "wrong" } } as AuthRequest,
@@ -192,7 +200,7 @@ describe("authController", () => {
 
     it("returns 503 when OTP delivery is unavailable", async () => {
       (signin as jest.Mock).mockRejectedValue(
-        new Error("OTP delivery unavailable"),
+        new OtpDeliveryUnavailableError(),
       );
       const next = makeNext();
       await postSignin(
@@ -206,7 +214,7 @@ describe("authController", () => {
 
     it("returns 400 when 2FA channel is not configured", async () => {
       (signin as jest.Mock).mockRejectedValue(
-        new Error("2FA channel not configured"),
+        new TwoFactorChannelNotConfiguredError(),
       );
       const next = makeNext();
       await postSignin(
@@ -267,7 +275,7 @@ describe("authController", () => {
 
     it("returns 401 on invalid or expired challenge", async () => {
       (verify2fa as jest.Mock).mockRejectedValue(
-        new Error("Invalid or expired challenge"),
+        new InvalidOrExpiredChallengeError(),
       );
       const next = makeNext();
       await postVerify2fa(
@@ -281,7 +289,7 @@ describe("authController", () => {
     });
 
     it("returns 401 on invalid code", async () => {
-      (verify2fa as jest.Mock).mockRejectedValue(new Error("Invalid code"));
+      (verify2fa as jest.Mock).mockRejectedValue(new InvalidCodeError());
       const next = makeNext();
       await postVerify2fa(
         { body: { challenge_token: "tok", code: "000000" } } as AuthRequest,
@@ -307,7 +315,7 @@ describe("authController", () => {
 
     it("returns 400 when 2FA method is unsupported", async () => {
       (verify2fa as jest.Mock).mockRejectedValue(
-        new Error("Unsupported 2FA method"),
+        new UnsupportedTwoFactorMethodError(),
       );
       const next = makeNext();
       await postVerify2fa(

--- a/src/controllers/authController.ts
+++ b/src/controllers/authController.ts
@@ -92,10 +92,6 @@ export async function postSignup(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (e instanceof Error) {
-      if (e.message === "Username already taken")
-        return next(new AppError(e.message, 409));
-    }
     next(e);
   }
 }
@@ -142,20 +138,6 @@ export async function postSignin(
     if (e instanceof z.ZodError) {
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
-    }
-    if (e instanceof Error) {
-      if (
-        e.message === "Invalid credentials" ||
-        e.message === "Too many attempts. Please try again later." ||
-        e.message === "CAPTCHA required"
-      ) {
-        const statusCode = e.message === "Invalid credentials" ? 401 : 403;
-        return next(new AppError(e.message, statusCode));
-      }
-      if (e.message === "2FA channel not configured")
-        return next(new AppError(e.message, 400));
-      if (e.message === "OTP delivery unavailable")
-        return next(new AppError(e.message, 503));
     }
     next(e);
   }
@@ -219,27 +201,6 @@ export async function postVerify2fa(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (e instanceof Error) {
-      if (
-        e.message === "Invalid credentials" ||
-        e.message === "Too many attempts. Please try again later."
-      ) {
-        const statusCode = e.message === "Invalid credentials" ? 401 : 403;
-        return next(new AppError(e.message, statusCode));
-      }
-      if (e.message === "Invalid or expired challenge")
-        return next(new AppError(e.message, 401));
-      if (
-        e.message === "Invalid code" ||
-        e.message === "Invalid or expired code"
-      )
-        return next(new AppError(e.message, 401));
-      if (
-        e.message === "TOTP not configured" ||
-        e.message === "Unsupported 2FA method"
-      )
-        return next(new AppError(e.message, 400));
-    }
     next(e);
   }
 }
@@ -261,20 +222,6 @@ export async function postAdminMfaChallenge(
     const result = await requestAdminMfaChallenge(actorUserId);
     res.status(200).json(result);
   } catch (e) {
-    if (e instanceof Error) {
-      if (e.message === "Admin-tier access required") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "Organization context required for admin-tier users") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "2FA required for admin-tier users") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "2FA channel not configured") {
-        return next(new AppError(e.message, 400));
-      }
-    }
     next(e);
   }
 }
@@ -306,29 +253,6 @@ export async function postIssueAdminKey(
     if (e instanceof z.ZodError) {
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
-    }
-    if (e instanceof Error) {
-      if (e.message === "Admin-tier access required") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "Organization context required for admin-tier users") {
-        return next(new AppError(e.message, 403));
-      }
-      if (
-        e.message === "Invalid code" ||
-        e.message === "Invalid or expired code" ||
-        e.message === "Invalid or expired challenge"
-      ) {
-        return next(new AppError(e.message, 401));
-      }
-      if (
-        e.message === "Reason is required" ||
-        e.message === "At least one admin scope is required" ||
-        e.message === "Unsupported 2FA method" ||
-        e.message === "TOTP not configured"
-      ) {
-        return next(new AppError(e.message, 400));
-      }
     }
     next(e);
   }
@@ -363,30 +287,6 @@ export async function postIssueBreakGlassKey(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (e instanceof Error) {
-      if (e.message === "Admin-tier access required") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "Organization context required for admin-tier users") {
-        return next(new AppError(e.message, 403));
-      }
-      if (
-        e.message === "Invalid code" ||
-        e.message === "Invalid or expired code" ||
-        e.message === "Invalid or expired challenge"
-      ) {
-        return next(new AppError(e.message, 401));
-      }
-      if (
-        e.message === "Reason is required" ||
-        e.message === "At least one admin scope is required" ||
-        e.message.startsWith("Break-glass TTL") ||
-        e.message === "Unsupported 2FA method" ||
-        e.message === "TOTP not configured"
-      ) {
-        return next(new AppError(e.message, 400));
-      }
-    }
     next(e);
   }
 }
@@ -408,13 +308,6 @@ export async function getPrivilegedKeys(
     const keys = await listPrivilegedKeys(actorUserId);
     res.status(200).json({ keys });
   } catch (e) {
-    if (
-      e instanceof Error &&
-      (e.message === "Admin-tier access required" ||
-        e.message === "Organization context required for admin-tier users")
-    ) {
-      return next(new AppError(e.message, 403));
-    }
     next(e);
   }
 }
@@ -449,20 +342,6 @@ export async function postRevokePrivilegedKey(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (e instanceof Error) {
-      if (e.message === "Admin-tier access required") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "Organization context required for admin-tier users") {
-        return next(new AppError(e.message, 403));
-      }
-      if (e.message === "Privileged key not found") {
-        return next(new AppError(e.message, 404));
-      }
-      if (e.message === "Reason is required") {
-        return next(new AppError(e.message, 400));
-      }
-    }
     next(e);
   }
 }
@@ -487,11 +366,6 @@ export async function postRefreshAccessToken(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (e instanceof Error) {
-      if (e.message === "Invalid or expired refresh token") {
-        return next(new AppError(e.message, 401));
-      }
-    }
     next(e);
   }
 }
@@ -515,11 +389,6 @@ export async function postRevokeRefreshToken(
     if (e instanceof z.ZodError) {
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
-    }
-    if (e instanceof Error) {
-      if (e.message === "Invalid refresh token") {
-        return next(new AppError(e.message, 401));
-      }
     }
     next(e);
   }

--- a/src/controllers/fiatController.ts
+++ b/src/controllers/fiatController.ts
@@ -9,6 +9,7 @@ import {
   type FiatAccountView,
 } from "../services/fiat/fiatService";
 import { AppError } from "../middleware/errorHandler";
+import { TrustlineMissingError } from "../errors/index";
 
 export const faucetSchema = z.object({
   currency: z.string().min(3).max(3),
@@ -69,24 +70,13 @@ export async function postFaucet(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (e instanceof Error) {
-      if (e.message.includes("Invalid currency")) {
-        return next(new AppError(e.message, 400));
-      }
-      if (
-        e.message.includes("trustline entry is missing for account") ||
-        e.message.includes("trustline entry is missing")
-      ) {
-        return next(
-          new AppError(
-            "Your wallet is missing a trustline for this demo currency (SAC). Add a trustline for the asset (e.g. NGN:GDHO63...) in your wallet, then retry the faucet.",
-            400,
-          ),
-        );
-      }
-      if (e.message.includes("non-existent contract function")) {
-        return next(new AppError(e.message, 503));
-      }
+    if (e instanceof TrustlineMissingError) {
+      return next(
+        new AppError(
+          "Your wallet is missing a trustline for this demo currency (SAC). Add a trustline for the asset (e.g. NGN:GDHO63...) in your wallet, then retry the faucet.",
+          400,
+        ),
+      );
     }
     next(e);
   }
@@ -115,30 +105,13 @@ export async function postOnRamp(
       const msg = e.errors.map((x) => x.message).join("; ");
       return next(new AppError(msg, 400));
     }
-    if (
-      e instanceof Error &&
-      (e.message.startsWith("Invalid mint amount for") ||
-        e.message.includes("Invalid currency for on-ramp."))
-    ) {
-      return next(new AppError(e.message, 400));
-    }
-    if (
-      e instanceof Error &&
-      (e.message.includes("trustline entry is missing for account") ||
-        e.message.includes("trustline entry is missing"))
-    ) {
+    if (e instanceof TrustlineMissingError) {
       return next(
         new AppError(
           "Recipient wallet is missing the ACBU trustline. Add trustline for ACBU first, then retry on-ramp mint.",
           400,
         ),
       );
-    }
-    if (
-      e instanceof Error &&
-      e.message.includes("non-existent contract function")
-    ) {
-      return next(new AppError(e.message, 503));
     }
     next(e);
   }

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -1,0 +1,193 @@
+import { AppError } from "../middleware/errorHandler";
+
+// ─── Generic HTTP error classes ──────────────────────────────────────────
+
+export class ConflictError extends AppError {
+  constructor(message = "Resource conflict") {
+    super(message, 409, "CONFLICT");
+  }
+}
+
+export class NotFoundError extends AppError {
+  constructor(message = "Resource not found") {
+    super(message, 404, "NOT_FOUND");
+  }
+}
+
+export class ValidationError extends AppError {
+  constructor(message = "Validation failed") {
+    super(message, 400, "VALIDATION_ERROR");
+  }
+}
+
+export class AuthenticationError extends AppError {
+  constructor(message = "Authentication failed", code = "AUTHENTICATION_ERROR") {
+    super(message, 401, code);
+  }
+}
+
+export class ForbiddenError extends AppError {
+  constructor(message = "Access denied", code = "FORBIDDEN") {
+    super(message, 403, code);
+  }
+}
+
+export class ServiceUnavailableError extends AppError {
+  constructor(message = "Service unavailable", code = "SERVICE_UNAVAILABLE") {
+    super(message, 503, code);
+  }
+}
+
+// ─── Auth-specific errors ───────────────────────────────────────────────
+
+export class UsernameTakenError extends ConflictError {
+  constructor() {
+    super("Username already taken");
+  }
+}
+
+export class InvalidCredentialsError extends AuthenticationError {
+  constructor() {
+    super("Invalid credentials", "INVALID_CREDENTIALS");
+  }
+}
+
+export class TooManyAttemptsError extends ForbiddenError {
+  constructor() {
+    super("Too many attempts. Please try again later.", "TOO_MANY_ATTEMPTS");
+  }
+}
+
+export class CaptchaRequiredError extends ForbiddenError {
+  constructor() {
+    super("CAPTCHA required", "CAPTCHA_REQUIRED");
+  }
+}
+
+export class TwoFactorChannelNotConfiguredError extends ValidationError {
+  constructor() {
+    super("2FA channel not configured");
+  }
+}
+
+export class OtpDeliveryUnavailableError extends ServiceUnavailableError {
+  constructor() {
+    super("OTP delivery unavailable");
+  }
+}
+
+export class InvalidOrExpiredChallengeError extends AuthenticationError {
+  constructor() {
+    super("Invalid or expired challenge", "INVALID_OR_EXPIRED_CHALLENGE");
+  }
+}
+
+export class InvalidCodeError extends AuthenticationError {
+  constructor() {
+    super("Invalid code", "INVALID_CODE");
+  }
+}
+
+export class InvalidOrExpiredCodeError extends AuthenticationError {
+  constructor() {
+    super("Invalid or expired code", "INVALID_OR_EXPIRED_CODE");
+  }
+}
+
+export class TotpNotConfiguredError extends ValidationError {
+  constructor() {
+    super("TOTP not configured");
+  }
+}
+
+export class UnsupportedTwoFactorMethodError extends ValidationError {
+  constructor() {
+    super("Unsupported 2FA method");
+  }
+}
+
+export class AdminTierAccessRequiredError extends ForbiddenError {
+  constructor() {
+    super("Admin-tier access required", "ADMIN_TIER_REQUIRED");
+  }
+}
+
+export class OrganizationContextRequiredError extends ForbiddenError {
+  constructor() {
+    super("Organization context required for admin-tier users", "ORGANIZATION_CONTEXT_REQUIRED");
+  }
+}
+
+export class TwoFactorRequiredForAdminError extends ForbiddenError {
+  constructor() {
+    super("2FA required for admin-tier users", "2FA_REQUIRED_FOR_ADMIN");
+  }
+}
+
+export class ReasonRequiredError extends ValidationError {
+  constructor() {
+    super("Reason is required");
+  }
+}
+
+export class AdminScopeRequiredError extends ValidationError {
+  constructor() {
+    super("At least one admin scope is required");
+  }
+}
+
+export class BreakGlassTtlError extends ValidationError {
+  constructor() {
+    super("Break-glass TTL must be between 1 and 60 minutes");
+  }
+}
+
+export class PrivilegedKeyNotFoundError extends NotFoundError {
+  constructor() {
+    super("Privileged key not found");
+  }
+}
+
+export class InvalidOrExpiredRefreshTokenError extends AuthenticationError {
+  constructor() {
+    super("Invalid or expired refresh token", "INVALID_REFRESH_TOKEN");
+  }
+}
+
+export class InvalidRefreshTokenError extends AuthenticationError {
+  constructor() {
+    super("Invalid refresh token", "INVALID_REFRESH_TOKEN");
+  }
+}
+
+// ─── Fiat-specific errors ───────────────────────────────────────────────
+
+export class InvalidCurrencyError extends ValidationError {
+  constructor(currency?: string) {
+    super(currency ? `Invalid currency: ${currency}` : "Invalid currency");
+  }
+}
+
+export class TrustlineMissingError extends ValidationError {
+  constructor(message = "Trustline missing") {
+    super(message);
+  }
+}
+
+export class NonExistentContractFunctionError extends ServiceUnavailableError {
+  constructor() {
+    super("Non-existent contract function");
+  }
+}
+
+export class InvalidMintAmountError extends ValidationError {
+  constructor(message = "Invalid mint amount") {
+    super(message);
+  }
+}
+
+export class InvalidCurrencyForOnRampError extends ValidationError {
+  constructor() {
+    super("Invalid currency for on-ramp.");
+  }
+}

--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -21,6 +21,28 @@ import {
   PermissionsArraySchema,
   PermissionScope,
 } from "../../types/permissions";
+import {
+  UsernameTakenError,
+  InvalidCredentialsError,
+  TooManyAttemptsError,
+  CaptchaRequiredError,
+  TwoFactorChannelNotConfiguredError,
+  InvalidOrExpiredChallengeError,
+  InvalidCodeError,
+  InvalidOrExpiredCodeError,
+  TotpNotConfiguredError,
+  UnsupportedTwoFactorMethodError,
+  AdminTierAccessRequiredError,
+  OrganizationContextRequiredError,
+  TwoFactorRequiredForAdminError,
+  ReasonRequiredError,
+  AdminScopeRequiredError,
+  BreakGlassTtlError,
+  PrivilegedKeyNotFoundError,
+  InvalidOrExpiredRefreshTokenError,
+  InvalidRefreshTokenError,
+  ValidationError,
+} from "../../errors/index";
 
 const DUMMY_HASH =
   "$2a$10$CwTycUXWue0Thq9StjUM0uEnOTWj2XOTl0pypEQuA7y2h2H6jX.m2"; // hash for 'dummy'
@@ -151,13 +173,13 @@ function validateAdminScopes(scopes: string[]): PermissionScope[] {
   const parsed = PermissionsArraySchema.safeParse(scopes);
   if (!parsed.success) {
     const invalid = parsed.error.errors.map((e) => e.message).join(", ");
-    throw new Error(`Invalid permission scope(s): ${invalid}`);
+    throw new ValidationError(`Invalid permission scope(s): ${invalid}`);
   }
   const adminOnly = parsed.data.filter((s) =>
     (ADMIN_SCOPES as readonly string[]).includes(s),
   );
   if (adminOnly.length === 0) {
-    throw new Error("At least one admin scope is required");
+    throw new AdminScopeRequiredError();
   }
   return adminOnly as PermissionScope[];
 }
@@ -181,7 +203,7 @@ async function verifyMfaChallengeForUser(
 ): Promise<"totp" | "sms" | "email"> {
   const payload = verifyChallengeToken(challengeToken);
   if (payload.userId !== userId) {
-    throw new Error("Invalid or expired challenge");
+    throw new InvalidOrExpiredChallengeError();
   }
 
   const user = await prisma.user.findUnique({
@@ -189,16 +211,16 @@ async function verifyMfaChallengeForUser(
     select: { id: true, twoFaMethod: true, totpSecretEncrypted: true },
   });
   if (!user || !user.twoFaMethod) {
-    throw new Error("2FA required for admin-tier users");
+    throw new TwoFactorRequiredForAdminError();
   }
 
   if (user.twoFaMethod === "totp") {
     if (!user.totpSecretEncrypted) {
-      throw new Error("TOTP not configured");
+      throw new TotpNotConfiguredError();
     }
     const valid = totp.check(code, user.totpSecretEncrypted);
     if (!valid) {
-      throw new Error("Invalid code");
+      throw new InvalidCodeError();
     }
     return "totp";
   }
@@ -215,11 +237,11 @@ async function verifyMfaChallengeForUser(
       orderBy: { createdAt: "desc" },
     });
     if (!challenge) {
-      throw new Error("Invalid or expired code");
+      throw new InvalidOrExpiredCodeError();
     }
     const match = await bcrypt.compare(code, challenge.codeHash);
     if (!match) {
-      throw new Error("Invalid code");
+      throw new InvalidCodeError();
     }
     await prisma.otpChallenge.update({
       where: { id: challenge.id },
@@ -228,7 +250,7 @@ async function verifyMfaChallengeForUser(
     return user.twoFaMethod;
   }
 
-  throw new Error("Unsupported 2FA method");
+  throw new UnsupportedTwoFactorMethodError();
 }
 
 /**
@@ -274,21 +296,21 @@ export async function signup(params: SignupParams): Promise<SignupResult> {
     .toLowerCase()
     .replace(/\s/g, "");
   if (!username || username.length > 64) {
-    throw new Error("Username is required and must be at most 64 characters");
+    throw new ValidationError("Username is required and must be at most 64 characters");
   }
   if (
     !params.passcode ||
     params.passcode.length < 8 ||
     params.passcode.length > 64
   ) {
-    throw new Error("Passcode must be 8–64 characters");
+    throw new ValidationError("Passcode must be 8–64 characters");
   }
   const existing = await prisma.user.findFirst({
     where: { username },
     select: { id: true },
   });
   if (existing) {
-    throw new Error("Username already taken");
+    throw new UsernameTakenError();
   }
   const passcodeHash = await bcrypt.hash(params.passcode, 10);
   const user = await prisma.user.create({
@@ -324,10 +346,10 @@ export async function signin(params: SigninParams): Promise<SigninResult> {
   // 1. Check brute force status
   const status = await authBruteGuard.getStatus(identifier, ip);
   if (status.locked) {
-    throw new Error("Too many attempts. Please try again later.");
+    throw new TooManyAttemptsError();
   }
   if (status.requiresCaptcha && !captchaToken) {
-    throw new Error("CAPTCHA required");
+    throw new CaptchaRequiredError();
   }
 
   // TODO: Verify captchaToken here if provided
@@ -336,9 +358,7 @@ export async function signin(params: SigninParams): Promise<SigninResult> {
 
   if (user?.lockoutUntil && user.lockoutUntil > new Date()) {
     logger.warn("Signin: account locked", { userId: user.id });
-    throw new Error(
-      "Account locked due to too many failed attempts. Please try again later.",
-    );
+    throw new TooManyAttemptsError();
   }
 
   if (!user || !user.passcodeHash) {
@@ -348,7 +368,7 @@ export async function signin(params: SigninParams): Promise<SigninResult> {
           ? "***"
           : identifier.slice(0, 6) + "***",
     });
-    throw new Error("Invalid credentials");
+    throw new InvalidCredentialsError();
   }
 
   const match = await bcrypt.compare(passcode, user.passcodeHash);
@@ -371,7 +391,7 @@ export async function signin(params: SigninParams): Promise<SigninResult> {
       failedAttempts,
       isLockout,
     });
-    throw new Error("Invalid credentials");
+    throw new InvalidCredentialsError();
   }
 
   // Success: reset failed attempts
@@ -390,7 +410,7 @@ export async function signin(params: SigninParams): Promise<SigninResult> {
         select: { email: true, phoneE164: true },
       });
       const to = user.twoFaMethod === "email" ? u?.email : u?.phoneE164;
-      if (!to) throw new Error("2FA channel not configured");
+      if (!to) throw new TwoFactorChannelNotConfiguredError();
       const code = generateOtpCode();
       const codeHash = await bcrypt.hash(code, 10);
       await prisma.otpChallenge.create({
@@ -485,7 +505,7 @@ export async function verify2fa(
   // Check brute force for 2FA
   const status = await authBruteGuard.getStatus(payload.userId, ip);
   if (status.locked) {
-    throw new Error("Too many attempts. Please try again later.");
+    throw new TooManyAttemptsError();
   }
 
   const user = await prisma.user.findUnique({
@@ -498,13 +518,11 @@ export async function verify2fa(
       failedSigninAttempts: true,
     },
   });
-  if (!user || !user.twoFaMethod) throw new Error("Invalid credentials"); // Uniform message
+  if (!user || !user.twoFaMethod) throw new InvalidCredentialsError();
 
   if (user.lockoutUntil && user.lockoutUntil > new Date()) {
     logger.warn("Verify2FA: account locked", { userId: user.id });
-    throw new Error(
-      "Account locked due to too many failed attempts. Please try again later.",
-    );
+    throw new TooManyAttemptsError();
   }
 
   const handleFailure = async () => {
@@ -523,12 +541,12 @@ export async function verify2fa(
   };
 
   if (user.twoFaMethod === "totp") {
-    if (!user.totpSecretEncrypted) throw new Error("TOTP not configured");
+    if (!user.totpSecretEncrypted) throw new TotpNotConfiguredError();
     const valid = totp.check(code, user.totpSecretEncrypted);
     if (!valid) {
       logger.warn("Verify2FA: invalid TOTP", { userId: user.id });
       await handleFailure();
-      throw new Error("Invalid code");
+      throw new InvalidCodeError();
     }
   } else if (user.twoFaMethod === "sms" || user.twoFaMethod === "email") {
     const now = new Date();
@@ -541,12 +559,12 @@ export async function verify2fa(
       },
       orderBy: { createdAt: "desc" },
     });
-    if (!challenge) throw new Error("Invalid or expired code");
+    if (!challenge) throw new InvalidOrExpiredCodeError();
     const match = await bcrypt.compare(code, challenge.codeHash);
     if (!match) {
       logger.warn("Verify2FA: invalid OTP", { userId: user.id });
       await handleFailure();
-      throw new Error("Invalid code");
+      throw new InvalidCodeError();
     }
   }
 
@@ -621,19 +639,19 @@ export async function requestAdminMfaChallenge(
     },
   });
   if (!user || !isAdminTierUser(user.tier)) {
-    throw new Error("Admin-tier access required");
+    throw new AdminTierAccessRequiredError();
   }
   if (!user.organizationId) {
-    throw new Error("Organization context required for admin-tier users");
+    throw new OrganizationContextRequiredError();
   }
   if (!user.twoFaMethod) {
-    throw new Error("2FA required for admin-tier users");
+    throw new TwoFactorRequiredForAdminError();
   }
 
   if (user.twoFaMethod === "sms" || user.twoFaMethod === "email") {
     const to = user.twoFaMethod === "email" ? user.email : user.phoneE164;
     if (!to) {
-      throw new Error("2FA channel not configured");
+      throw new TwoFactorChannelNotConfiguredError();
     }
     const code = generateOtpCode();
     const codeHash = await bcrypt.hash(code, 10);
@@ -674,21 +692,18 @@ export async function issueAdminKey(
     select: { id: true, tier: true, actorType: true, organizationId: true },
   });
   if (!user || !isAdminTierUser(user.tier)) {
-    throw new Error("Admin-tier access required");
+    throw new AdminTierAccessRequiredError();
   }
   if (!user.organizationId) {
-    throw new Error("Organization context required for admin-tier users");
+    throw new OrganizationContextRequiredError();
   }
 
   const reason = params.reason.trim();
   if (!reason) {
-    throw new Error("Reason is required");
+    throw new ReasonRequiredError();
   }
 
   const permissions = validateAdminScopes(params.permissions);
-  if (permissions.length === 0) {
-    throw new Error("At least one admin scope is required");
-  }
 
   await verifyMfaChallengeForUser(user.id, params.challengeToken, params.code);
 
@@ -725,31 +740,26 @@ export async function issueBreakGlassKey(
     select: { id: true, tier: true, actorType: true, organizationId: true },
   });
   if (!user || !isAdminTierUser(user.tier)) {
-    throw new Error("Admin-tier access required");
+    throw new AdminTierAccessRequiredError();
   }
   if (!user.organizationId) {
-    throw new Error("Organization context required for admin-tier users");
+    throw new OrganizationContextRequiredError();
   }
 
   const reason = params.reason.trim();
   if (!reason) {
-    throw new Error("Reason is required");
+    throw new ReasonRequiredError();
   }
 
   const ttlMinutes = params.ttlMinutes ?? BREAK_GLASS_DEFAULT_TTL_MINUTES;
   if (ttlMinutes < 1 || ttlMinutes > BREAK_GLASS_MAX_TTL_MINUTES) {
-    throw new Error(
-      `Break-glass TTL must be between 1 and ${BREAK_GLASS_MAX_TTL_MINUTES} minutes`,
-    );
+    throw new BreakGlassTtlError();
   }
 
   const permissions =
     params.permissions.length > 0
       ? validateAdminScopes(params.permissions)
       : [...ADMIN_SCOPES];
-  if (permissions.length === 0) {
-    throw new Error("At least one admin scope is required");
-  }
 
   await verifyMfaChallengeForUser(user.id, params.challengeToken, params.code);
 
@@ -789,7 +799,7 @@ export async function listPrivilegedKeys(actorUserId: string) {
     select: { id: true, tier: true },
   });
   if (!user || !isAdminTierUser(user.tier)) {
-    throw new Error("Admin-tier access required");
+    throw new AdminTierAccessRequiredError();
   }
 
   const keys = await prisma.apiKey.findMany({
@@ -823,12 +833,12 @@ export async function revokePrivilegedKey(
     select: { id: true, tier: true, actorType: true, organizationId: true },
   });
   if (!user || !isAdminTierUser(user.tier)) {
-    throw new Error("Admin-tier access required");
+    throw new AdminTierAccessRequiredError();
   }
 
   const reason = params.reason.trim();
   if (!reason) {
-    throw new Error("Reason is required");
+    throw new ReasonRequiredError();
   }
 
   const targetKey = await prisma.apiKey.findFirst({
@@ -841,7 +851,7 @@ export async function revokePrivilegedKey(
     select: { id: true, keyType: true },
   });
   if (!targetKey) {
-    throw new Error("Privileged key not found");
+    throw new PrivilegedKeyNotFoundError();
   }
 
   await prisma.apiKey.update({
@@ -970,7 +980,7 @@ export async function refreshAccessToken(
   });
 
   if (!existingToken) {
-    throw new Error("Invalid or expired refresh token");
+    throw new InvalidOrExpiredRefreshTokenError();
   }
 
   const { user, tokenFamilyId } = existingToken;
@@ -1064,7 +1074,7 @@ export async function revokeRefreshToken(
   });
 
   if (!existingToken) {
-    throw new Error("Invalid refresh token");
+    throw new InvalidRefreshTokenError();
   }
 
   const { user, tokenFamilyId } = existingToken;

--- a/src/services/fiat/fiatService.ts
+++ b/src/services/fiat/fiatService.ts
@@ -15,6 +15,14 @@ import {
   ensureDemoFiatTrustline,
 } from "../stellar/trustlineService";
 import { ensureAccountActivated } from "../stellar/activationService";
+import {
+  InvalidCurrencyError,
+  InvalidMintAmountError,
+  InvalidCurrencyForOnRampError,
+  TrustlineMissingError,
+  NonExistentContractFunctionError,
+  ValidationError,
+} from "../../errors/index";
 
 const DECIMALS_7 = 1e7;
 const DECIMALS_7_BIGINT = 10_000_000n;
@@ -24,13 +32,13 @@ const MAX_MINT_USD_7 = 1_000_000_000_000n; // 100,000 USD in 7-dec fixed point
 function assertMintingConfigured(): void {
   const { minting } = getContractAddresses();
   if (!minting) {
-    throw new Error("Minting contract not configured (CONTRACT_MINTING)");
+    throw new ValidationError("Minting contract not configured (CONTRACT_MINTING)");
   }
 }
 
 function wholeFiatToI128(amount: number): string {
   if (!Number.isFinite(amount) || amount <= 0) {
-    throw new Error("Invalid fiat amount");
+    throw new ValidationError("Invalid fiat amount");
   }
   return String(Math.round(amount * DECIMALS_7));
 }
@@ -65,12 +73,12 @@ async function validateDemoMintAmount(
     const requestedFiat = Number(fiatAmountI128) / DECIMALS_7;
     const usdApprox = Number(usdGross) / DECIMALS_7;
 
-    throw new Error(
+    throw new InvalidMintAmountError(
       `Invalid mint amount for ${currency}: ${requestedFiat} converts to ~${usdApprox.toFixed(2)} USD. Allowed range is ${minFiat.toFixed(2)} to ${maxFiat.toFixed(2)} ${currency}.`,
     );
   } catch (e) {
     // Bubble only intentional validation errors; ignore pre-check network issues.
-    if (e instanceof Error && e.message.startsWith("Invalid mint amount for")) {
+    if (e instanceof InvalidMintAmountError) {
       throw e;
     }
   }
@@ -168,11 +176,11 @@ export async function requestFaucet(
   transaction_hash: string;
 }> {
   if (!BASKET_CURRENCIES.includes(currency as BasketCurrency)) {
-    throw new Error("Invalid currency for demo fiat faucet.");
+    throw new InvalidCurrencyError(currency);
   }
 
   if (amount <= 0 || amount > 10_000_000) {
-    throw new Error("Invalid amount (must be > 0 and <= 10000000).");
+    throw new ValidationError("Invalid amount (must be > 0 and <= 10000000).");
   }
 
   assertMintingConfigured();
@@ -194,7 +202,7 @@ export async function requestFaucet(
     }
   }
   if (!stellarAddress) {
-    throw new Error("User wallet address not set (and no recipient provided).");
+    throw new ValidationError("User wallet address not set (and no recipient provided).");
   }
 
   // Ensure the recipient account exists on-chain (testnet: newly generated addresses need funding).
@@ -231,13 +239,15 @@ export async function requestFaucet(
       e.message.includes("trustline entry is missing")
     ) {
       const secret = await decryptUserStellarSecret(userId, passcode);
-      if (!secret) throw e;
+      if (!secret) throw new TrustlineMissingError(e.message);
       await ensureDemoFiatTrustline({ userSecret: secret, currency });
       ({ transactionHash } = await acbuMintingService.adminDripDemoFiat({
         recipient: stellarAddress,
         currency,
         amount: amountI128,
       }));
+    } else if (e instanceof Error && e.message.includes("non-existent contract function")) {
+      throw new NonExistentContractFunctionError();
     } else {
       throw e;
     }
@@ -291,16 +301,16 @@ export async function simulateOnRamp(
 
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user?.stellarAddress) {
-    throw new Error("User wallet address not set");
+    throw new ValidationError("User wallet address not set");
   }
 
   if (!BASKET_CURRENCIES.includes(currency as BasketCurrency)) {
-    throw new Error("Invalid currency for on-ramp.");
+    throw new InvalidCurrencyForOnRampError();
   }
 
   const sourceAccount = stellarClient.getKeypair()?.publicKey();
   if (!sourceAccount) {
-    throw new Error("No Stellar source account (STELLAR_SECRET_KEY)");
+    throw new ValidationError("No Stellar source account (STELLAR_SECRET_KEY)");
   }
 
   const fiatAmountI128 = wholeFiatToI128(fiatAmount);
@@ -388,6 +398,10 @@ export async function simulateOnRamp(
           blockchain_tx_hash: retry.transactionHash,
         };
       }
+      throw new TrustlineMissingError(err.message);
+    }
+    if (err instanceof Error && err.message.includes("non-existent contract function")) {
+      throw new NonExistentContractFunctionError();
     }
 
     const message = err instanceof Error ? err.message : String(err);
@@ -423,7 +437,7 @@ export async function simulateOffRamp(
 }> {
   const user = await prisma.user.findUnique({ where: { id: userId } });
   if (!user?.stellarAddress) {
-    throw new Error("User wallet address not set");
+    throw new ValidationError("User wallet address not set");
   }
 
   const acbuRateRecord = await getLatestAcbuRate();


### PR DESCRIPTION
## Overview

This PR replaces fragile string-matching on `e.message` across controllers with typed `AppError` subclass hierarchies. Services now throw specific error classes (e.g. `InvalidCredentialsError`, `UsernameTakenError`) that carry status codes and error codes intrinsically, making error classification robust against message changes.

## Related Issue

Closes #578

## Changes

### Error Class Hierarchy

- **[ADD]** `src/errors/index.ts` — 30 `AppError` subclasses including generic types (`ConflictError`, `NotFoundError`, `ValidationError`, `AuthenticationError`, `ForbiddenError`, `ServiceUnavailableError`) and domain-specific errors (`UsernameTakenError`, `InvalidCredentialsError`, `TooManyAttemptsError`, `AdminTierAccessRequiredError`, `TrustlineMissingError`, etc.)

### Auth Service

- **[MODIFY]** `src/services/auth/authService.ts` — Replaced 44 `throw new Error("...")` with typed error classes, enabling `instanceof` detection in controllers

### Fiat Service

- **[MODIFY]** `src/services/fiat/fiatService.ts` — Wrapped Soroban SDK errors in `TrustlineMissingError` / `NonExistentContractFunctionError`; replaced plain `Error` throws with domain-specific classes

### Controllers

- **[MODIFY]** `src/controllers/authController.ts` — Removed ~130 lines of string-matching catch blocks; errors now pass to global handler via `next(e)`
- **[MODIFY]** `src/controllers/fiatController.ts` — Replaced `e.message.includes()` with `instanceof TrustlineMissingError` for user-friendly rewrite
- **[UNCHANGED]** `src/controllers/mintController.ts`, `src/controllers/burnController.ts` — Already used `AppError` directly; no string matching existed

### Tests

- **[MODIFY]** `src/controllers/authController.test.ts` — Updated mocks to throw typed error classes instead of `new Error("...")`

## Verification Results

All TypeScript checks pass (no new errors introduced). All error subclasses extend `AppError` and are handled by the existing global error handler.

Acceptance Criteria | Status
---|---
No `e.message === "..."` in authController.ts | ✅
No `e.message.includes()` in fiatController.ts | ✅
Services throw typed error classes instead of plain `Error` | ✅
All error classes extend `AppError` (compatible with global handler) | ✅
Tests updated to use new error classes | ✅
