### PR TITLE
fix(security): replace Math.random() OTP with CSPRNG (#644)

### DIFF
--- a/src/services/auth/authService.ts
+++ b/src/services/auth/authService.ts
@@ -21,6 +21,7 @@ import {
   PermissionsArraySchema,
   PermissionScope,
 } from "../../types/permissions";
+import { generateSecureOtp } from "../../utils/otp";
 
 const DUMMY_HASH =
   "$2a$10$CwTycUXWue0Thq9StjUM0uEnOTWj2XOTl0pypEQuA7y2h2H6jX.m2"; // hash for 'dummy'
@@ -137,10 +138,6 @@ function normalizeIdentifier(s: string): {
     return { kind: "email", value: lower };
   }
   return { kind: "username", value: lower.replace(/\s/g, "") };
-}
-
-function generateOtpCode(): string {
-  return String(Math.floor(100000 + Math.random() * 900000));
 }
 
 function isAdminTierUser(tier: string | null | undefined): boolean {
@@ -391,7 +388,7 @@ export async function signin(params: SigninParams): Promise<SigninResult> {
       });
       const to = user.twoFaMethod === "email" ? u?.email : u?.phoneE164;
       if (!to) throw new Error("2FA channel not configured");
-      const code = generateOtpCode();
+      const code = generateSecureOtp();
       const codeHash = await bcrypt.hash(code, 10);
       await prisma.otpChallenge.create({
         data: {
@@ -635,7 +632,7 @@ export async function requestAdminMfaChallenge(
     if (!to) {
       throw new Error("2FA channel not configured");
     }
-    const code = generateOtpCode();
+    const code = generateSecureOtp();
     const codeHash = await bcrypt.hash(code, 10);
     await prisma.otpChallenge.create({
       data: {

--- a/src/services/recovery/recoveryService.ts
+++ b/src/services/recovery/recoveryService.ts
@@ -24,6 +24,7 @@ import {
   detectSuspiciousPatterns,
   rotateUserSessions,
 } from "./auditService";
+import { generateSecureOtp } from "../../utils/otp";
 
 const OTP_EXPIRY_MINUTES = 10;
 
@@ -54,10 +55,6 @@ export interface VerifyRecoveryOtpParams {
 export interface VerifyRecoveryOtpResult {
   api_key: string;
   user_id: string;
-}
-
-function generateOtpCode(): string {
-  return String(Math.floor(100000 + Math.random() * 900000));
 }
 
 async function publishOtpToQueue(payload: {
@@ -197,7 +194,7 @@ export async function unlockApp(
     throw new Error("Recovery channel not configured");
   }
 
-  const code = generateOtpCode();
+  const code = generateSecureOtp();
   const codeHash = await bcrypt.hash(code, 10);
   await prisma.otpChallenge.create({
     data: {

--- a/src/utils/otp.test.ts
+++ b/src/utils/otp.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for cryptographically secure OTP generation.
+ */
+import { generateSecureOtp } from "./otp";
+import { randomInt } from "crypto";
+
+jest.mock("crypto", () => ({
+  randomInt: jest.fn(),
+}));
+
+describe("generateSecureOtp", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("generates a 6-digit OTP string", () => {
+    (randomInt as jest.Mock).mockReturnValue(123456);
+
+    const otp = generateSecureOtp();
+
+    expect(otp).toBe("123456");
+    expect(randomInt).toHaveBeenCalledWith(100_000, 1_000_000);
+  });
+
+  it("pads leading zeros correctly for lower-bound values", () => {
+    (randomInt as jest.Mock).mockReturnValue(100000);
+
+    const otp = generateSecureOtp();
+
+    expect(otp).toBe("100000");
+    expect(otp).toHaveLength(6);
+  });
+
+  it("handles upper-bound values correctly", () => {
+    (randomInt as jest.Mock).mockReturnValue(999999);
+
+    const otp = generateSecureOtp();
+
+    expect(otp).toBe("999999");
+    expect(otp).toHaveLength(6);
+  });
+
+  it("generates different OTPs on successive calls", () => {
+    (randomInt as jest.Mock)
+      .mockReturnValueOnce(123456)
+      .mockReturnValueOnce(789012)
+      .mockReturnValueOnce(345678);
+
+    const otp1 = generateSecureOtp();
+    const otp2 = generateSecureOtp();
+    const otp3 = generateSecureOtp();
+
+    expect(otp1).toBe("123456");
+    expect(otp2).toBe("789012");
+    expect(otp3).toBe("345678");
+    expect(randomInt).toHaveBeenCalledTimes(3);
+  });
+
+  it("always returns exactly 6 characters", () => {
+    const testValues = [100000, 100001, 500000, 999998, 999999];
+
+    testValues.forEach((value) => {
+      (randomInt as jest.Mock).mockReturnValueOnce(value);
+      const otp = generateSecureOtp();
+      expect(otp).toHaveLength(6);
+    });
+  });
+
+  it("calls crypto.randomInt with correct range [100_000, 1_000_000)", () => {
+    (randomInt as jest.Mock).mockReturnValue(123456);
+
+    generateSecureOtp();
+
+    expect(randomInt).toHaveBeenCalledWith(100_000, 1_000_000);
+  });
+
+  describe("integration: real crypto.randomInt behavior", () => {
+    beforeEach(() => {
+      // Unmock crypto.randomInt for real integration tests
+      jest.unmock("crypto");
+      jest.resetModules();
+    });
+
+    it("generates valid 6-digit OTPs with real CSPRNG", () => {
+      // Re-require after unmocking
+      const { generateSecureOtp: realOtp } = require("./otp");
+
+      for (let i = 0; i < 100; i++) {
+        const otp = realOtp();
+        expect(otp).toMatch(/^\d{6}$/);
+        const num = parseInt(otp, 10);
+        expect(num).toBeGreaterThanOrEqual(100000);
+        expect(num).toBeLessThan(1000000);
+      }
+    });
+
+    it("generates unique OTPs with high probability", () => {
+      const { generateSecureOtp: realOtp } = require("./otp");
+      const otps = new Set<string>();
+      const iterations = 1000;
+
+      for (let i = 0; i < iterations; i++) {
+        otps.add(realOtp());
+      }
+
+      // With 900k possible values and 1000 samples, duplicates are extremely unlikely
+      // (birthday paradox: ~0.06% chance of collision)
+      expect(otps.size).toBeGreaterThan(990);
+    });
+  });
+});

--- a/src/utils/otp.ts
+++ b/src/utils/otp.ts
@@ -1,0 +1,29 @@
+/**
+ * Cryptographically secure OTP generation.
+ *
+ * Math.random() is a non-reseeding xorshift PRNG whose internal state is
+ * fully algebraically recoverable from a handful of observed outputs.  Any
+ * OTP backed by it — login 2FA, account-recovery unlock — is trivially
+ * predictable once an attacker observes a few consecutive codes.
+ *
+ * crypto.randomInt(min, max) is seeded from the OS CSPRNG and is safe for
+ * security-sensitive values.  Both Node.js built-in and Web Crypto spell it
+ * the same way, so no extra dependency is needed.
+ *
+ * The range [100_000, 1_000_000) produces exactly 6-digit codes with uniform
+ * distribution (900 000 possible values, same as the old Math.floor approach
+ * but without the bias or predictability).
+ */
+import { randomInt } from "crypto";
+
+const OTP_MIN = 100_000; // inclusive
+const OTP_MAX = 1_000_000; // exclusive — gives 6-digit codes: 100000–999999
+
+/**
+ * Generate a cryptographically secure 6-digit OTP code.
+ *
+ * @returns A string of exactly 6 decimal digits, e.g. "482031".
+ */
+export function generateSecureOtp(): string {
+  return String(randomInt(OTP_MIN, OTP_MAX));
+}


### PR DESCRIPTION
- Extract generateSecureOtp() to src/utils/otp.ts using crypto.randomInt()
- Remove duplicate generateOtpCode() from authService.ts and recoveryService.ts
- Update all 3 call sites (signin 2FA, admin MFA challenge, recovery unlock)
- Add otp.test.ts with 8 tests covering unit and real-CSPRNG integration

Math.random() is a non-reseeding xorshift PRNG whose state is algebraically recoverable from observed outputs. crypto.randomInt() draws from OS entropy and is safe for security-sensitive values like login 2FA and account recovery.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

closes #113 

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
