### PR TITLE
fix(test): align acbuAmount test mocks with string return type (fixes #626)

### DIFF
--- a/tests/integration/mintBurnSequence.integration.test.ts
+++ b/tests/integration/mintBurnSequence.integration.test.ts
@@ -202,7 +202,7 @@ describe("B-444 simultaneous mint and burn", () => {
     expect(prismaMock.transaction.update).toHaveBeenCalledTimes(2);
     expect(mintResult).toEqual({
       transactionId: "mint-tx-1",
-      acbuAmount: 0.1,
+      acbuAmount: "0.1",
     });
     expect(burnRes.status).toHaveBeenCalledWith(200);
     expect(burnRes.json).toHaveBeenCalledWith(

--- a/tests/swapRace.test.ts
+++ b/tests/swapRace.test.ts
@@ -133,7 +133,7 @@ describe("B-075 — On-ramp swap race: duplicate processing", () => {
       });
       mintFromUsdcInternal.mockResolvedValue({
         transactionId: "tx-002",
-        acbuAmount: 9,
+        acbuAmount: "9",
       });
       (prisma.onRampSwap.update as jest.Mock).mockResolvedValue({});
 


### PR DESCRIPTION
## Closes #626

## Summary

 [LOW] acbu_amount field returned as string vs Decimal inconsistency.

### Background

PR #704 (commit 58b0365) updated `mintFromUsdcInternal()` in `mintController.ts` to return `{ acbuAmount: string }` instead of `{ acbuAmount: number }`, ensuring `acbu_amount` is always serialized as a string in API responses. However, two test files were missed — they still mocked the old number type, creating an inconsistency between the source code contract and the test expectations.

### Changes

| File | Change |
|------|--------|
| `tests/swapRace.test.ts` | `acbuAmount: 9` → `acbuAmount: "9"` |
| `tests/integration/mintBurnSequence.integration.test.ts` | `acbuAmount: 0.1` → `acbuAmount: "0.1"` |

### Verification

- ✅ TypeScript typecheck — no errors in changed files
- ✅ 2 files changed, 2 lines total — minimal, targeted fix
- ✅ All pre-existing test suite behavior preserved (no regressions)

### Related

- PR #704: `fix(api): ensure acbu_amount is always serialized as string`
- Issue #626: acbu_amount field returned as string vs Decimal inconsistency

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated mint and swap test expectations to reflect token amounts represented as strings.
  * Improved test alignment with the current atomic-claim success behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->