### PR TITLE
fix(controllers): remove unused Prisma and logger imports in userController

### DIFF
--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -1,11 +1,9 @@
 import { Response, NextFunction } from "express";
-import type { Prisma } from "@prisma/client";
 import { z } from "zod";
 import bcrypt from "bcrypt";
 import { AuthRequest } from "../middleware/auth";
 import { prisma } from "../config/database";
 import { AppError } from "../middleware/errorHandler";
-import { logger } from "../config/logger";
 import { tombstoneDeleteUser } from "../services/user";
 
 /** Normalize username: lowercase, no spaces. */


### PR DESCRIPTION
## Summary
Closes #719

`Prisma` and `logger` were imported in `src/controllers/userController.ts` but never used, violating TypeScript strict rules (`TS6133` under `noUnusedLocals`).

## Changes
- Removed `import type { Prisma } from "@prisma/client";` (line 2)
- Removed `import { logger } from "../config/logger";` (line 8)

## Verification
- `tsc --noEmit` reports no TS6133 unused-import errors for `userController.ts`.