### PR TITLE
fix(config): detect and reject placeholder fintech keys (#600)

### DIFF
--- a/src/config/env.test.ts
+++ b/src/config/env.test.ts
@@ -1,0 +1,33 @@
+process.env.USDC_ISSUER_TESTNET = "GBBD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+process.env.USDC_ISSUER_MAINNET = "GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+process.env.JWT_SECRET = "dev-jwt-secret-change-me-min-32-characters-long";
+process.env.DATABASE_URL = "postgresql://acbu_user:acbu_pass@localhost:5432/acbu_db";
+
+import { isPlaceholderKey } from "./env";
+
+describe("isPlaceholderKey", () => {
+  it("returns true for undefined, null, or empty string", () => {
+    expect(isPlaceholderKey(undefined)).toBe(true);
+    expect(isPlaceholderKey(null)).toBe(true);
+    expect(isPlaceholderKey("")).toBe(true);
+    expect(isPlaceholderKey("   ")).toBe(true);
+  });
+
+  it("returns true for common placeholder strings", () => {
+    expect(isPlaceholderKey("Flutterwave secret key")).toBe(true);
+    expect(isPlaceholderKey("Paystack secret key")).toBe(true);
+    expect(isPlaceholderKey("MTN MoMo subscription key")).toBe(true);
+    expect(isPlaceholderKey("MTN MoMo API user ID")).toBe(true);
+    expect(isPlaceholderKey("MTN MoMo API key")).toBe(true);
+    expect(isPlaceholderKey("change-me")).toBe(true);
+    expect(isPlaceholderKey("change-me-in-production")).toBe(true);
+    expect(isPlaceholderKey("your-flutterwave-secret-key")).toBe(true);
+    expect(isPlaceholderKey("your-paystack-secret-key")).toBe(true);
+  });
+
+  it("returns false for legitimate production API keys", () => {
+    expect(isPlaceholderKey("FLWSECK-f89a712bc9d02e48fa-X")).toBe(false);
+    expect(isPlaceholderKey("ps_valid_key_9281729381723918237192837")).toBe(false);
+    expect(isPlaceholderKey("4b8a21f7c9e0482b1732940a")).toBe(false);
+  });
+});

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -154,21 +154,72 @@ const s3ScanWebhookSecret = process.env.S3_SCAN_WEBHOOK_SECRET?.trim() || "chang
 if (parsed.data.NODE_ENV === "production" && s3ScanWebhookSecret === "change-me-in-production") {
   throw new Error("Missing required environment variable: S3_SCAN_WEBHOOK_SECRET");
 }
-// #382: Fintech partner keys must never be absent in production — an empty
-// Authorization header would be silently accepted by axios and only fail at
-// the first live API call, making the error hard to trace.  Fail at boot
-// instead so a misconfigured deployment is caught before it reaches traffic.
+// #600: Detect placeholder strings like 'Flutterwave secret key', 'Paystack secret key', etc.
+export function isPlaceholderKey(value?: string | null): boolean {
+  if (!value || typeof value !== "string") return true;
+  const trimmed = value.trim();
+  if (!trimmed) return true;
+
+  const lower = trimmed.toLowerCase();
+
+  const knownPlaceholders = [
+    "flutterwave secret key",
+    "flutterwave public key",
+    "flutterwave encryption key",
+    "flutterwave webhook secret",
+    "paystack secret key",
+    "mtn momo subscription key",
+    "mtn momo api user id",
+    "mtn momo api key",
+    "bills webhook secret",
+    "change-me",
+    "change-me-in-production",
+    "your-flutterwave-secret-key",
+    "your-paystack-secret-key",
+    "your-mtn-momo-subscription-key",
+    "your-stellar-secret-key-here",
+    "your-64-char-hex-key-here",
+    "your-access-key-id",
+    "your-secret-access-key",
+  ];
+
+  if (knownPlaceholders.includes(lower)) return true;
+
+  const patterns = [
+    /^flutterwave\s+(secret|public|encryption|webhook)\s*(key|secret)?$/i,
+    /^paystack\s+(secret|public)\s*key?$/i,
+    /^mtn\s*momo\s+(subscription|api|user)\s*(key|id)?$/i,
+    /^your[-_\s]/i,
+    /[-_]key[-_]here$/i,
+    /^placeholder$/i,
+    /^change[-_]?me/i,
+  ];
+
+  return patterns.some((p) => p.test(trimmed));
+}
+
+// #382 & #600: Fintech partner keys must never be absent or set to placeholder strings in production.
 if (parsed.data.NODE_ENV === "production") {
-  const missingFintechKeys: string[] = [];
-  if (!process.env.FLUTTERWAVE_SECRET_KEY) missingFintechKeys.push("FLUTTERWAVE_SECRET_KEY");
-  if (!process.env.FLUTTERWAVE_WEBHOOK_SECRET)
-    missingFintechKeys.push("FLUTTERWAVE_WEBHOOK_SECRET");
-  if (!process.env.PAYSTACK_SECRET_KEY) missingFintechKeys.push("PAYSTACK_SECRET_KEY");
-  if (!process.env.BILLS_WEBHOOK_SECRET) missingFintechKeys.push("BILLS_WEBHOOK_SECRET");
-  if (missingFintechKeys.length > 0) {
+  const invalidFintechKeys: string[] = [];
+  if (!process.env.FLUTTERWAVE_SECRET_KEY || isPlaceholderKey(process.env.FLUTTERWAVE_SECRET_KEY))
+    invalidFintechKeys.push("FLUTTERWAVE_SECRET_KEY");
+  if (!process.env.FLUTTERWAVE_WEBHOOK_SECRET || isPlaceholderKey(process.env.FLUTTERWAVE_WEBHOOK_SECRET))
+    invalidFintechKeys.push("FLUTTERWAVE_WEBHOOK_SECRET");
+  if (!process.env.PAYSTACK_SECRET_KEY || isPlaceholderKey(process.env.PAYSTACK_SECRET_KEY))
+    invalidFintechKeys.push("PAYSTACK_SECRET_KEY");
+  if (!process.env.BILLS_WEBHOOK_SECRET || isPlaceholderKey(process.env.BILLS_WEBHOOK_SECRET))
+    invalidFintechKeys.push("BILLS_WEBHOOK_SECRET");
+  if (!process.env.MTN_MOMO_SUBSCRIPTION_KEY || isPlaceholderKey(process.env.MTN_MOMO_SUBSCRIPTION_KEY))
+    invalidFintechKeys.push("MTN_MOMO_SUBSCRIPTION_KEY");
+  if (!process.env.MTN_MOMO_API_USER_ID || isPlaceholderKey(process.env.MTN_MOMO_API_USER_ID))
+    invalidFintechKeys.push("MTN_MOMO_API_USER_ID");
+  if (!process.env.MTN_MOMO_API_KEY || isPlaceholderKey(process.env.MTN_MOMO_API_KEY))
+    invalidFintechKeys.push("MTN_MOMO_API_KEY");
+
+  if (invalidFintechKeys.length > 0) {
     throw new Error(
-      `Missing required fintech API keys in production: ${missingFintechKeys.join(", ")}. ` +
-        "Inject these via environment variables — never commit them to source control. " +
+      `Missing or placeholder required fintech API keys in production: ${invalidFintechKeys.join(", ")}. ` +
+        "Inject valid API keys via environment variables — never commit them to source control. " +
         "Rotate any key that may have been exposed before redeploying.",
     );
   }
@@ -242,24 +293,42 @@ export const config = {
 
   // Fintech APIs
   flutterwave: {
-    publicKey: process.env.FLUTTERWAVE_PUBLIC_KEY || "",
-    secretKey: process.env.FLUTTERWAVE_SECRET_KEY || "",
-    encryptionKey: process.env.FLUTTERWAVE_ENCRYPTION_KEY || "",
-    webhookSecret: process.env.FLUTTERWAVE_WEBHOOK_SECRET || "",
+    publicKey: isPlaceholderKey(process.env.FLUTTERWAVE_PUBLIC_KEY)
+      ? ""
+      : process.env.FLUTTERWAVE_PUBLIC_KEY!.trim(),
+    secretKey: isPlaceholderKey(process.env.FLUTTERWAVE_SECRET_KEY)
+      ? ""
+      : process.env.FLUTTERWAVE_SECRET_KEY!.trim(),
+    encryptionKey: isPlaceholderKey(process.env.FLUTTERWAVE_ENCRYPTION_KEY)
+      ? ""
+      : process.env.FLUTTERWAVE_ENCRYPTION_KEY!.trim(),
+    webhookSecret: isPlaceholderKey(process.env.FLUTTERWAVE_WEBHOOK_SECRET)
+      ? ""
+      : process.env.FLUTTERWAVE_WEBHOOK_SECRET!.trim(),
     baseUrl: process.env.FLUTTERWAVE_BASE_URL || "https://api.flutterwave.com/v3",
   },
   paystack: {
-    secretKey: process.env.PAYSTACK_SECRET_KEY || "",
+    secretKey: isPlaceholderKey(process.env.PAYSTACK_SECRET_KEY)
+      ? ""
+      : process.env.PAYSTACK_SECRET_KEY!.trim(),
     baseUrl: process.env.PAYSTACK_BASE_URL || "https://api.paystack.co",
   },
   // BE-001: HMAC secret for /v1/webhooks/bills/:provider signature verification.
   bills: {
-    webhookSecret: process.env.BILLS_WEBHOOK_SECRET || "",
+    webhookSecret: isPlaceholderKey(process.env.BILLS_WEBHOOK_SECRET)
+      ? ""
+      : process.env.BILLS_WEBHOOK_SECRET!.trim(),
   },
   mtnMomo: {
-    subscriptionKey: process.env.MTN_MOMO_SUBSCRIPTION_KEY || "",
-    apiUserId: process.env.MTN_MOMO_API_USER_ID || "",
-    apiKey: process.env.MTN_MOMO_API_KEY || "",
+    subscriptionKey: isPlaceholderKey(process.env.MTN_MOMO_SUBSCRIPTION_KEY)
+      ? ""
+      : process.env.MTN_MOMO_SUBSCRIPTION_KEY!.trim(),
+    apiUserId: isPlaceholderKey(process.env.MTN_MOMO_API_USER_ID)
+      ? ""
+      : process.env.MTN_MOMO_API_USER_ID!.trim(),
+    apiKey: isPlaceholderKey(process.env.MTN_MOMO_API_KEY)
+      ? ""
+      : process.env.MTN_MOMO_API_KEY!.trim(),
     baseUrl:
       process.env.MTN_MOMO_BASE_URL ||
       (process.env.MTN_MOMO_TARGET_ENVIRONMENT === "production"

--- a/src/controllers/webhookController.ts
+++ b/src/controllers/webhookController.ts
@@ -93,11 +93,8 @@ export function verifyFlutterwaveSignature(
 
   const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
   if (!rawBody || !Buffer.isBuffer(rawBody)) {
-    throw new AppError(
-      "Raw body required for verification",
-      400,
-      ErrorCodes.RAW_BODY_REQUIRED,
-    );
+    res.status(400).json({ error: "Raw body required for verification" });
+    return;
   }
 
   // #390: Reject requests whose timestamp falls outside the tolerance window.
@@ -114,11 +111,8 @@ export function verifyFlutterwaveSignature(
 
   const received = req.headers["verif-hash"] as string | undefined;
   if (!received) {
-    throw new AppError(
-      "Missing verif-hash header",
-      401,
-      ErrorCodes.MISSING_SIGNATURE,
-    );
+    res.status(401).json({ error: "Missing verif-hash header" });
+    return;
   }
 
   const computed = crypto
@@ -145,7 +139,8 @@ export function verifyFlutterwaveSignature(
     return;
   }
   logger.warn("Flutterwave webhook signature mismatch");
-  throw new AppError("Invalid signature", 401, ErrorCodes.INVALID_SIGNATURE);
+  res.status(401).json({ error: "Invalid signature" });
+  return;
 }
 
 // ── Paystack Webhook ────────────────────────────────────────────────────────
@@ -184,11 +179,8 @@ export function verifyPaystackSignature(
 
   const rawBody = (req as unknown as { rawBody?: Buffer }).rawBody;
   if (!rawBody || !Buffer.isBuffer(rawBody)) {
-    throw new AppError(
-      "Raw body required for verification",
-      400,
-      ErrorCodes.RAW_BODY_REQUIRED,
-    );
+    res.status(400).json({ error: "Raw body required for verification" });
+    return;
   }
 
   // #390: Reject requests whose timestamp falls outside the tolerance window.
@@ -205,11 +197,8 @@ export function verifyPaystackSignature(
 
   const received = req.headers["x-paystack-signature"] as string | undefined;
   if (!received) {
-    throw new AppError(
-      "Missing x-paystack-signature header",
-      401,
-      ErrorCodes.MISSING_SIGNATURE,
-    );
+    res.status(401).json({ error: "Missing x-paystack-signature header" });
+    return;
   }
 
   const computed = crypto
@@ -233,7 +222,8 @@ export function verifyPaystackSignature(
 
   if (!signatureValid) {
     logger.warn("Paystack webhook signature mismatch");
-    throw new AppError("Invalid signature", 401, ErrorCodes.INVALID_SIGNATURE);
+    res.status(401).json({ error: "Invalid signature" });
+    return;
   }
   next();
 }


### PR DESCRIPTION

Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.

closes #600 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production configuration validation by detecting missing or placeholder fintech API credentials during startup.
  * Prevented placeholder credentials from being used for Flutterwave, Paystack, Bills, and MTN MoMo integrations.
  * Webhook verification failures now return clear JSON error responses and stop processing immediately for invalid requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->