### PR TITLE
fix: Resolve tsconfig include/exclude conflict for tests

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,25 +29,10 @@
     "src/**/*",
     "prisma/**/*",
     "scripts/**/*",
-    "tests/setup.ts",
-    "tests/webhookService.test.ts",
-    "tests/walletActivationService.test.ts",
-    "tests/walletService.test.ts",
-    "tests/transferService.test.ts",
-    "tests/RebalancingEngine.test.ts",
-    "tests/recoveryService.test.ts",
-    "tests/centralBankClient.test.ts",
-    "tests/forexClient.test.ts",
-    "tests/notificationService.test.ts",
-    "tests/metricsService.test.ts",
-    "scripts/basketService.test.ts",
-    "scripts/contracts.test.ts",
-    "scripts/auditService.test.ts",
-    "tests/idempotencyStore.test.ts"
+    "tests/**/*"
   ],
   "exclude": [
     "node_modules",
-    "dist",
-    "tests"
+    "dist"
   ]
 }


### PR DESCRIPTION
## Summary
- Replace individual test file includes with glob pattern `tests/**/*`
- Remove `tests` directory from exclude array
- Simplifies maintenance - new test files are automatically included

## Problem
The previous configuration listed specific test files in `include` while simultaneously excluding the entire `tests/` directory in `exclude`. This was:
- Confusing and contradictory
- Required manual updates when adding new test files
- Created maintenance overhead

## Solution
Changed from:
```json
"include": [
  "src/**/*",
  "tests/setup.ts",
  "tests/webhookService.test.ts",
  // ... many specific files
],
"exclude": ["node_modules", "dist", "tests"]
```

To:
```json
"include": [
  "src/**/*",
  "prisma/**/*",
  "scripts/**/*",
  "tests/**/*"
],
"exclude": ["node_modules", "dist"]
```

## Test Plan
- [ ] Run `tsc --noEmit` to verify TypeScript compilation
- [ ] Run `npm test` to verify all tests still pass
- [ ] Add a new test file and verify it's picked up automatically

Closes #607

🤖 Generated with [Claude Code](https://claude.com/claude-code)