### PR TITLE
fix: remove unused crypto import in userController

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,4 +1,3 @@
-import crypto from "crypto";
 import { Response, NextFunction } from "express";
 import type { Prisma } from "@prisma/client";
 import { z } from "zod";


### PR DESCRIPTION
## Summary
- Remove the unused `import crypto from "crypto"` at the top of `src/controllers/userController.ts`.

## Details
The `crypto` module was imported but never referenced anywhere in the file. This is dead code that adds unnecessary weight to the module graph and could trigger unused-import lint warnings.

## Changes
- `src/controllers/userController.ts`: Removed `import crypto from "crypto";` (line 1)

## Verification
- Confirmed via grep that `crypto` had zero usages beyond the import itself.
- The `deleteMe` function and all other exports do not use `crypto.randomUUID` or any other `crypto` API.

Closes #615