### PR TITLE
fix(api): ensure acbu_amount is always serialized as string

### DIFF
--- a/src/controllers/burnController.ts
+++ b/src/controllers/burnController.ts
@@ -27,6 +27,17 @@ import { AppError } from "../middleware/errorHandler";
 import { getLatestAcbuRate } from "../services/rates/acbuRateCache";
 import { extractIdempotencyKey } from "../utils/idempotency";
 
+/** Stringify a Decimal-like value from a Prisma model. Always returns a string. */
+function toStringDecimal(v: unknown): string {
+  if (v === null || v === undefined) return "0";
+  if (typeof v === "string") return v;
+  if (typeof v === "number") return String(v);
+  if (typeof v === "object" && v !== null && "toString" in v) {
+    return String((v as { toString: () => string }).toString());
+  }
+  return "0";
+}
+
 /** Best-effort stringify for Decimal-like values in Prisma models. */
 function toNullableStringDecimal(v: unknown): string | null {
   if (v === null || v === undefined) return null;
@@ -46,7 +57,7 @@ function respondFromExistingBurnTx(
 ): void {
   res.status(200).json({
     transaction_id: tx.id,
-    acbu_amount: toNullableStringDecimal(tx.acbuAmountBurned),
+    acbu_amount: toStringDecimal(tx.acbuAmountBurned),
     local_amount: toNullableStringDecimal(tx.localAmount),
     currency: tx.localCurrency,
     fee: toNullableStringDecimal(tx.fee),

--- a/src/controllers/mintController.ts
+++ b/src/controllers/mintController.ts
@@ -174,7 +174,7 @@ export async function mintFromUsdcInternal(
   walletAddress: string,
   userId?: string,
   organizationId?: string,
-): Promise<{ transactionId: string; acbuAmount: number }> {
+): Promise<{ transactionId: string; acbuAmount: string }> {
   const usdcDecimal = new Decimal(usdcAmount);
   const feeUsdcDecimal = calculateFee(usdcDecimal, MINT_FEE_BPS);
   const usdcAmount7 = decimalToContractNumber(usdcDecimal).toString();
@@ -225,7 +225,6 @@ export async function mintFromUsdcInternal(
       recipient: walletAddress,
     });
     const acbuDecimal = contractNumberToDecimal(Number(result.acbuAmount));
-    const acbuNum = acbuDecimal.toNumber();
     await prisma.transaction.update({
       where: { id: tx.id },
       data: {
@@ -235,7 +234,7 @@ export async function mintFromUsdcInternal(
         completedAt: new Date(),
       },
     });
-    return { transactionId: tx.id, acbuAmount: acbuNum };
+    return { transactionId: tx.id, acbuAmount: acbuDecimal.toString() };
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     logger.error("Soroban mint_from_usdc failed", {

--- a/tests/swapRace.test.ts
+++ b/tests/swapRace.test.ts
@@ -80,7 +80,7 @@ describe("B-075 — On-ramp swap race: duplicate processing", () => {
       swapUsdcToXlm.mockResolvedValue({ xlmReceived: 500, txHash: "txhash1" });
       mintFromUsdcInternal.mockResolvedValue({
         transactionId: "tx-001",
-        acbuAmount: 95,
+        acbuAmount: "95",
       });
       (prisma.onRampSwap.update as jest.Mock).mockResolvedValue({});
 


### PR DESCRIPTION
## Summary

Fixes inconsistent serialization of `acbu_amount` in API responses from `burnController.ts` and `mintController.ts`.

### Problem

Two separate inconsistencies existed:

1. **burnController** – `respondFromExistingBurnTx()` used `toNullableStringDecimal()` for `acbu_amount`, which can return `null` when the DB field is null. Fresh (non-idempotent) responses always returned a string via `acbuDecimal.toString()`. This meant the same endpoint could emit either a string or `null` for `acbu_amount` depending on the code path.

2. **mintController** – `mintFromUsdcInternal()` returned `acbuAmount` as a `number` (via `acbuDecimal.toNumber()`) rather than a string, making the return type inconsistent with the Decimal string convention used everywhere else.

### Fix

- **burnController.ts**: Added a `toStringDecimal()` helper that always returns a `string` (falls back to `"0"` instead of `null`). Updated `respondFromExistingBurnTx()` to use it for `acbu_amount`, guaranteeing a string in all response paths.

- **mintController.ts**: Changed the return type of `mintFromUsdcInternal()` from `{ acbuAmount: number }` to `{ acbuAmount: string }`. Returns `acbuDecimal.toString()` directly, eliminating the unnecessary `toNumber()` conversion. Removed the now-unused `acbuNum` variable.

- **tests/swapRace.test.ts**: Updated the mock return value from `acbuAmount: 95` (number) to `acbuAmount: '95'` (string) to match the updated return type.

### Impact

- No breaking changes to callers of `mintFromUsdcInternal()` — both job files (`xlmToAcbuJob.ts`, `usdcConvertAndMintJob.ts`) only log the value and are not affected by the string/number distinction.
- API response shape for `/v1/burn/acbu` is now consistent: `acbu_amount` is always a string.

Closes #623
Closes #262
Closes #620

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved transaction amount handling to consistently return ACBU amounts as strings.
  * Prevented missing ACBU amounts from appearing as `null`; unavailable values now default to `"0"`.
  * Preserved accurate decimal values during USDC-to-ACBU conversions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->