### PR TITLE
fix(#603, #606): fix README ENV_VARS.md links and enable no-explicit-any warn

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,7 @@
   ],
   "reportUnusedDisableDirectives": true,
   "rules": {
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "warn",
     "@typescript-eslint/no-unused-vars": ["warn", { "argsIgnorePattern": "^_" }]
   },
   "env": {

--- a/README.md
+++ b/README.md
@@ -173,9 +173,9 @@ pnpm test:coverage
 
 ## Environment Variables
 
-**Full list:** See [ENV_VARS.md](ENV_VARS.md). No mock data; all values must be real or explicitly empty.
+**Full list:** See [ENV_VARS.md](./ENV_VARS.md). No mock data; all values must be real or explicitly empty.
 
-**Required:** `DATABASE_URL` (migrations / fallback), `MONGODB_URI` (MongoDB Atlas), `RABBITMQ_URL`, `JWT_SECRET`. Runtime DB: **Prisma Accelerate** via `PRISMA_ACCELERATE_URL` (see [ENV_VARS.md](ENV_VARS.md)).
+**Required:** `DATABASE_URL` (migrations / fallback), `MONGODB_URI` (MongoDB Atlas), `RABBITMQ_URL`, `JWT_SECRET`. Runtime DB: **Prisma Accelerate** via `PRISMA_ACCELERATE_URL` (see [ENV_VARS.md](./ENV_VARS.md)).
 
 **Fintech:** Flutterwave (`FLUTTERWAVE_SECRET_KEY`, etc.), Paystack (`PAYSTACK_SECRET_KEY`), MTN MoMo (`MTN_MOMO_SUBSCRIPTION_KEY`, `MTN_MOMO_API_USER_ID`, `MTN_MOMO_API_KEY`). Optional: `FINTECH_CURRENCY_PROVIDERS`.
 


### PR DESCRIPTION
## Summary

Fixes two medium-severity issues reported in the issue tracker.

### #603 — README links to non-existent ENV_VARS.md path

`ENV_VARS.md` lives at the repo root alongside `README.md`. The existing bare relative links (`ENV_VARS.md`) resolve correctly on GitHub but are ambiguous. Updated both occurrences to explicit `./ENV_VARS.md` paths to make the file location unambiguous and eliminate confusion.

**Files changed:** `README.md` (lines 176, 178)

### #606 — `no-explicit-any` disabled globally in ESLint without justification

Changed `@typescript-eslint/no-explicit-any` from `"off"` to `"warn"` in `.eslintrc.json`. This:
- Does **not** break existing builds — all `any` casts become warnings, not errors
- Gives the team full visibility into every untyped cast across the codebase
- Aligns with the known-issues document that lists many `as any` casts that need cleanup
- Sets the minimum enforcement level the ticket requires

**Files changed:** `.eslintrc.json` (line 11)

## Testing

Ran `pnpm lint` — config parses correctly, `no-explicit-any` warnings surface as expected across the codebase without blocking the build.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the environment variables documentation link and improved formatting for readability.

* **Chores**
  * ESLint now flags explicit `any` usage as a warning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
closes #603 
closes #606 