### PR TITLE
Fix #572: MongoRateLimitStore falls back to in-memory limiter when Mo…

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -341,8 +341,10 @@ async function startServer() {
       }
     } else {
       logger.warn("MONGODB_URI not set; cache will be disabled.");
+      logger.warn(
+        "Rate limiters will run in degraded in-memory fallback mode. Limits are per-instance, not shared across replicas.",
+      );
     }
-
     // Connect to RabbitMQ (optional: server starts even if unreachable or credentials invalid)
     let rabbitReady = false;
     if (config.rabbitmqUrl) {

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -138,78 +138,125 @@ class MongoRateLimitStore implements Store {
   }
 
   async increment(key: string): Promise<ClientRateLimitInfo> {
-    const db = getMongoDB();
-    const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
-    const now = new Date();
-    const expiresAt = new Date(now.getTime() + this.windowMs);
-    const namespacedKey = this.buildKey(key);
+    try {
+      const db = getMongoDB();
+      const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
+      const now = new Date();
+      const expiresAt = new Date(now.getTime() + this.windowMs);
+      const namespacedKey = this.buildKey(key);
 
-    const result = await collection.findOneAndUpdate(
-      { key: namespacedKey },
-      {
-        $inc: { "value.count": 1 },
-        $set: {
-          updatedAt: now,
-          expiresAt,
-          namespace: this.prefix,
+      const result = await collection.findOneAndUpdate(
+        { key: namespacedKey },
+        {
+          $inc: { "value.count": 1 },
+          $set: {
+            updatedAt: now,
+            expiresAt,
+            namespace: this.prefix,
+          },
+          $setOnInsert: {
+            key: namespacedKey,
+            namespace: this.prefix,
+            value: { count: 0 },
+          },
         },
-        $setOnInsert: {
-          key: namespacedKey,
-          namespace: this.prefix,
-          value: { count: 0 },
-        },
-      },
-      { upsert: true, returnDocument: "after" },
-    );
+        { upsert: true, returnDocument: "after" },
+      );
 
-    const doc = result?.value as unknown as RateLimitDocument | null;
-    const totalHits = doc?.value?.count ?? 1;
-    return {
-      totalHits,
-      resetTime: doc?.expiresAt ?? expiresAt,
-    };
+      const doc = result?.value as unknown as RateLimitDocument | null;
+      const totalHits = doc?.value?.count ?? 1;
+      return {
+        totalHits,
+        resetTime: doc?.expiresAt ?? expiresAt,
+      };
+    } catch (error) {
+      logger.error("MongoRateLimitStore.increment failed, using in-memory fallback", {
+        namespace: this.prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      fallbackMetrics.failuresTotal++;
+      fallbackMetrics.lastFailureAt = Date.now();
+      fallbackMetrics.fallbackActivations++;
+
+      const fallbackKey = `${this.prefix}:${key}`;
+      const result = incrementFallback(fallbackKey, this.windowMs);
+      return {
+        totalHits: result.count,
+        resetTime: new Date(Date.now() + this.windowMs),
+      };
+    }
   }
 
   async decrement(key: string): Promise<void> {
-    const db = getMongoDB();
-    const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
-    await collection.updateOne(
-      { key: this.buildKey(key) },
-      {
-        $inc: { "value.count": -1 },
-        $set: { updatedAt: new Date() },
-      },
-    );
+    try {
+      const db = getMongoDB();
+      const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
+      await collection.updateOne(
+        { key: this.buildKey(key) },
+        {
+          $inc: { "value.count": -1 },
+          $set: { updatedAt: new Date() },
+        },
+      );
+    } catch (error) {
+      logger.warn("MongoRateLimitStore.decrement failed, skipping (in-memory fallback has no decrement)", {
+        namespace: this.prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async resetKey(key: string): Promise<void> {
-    const db = getMongoDB();
-    const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
-    await collection.deleteOne({ key: this.buildKey(key) });
+    try {
+      const db = getMongoDB();
+      const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
+      await collection.deleteOne({ key: this.buildKey(key) });
+    } catch (error) {
+      logger.warn("MongoRateLimitStore.resetKey failed", {
+        namespace: this.prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      fallbackRateLimitStore.delete(`${this.prefix}:${key}`);
+    }
   }
 
   async resetAll(): Promise<void> {
-    const db = getMongoDB();
-    const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
-    await collection.deleteMany({ namespace: this.prefix });
+    try {
+      const db = getMongoDB();
+      const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
+      await collection.deleteMany({ namespace: this.prefix });
+    } catch (error) {
+      logger.warn("MongoRateLimitStore.resetAll failed", {
+        namespace: this.prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
   }
 
   async get(key: string): Promise<ClientRateLimitInfo | undefined> {
-    const db = getMongoDB();
-    const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
-    const doc = (await collection.findOne({
-      key: this.buildKey(key),
-      expiresAt: { $gt: new Date() },
-    })) as RateLimitDocument | null;
+    try {
+      const db = getMongoDB();
+      const collection = db.collection<RateLimitDocument>(RATE_LIMIT_COLLECTION);
+      const doc = (await collection.findOne({
+        key: this.buildKey(key),
+        expiresAt: { $gt: new Date() },
+      })) as RateLimitDocument | null;
 
-    if (!doc) {
+      if (!doc) {
+        return undefined;
+      }
+
+      return {
+        totalHits: doc.value.count,
+        resetTime: doc.expiresAt,
+      };
+    } catch (error) {
+      logger.warn("MongoRateLimitStore.get failed", {
+        namespace: this.prefix,
+        error: error instanceof Error ? error.message : String(error),
+      });
       return undefined;
     }
-
-    return {
-      totalHits: doc.value.count,
-      resetTime: doc.expiresAt,
-    };
   }
 
   private buildKey(key: string): string {


### PR DESCRIPTION
Closes #572

## Summary
MongoRateLimitStore's methods (increment, decrement, resetKey, resetAll, get) previously called getMongoDB() with no error handling, so when MONGODB_URI is unset or Mongo is unreachable, the store throws — meaning rate limiting either crashes requests or silently doesn't enforce, per the issue.

Fix wraps each method in try/catch. increment() (the method that actually enforces limits per-request) falls back to the existing in-memory fallbackRateLimitStore/incrementFallback pattern already used elsewhere in this file for cache-outage handling — same fallback metrics and logging conventions. The other methods (decrement, resetKey, resetAll, get) degrade gracefully by logging a warning and no-op'ing/returning undefined, since they're secondary operations.

Added a startup warning in index.ts next to the existing "MONGODB_URI not set; cache will be disabled" log, so ops has visibility when rate limiting is running in degraded per-instance mode.

In-memory fallback is per-process — if this service runs multiple replicas, each enforces its own limit independently rather than a shared one. This matches the existing tradeoff already accepted in apiKeyRateLimiter's fallback path, not a new gap introduced here.

## Scope
- [x] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [x] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #572
- Related PR(s):

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Rate limiting now continues operating with an in-memory fallback when database connectivity fails.
  - Database errors during rate-limit updates and resets no longer interrupt requests.
  - Improved handling of rate-limit status checks when the database is unavailable.
  - Added clearer startup warnings when rate limiting runs in per-instance fallback mode without a database connection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->