### PR TITLE
fix(docs): correct port 3000 → 5000 in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pnpm prisma:seed
 pnpm dev
 ```
 
-The server will start on `http://localhost:3000` (or the port specified in `.env`).
+The server will start on `http://localhost:5000` (or the port specified in `.env`).
 
 Nodemon will automatically restart the server when you make changes to the code.
 
@@ -135,7 +135,7 @@ backend/
 ## API Documentation
 
 Once the server is running, API documentation is available at:
-- Swagger UI: `http://localhost:3000/api-docs` (development only, disabled in production for security)
+- Swagger UI: `http://localhost:5000/api-docs` (development only, disabled in production for security)
 
 **Segment routes** (require API key with segment scope): `/v1/p2p`, `/v1/sme`, `/v1/international`, `/v1/salary`, `/v1/enterprise`, `/v1/savings`, `/v1/lending`, `/v1/gateway`, `/v1/bills`. For a full list of routes and smart contracts, see the repository docs in the `docs/` folder.
 


### PR DESCRIPTION
## Summary
- Correct the documented port in the README from 3000 to 5000.

## Changes
- Updated the README text to reflect the intended local development port.

## Testing
- No functional code changes; documentation-only update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated local development instructions to use port 5000.
  * Updated the documented Swagger UI address for local development.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #602 