### PR TITLE
fix: clarify unused Redis config in .env.example (#612)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -64,7 +64,11 @@ RATE_LIMIT_CIRCUIT_BREAKER_COOLDOWN_MS=60000
 # Business calendar timezone for salary schedules and withdrawal windows (#408)
 # BUSINESS_TIMEZONE=Africa/Lagos
 
-# ── Redis cache (optional; Sentinel failover supported) ───────────────────────
+# ── Redis cache (not currently used — reserved for future use) ─────────────────
+# NOTE: Redis is NOT included in docker-compose.yml and is not used by the
+# active cache layer (src/utils/cache.ts uses MongoDB). These variables are
+# reserved for a future Redis-backed cache. Do NOT add a Redis service to
+# docker-compose unless the codebase is migrated to use it.
 # REDIS_URL=redis://localhost:6379
 # REDIS_SENTINELS=127.0.0.1:26379,127.0.0.1:26380
 # REDIS_SENTINEL_NAME=mymaster


### PR DESCRIPTION
## Summary

The Redis configuration block in .env.example was misleading because:

- Redis is **not** included in docker-compose.yml
- The active cache layer (src/utils/cache.ts) uses MongoDB, not Redis
- BACKEND_TODO previously stated Redis is not used

## Changes

Added a clear comment to the Redis section in .env.example explaining that Redis is reserved for future use and should not be added to docker-compose.yml unless the codebase is migrated to use it.

### Before
`
# ── Redis cache (optional; Sentinel failover supported) ───────────────────────
`

### After
`
# ── Redis cache (not currently used — reserved for future use) ─────────────────
# NOTE: Redis is NOT included in docker-compose.yml and is not used by the
# active cache layer (src/utils/cache.ts uses MongoDB). These variables are
# reserved for a future Redis-backed cache. Do NOT add a Redis service to
# docker-compose unless the codebase is migrated to use it.
`

Closes #612