### PR TITLE
fix(logging): remove duplicate redactFormat/redactPii/redactLogValue in logger.ts

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -38,66 +38,6 @@ if (!fs.existsSync(logDir)) {
   fs.mkdirSync(logDir, { recursive: true });
 }
 
-const CARD_NUMBER_PATTERN = /\b\d{13,19}\b/g;
-
-const SENSITIVE_KEY_PATTERN =
-  /pass(?:word|code|wd)|secret|token|authorization|api[_-]?key|private[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|secret[_-]?key|secret[_-]?access[_-]?key|\bpin\b|cvv|cvc|ssn|bvn|credit[_-]?card|card[_-]?number|cookie|mnemonic|\bseed\b|\bjwt\b/i;
-
-const REDACTED = "[REDACTED]";
-
-function redactPii(value: string): string {
-  return value.replace(CARD_NUMBER_PATTERN, REDACTED);
-}
-
-function isSensitiveKey(key: string): boolean {
-  return SENSITIVE_KEY_PATTERN.test(key);
-}
-
-/** Recursively redact sensitive keys and card-like numbers from log values. */
-export function redactLogValue(
-  value: unknown,
-  key?: string,
-  seen: WeakSet<object> = new WeakSet(),
-): unknown {
-  if (key !== undefined && isSensitiveKey(key)) {
-    return REDACTED;
-  }
-  if (typeof value === "string") {
-    return redactPii(value);
-  }
-  if (value === null || typeof value !== "object") {
-    return value;
-  }
-  if (seen.has(value)) {
-    return "[Circular]";
-  }
-  seen.add(value);
-
-  if (Array.isArray(value)) {
-    return value.map((item) => redactLogValue(item, undefined, seen));
-  }
-
-  const result: Record<string, unknown> = {};
-  for (const [childKey, childValue] of Object.entries(value as Record<string, unknown>)) {
-    result[childKey] = redactLogValue(childValue, childKey, seen);
-  }
-  return result;
-}
-
-/** Winston format: apply PII/secret redaction to every log info object. */
-export const redactFormat = winston.format((info) => {
-  const seen = new WeakSet<object>();
-  for (const key of Object.keys(info)) {
-    if (key === "level") continue;
-    (info as Record<string, unknown>)[key] = redactLogValue(
-      (info as Record<string, unknown>)[key],
-      key,
-      seen,
-    );
-  }
-  return info;
-});
-
 const logFormat = winston.format.combine(
   winston.format.timestamp({ format: "YYYY-MM-DD HH:mm:ss" }),
   winston.format.errors({ stack: true }),

--- a/tests/logger.duplicate-imports.test.ts
+++ b/tests/logger.duplicate-imports.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Tests for #713 — logger.ts no longer redeclares imported redactFormat / redactPii.
+ *
+ * Verifies that:
+ *  - logger.ts re-exports match the logRedaction.ts canonical implementations (same reference)
+ *  - logger loads without duplicate-identifier errors
+ *  - redaction still works end-to-end through the logger re-export path
+ */
+import {
+  redactFormat as loggerRedactFormat,
+  redactPii as loggerRedactPii,
+  redactLogValue as loggerRedactLogValue,
+} from "../src/config/logger";
+import {
+  redactFormat as logRedactionRedactFormat,
+  redactPii as logRedactionRedactPii,
+  redactLogValue as logRedactionRedactLogValue,
+} from "../src/config/logRedaction";
+import winston from "winston";
+import { Writable } from "stream";
+
+describe("logger.ts re-exports from logRedaction.ts", () => {
+  it("redactFormat imported from logger is the same reference as logRedaction", () => {
+    expect(loggerRedactFormat).toBe(logRedactionRedactFormat);
+  });
+
+  it("redactPii imported from logger is the same reference as logRedaction", () => {
+    expect(loggerRedactPii).toBe(logRedactionRedactPii);
+  });
+
+  it("redactLogValue imported from logger is the same reference as logRedaction", () => {
+    expect(loggerRedactLogValue).toBe(logRedactionRedactLogValue);
+  });
+});
+
+describe("logger module loads without duplicate-identifier errors", () => {
+  it("exports logger and logFinancialEvent from logger.ts", async () => {
+    const mod = await import("../src/config/logger");
+    expect(mod.logger).toBeDefined();
+    expect(typeof mod.logger.info).toBe("function");
+    expect(typeof mod.logFinancialEvent).toBe("function");
+  });
+
+  it("re-exported redactFormat is callable and returns a winston format", () => {
+    const format = loggerRedactFormat();
+    expect(format).toBeDefined();
+    expect(typeof format.transform).toBe("function");
+  });
+});
+
+describe("redaction works through logger re-export path", () => {
+  it("redactFormat from logger redacts sensitive meta in winston transport", (done) => {
+    const chunks: string[] = [];
+    const stream = new Writable({
+      write(chunk, _encoding, callback) {
+        chunks.push(chunk.toString());
+        callback();
+      },
+    });
+
+    const testLogger = winston.createLogger({
+      level: "debug",
+      format: winston.format.combine(
+        loggerRedactFormat(),
+        winston.format.json(),
+      ),
+      transports: [new winston.transports.Stream({ stream })],
+    });
+
+    testLogger.debug("test message", {
+      apiKey: "sk-secret-12345",
+      passcode: "9999",
+      safe: "not-redacted",
+    });
+
+    setImmediate(() => {
+      expect(chunks).toHaveLength(1);
+      const parsed = JSON.parse(chunks[0]);
+      expect(parsed.apiKey).toBe("[REDACTED]");
+      expect(parsed.passcode).toBe("[REDACTED]");
+      expect(parsed.safe).toBe("not-redacted");
+      done();
+    });
+  });
+
+  it("redactPii from logger masks card-like numbers", () => {
+    const input = "charge to card 4111111111111111 succeeded";
+    const result = loggerRedactPii(input);
+    expect(result).toBe("charge to card [REDACTED] succeeded");
+    expect(result).not.toContain("4111111111111111");
+  });
+
+  it("redactLogValue from logger recursively redacts sensitive keys", () => {
+    const input = {
+      user: "alice",
+      nested: { token: "bearer-xyz", password: "hunter2" },
+    };
+    const result = loggerRedactLogValue(input);
+    expect(result).toEqual({
+      user: "alice",
+      nested: { token: "[REDACTED]", password: "[REDACTED]" },
+    });
+  });
+
+  it("negative: redactLogValue does NOT redact non-sensitive keys", () => {
+    const input = { amount: 100, currency: "NGN", message: "hello" };
+    const result = loggerRedactLogValue(input);
+    expect(result).toEqual(input);
+  });
+});


### PR DESCRIPTION
## Summary
Remove duplicate local definitions of `redactFormat`, `redactPii`, and `redactLogValue` from `src/config/logger.ts` that conflicted with the same symbols imported and re-exported from `./logRedaction.ts`. This eliminates TS2395/TS2440/TS2323/TS2484 duplicate-identifier errors while preserving identical redaction behavior.

Closes #713

## Changes
- **src/config/logger.ts**: Removed 60 lines of duplicate local definitions (`CARD_NUMBER_PATTERN`, `SENSITIVE_KEY_PATTERN`, `REDACTED` constants; `redactPii`, `isSensitiveKey`, `redactLogValue`, and `redactFormat` functions/exports). The import on line 7 (`import { redactFormat, redactPii } from "./logRedaction"`) and the re-export on line 9 (`export { redactFormat, redactLogValue, redactPii } from "./logRedaction"`) are retained, ensuring all consumers continue to receive the same API.
- **tests/logger.duplicate-imports.test.ts** (new): 9 tests verifying that logger.ts re-exports are the same references as logRedaction.ts, the module loads cleanly, and redaction works end-to-end through the re-export path (including a negative test confirming non-sensitive keys are not redacted).

## Testing
- `tsc --noEmit -p tsconfig.build.json` — **zero errors** in `logger.ts` or `logRedaction.ts` (all other errors are pre-existing in unrelated files).
- `pnpm jest tests/logger --forceExit` — **17/17 tests pass** across `logger.redaction.test.ts` (5), `logger.transportLevels.test.ts` (3), and `logger.duplicate-imports.test.ts` (9).

## Checklist
- [x] Follows CONTRIBUTING.md conventions
- [x] All acceptance criteria from #713 are met
- [x] Existing tests pass unchanged
- [x] New tests cover happy path, named edge cases, and a negative case
- [ ] CI is green (awaiting checks)