### PR TITLE
[LOW] Redis referenced in .env.example but not in docker-compose and BACKEND_TODO 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,15 +64,6 @@ RATE_LIMIT_CIRCUIT_BREAKER_COOLDOWN_MS=60000
 # Business calendar timezone for salary schedules and withdrawal windows (#408)
 # BUSINESS_TIMEZONE=Africa/Lagos
 
-# ── Redis cache (optional; Sentinel failover supported) ───────────────────────
-# REDIS_URL=redis://localhost:6379
-# REDIS_SENTINELS=127.0.0.1:26379,127.0.0.1:26380
-# REDIS_SENTINEL_NAME=mymaster
-# REDIS_PASSWORD=
-# REDIS_MAX_RETRIES_PER_REQUEST=3
-# REDIS_READONLY_RETRY_ATTEMPTS=3
-# REDIS_READONLY_RETRY_DELAY_MS=100
-
 # Stellar / USDC swap
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org

--- a/src/middleware/errorHandler.ts
+++ b/src/middleware/errorHandler.ts
@@ -64,6 +64,27 @@ function summarizeErrorDetails(details: unknown): unknown {
   return "REDACTED_NON_OBJECT_DETAILS";
 }
 
+/**
+ * Sanitize AppError.details before including it in a client-facing response.
+ *
+ * Guarantees:
+ *  - Only plain JSON-serializable values reach the client (no class instances,
+ *    Buffers, functions, Symbols, or circular references).
+ *  - Returns undefined if sanitization fails for any reason, so callers can
+ *    simply omit the details key rather than crashing or leaking internals.
+ */
+function sanitizeDetailsForClient(details: unknown): unknown {
+  if (details === null || details === undefined) return undefined;
+  try {
+    // JSON round-trip drops functions/Symbols/undefined values and throws on
+    // circular references, guaranteeing a plain, serializable value.
+    return JSON.parse(JSON.stringify(details));
+  } catch {
+    // Circular reference or other non-serializable content — omit entirely.
+    return undefined;
+  }
+}
+
 export const errorHandler = (
   err: Error | AppError | SyntaxError,
   req: Request,
@@ -93,13 +114,14 @@ export const errorHandler = (
       details: summarizeErrorDetails(err.details),
     });
 
+    const clientDetails = sanitizeDetailsForClient(err.details);
     res.status(err.statusCode).json({
       error: {
         code: err.code,
         error_code: err.code,
         message: err.message,
         statusCode: err.statusCode,
-        ...(err.details ? { details: err.details } : {}),
+        ...(clientDetails !== undefined ? { details: clientDetails } : {}),
       },
     });
     return;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,22 +28,7 @@
   "include": [
     "src/**/*",
     "prisma/**/*",
-    "scripts/**/*",
-    "tests/setup.ts",
-    "tests/webhookService.test.ts",
-    "tests/walletActivationService.test.ts",
-    "tests/walletService.test.ts",
-    "tests/transferService.test.ts",
-    "tests/RebalancingEngine.test.ts",
-    "tests/recoveryService.test.ts",
-    "tests/centralBankClient.test.ts",
-    "tests/forexClient.test.ts",
-    "tests/notificationService.test.ts",
-    "tests/metricsService.test.ts",
-    "scripts/basketService.test.ts",
-    "scripts/contracts.test.ts",
-    "scripts/auditService.test.ts",
-    "tests/idempotencyStore.test.ts"
+    "scripts/**/*"
   ],
   "exclude": [
     "node_modules",


### PR DESCRIPTION
## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.

closes #587 
closes #607 
closes #612 
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error responses by safely including only JSON-compatible error details.
  * Prevented malformed or non-serializable error information from causing additional response failures or exposing unintended data.

* **Documentation**
  * Removed outdated optional Redis cache configuration guidance from the environment variable template.

* **Chores**
  * Updated TypeScript compilation settings to better separate application code from test files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->