### PR TITLE
Fix/772 currencyconverter golden tests

### DIFF
--- a/src/services/rates/currencyConverter.test.ts
+++ b/src/services/rates/currencyConverter.test.ts
@@ -208,6 +208,30 @@ describe("currencyConverter", () => {
 
       expect(result).toBeCloseTo(50.00025, 5);
     });
+
+    it("should handle string inputs as golden test", async () => {
+      (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue({
+        acbuNgn: new Decimal("1000.00"),
+        acbuUsd: new Decimal("0.50"),
+        timestamp: new Date(),
+      });
+
+      const result = await convertLocalToUsd("100000.5", "NGN");
+
+      expect(result).toBeCloseTo(50.00025, 5);
+    });
+
+    it("should handle Decimal inputs as golden test", async () => {
+      (prisma.acbuRate.findFirst as jest.Mock).mockResolvedValue({
+        acbuNgn: new Decimal("1000.00"),
+        acbuUsd: new Decimal("0.50"),
+        timestamp: new Date(),
+      });
+
+      const result = await convertLocalToUsd(new Decimal("100000.5"), "NGN");
+
+      expect(result).toBeCloseTo(50.00025, 5);
+    });
   });
 
   describe("convertLocalToUsdWithPrecision", () => {

--- a/src/services/rates/currencyConverter.ts
+++ b/src/services/rates/currencyConverter.ts
@@ -102,7 +102,7 @@ export async function convertLocalToUsd(
 
   // Convert using high-precision Decimal arithmetic
   const localAmountDecimal = new Decimal(localAmount);
-  const rateDecimal = new Decimal(localToAcbuRate);
+  const rateDecimal = new Decimal(localToAcbuRate as Decimal);
 
   // Calculate ACBU equivalent
   const acbuAmount = localAmountDecimal.div(rateDecimal);
@@ -173,7 +173,7 @@ export async function convertLocalToUsdWithPrecision(
 
   // Convert using high-precision Decimal arithmetic
   const localAmountDecimal = new Decimal(localAmount);
-  const rateDecimal = new Decimal(localToAcbuRate);
+  const rateDecimal = new Decimal(localToAcbuRate as Decimal);
 
   // Calculate ACBU equivalent
   const acbuAmount = localAmountDecimal.div(rateDecimal);

--- a/src/services/rates/currencyConverter.ts
+++ b/src/services/rates/currencyConverter.ts
@@ -66,7 +66,7 @@ const rateField = {
  * @throws AppError if currency not supported, rates not available, or conversion fails
  */
 export async function convertLocalToUsd(
-  localAmount: number,
+  localAmount: number | string | Decimal,
   currency: string,
 ): Promise<number> {
   // Validate currency is supported
@@ -101,8 +101,8 @@ export async function convertLocalToUsd(
   }
 
   // Convert using high-precision Decimal arithmetic
-  const localAmountDecimal = new Decimal(localAmount);
-  const rateDecimal = new Decimal(localToAcbuRate as Decimal);
+  const localAmountDecimal = new Decimal(localAmount as any);
+  const rateDecimal = new Decimal(localToAcbuRate as any);
 
   // Calculate ACBU equivalent
   const acbuAmount = localAmountDecimal.div(rateDecimal);
@@ -172,8 +172,8 @@ export async function convertLocalToUsdWithPrecision(
   }
 
   // Convert using high-precision Decimal arithmetic
-  const localAmountDecimal = new Decimal(localAmount);
-  const rateDecimal = new Decimal(localToAcbuRate as Decimal);
+  const localAmountDecimal = new Decimal(localAmount as any);
+  const rateDecimal = new Decimal(localToAcbuRate as any);
 
   // Calculate ACBU equivalent
   const acbuAmount = localAmountDecimal.div(rateDecimal);


### PR DESCRIPTION
## Description
This PR addresses issue #772 where type regressions similar to W2-B-029/030 caused the `currencyConverter.test.ts` suite to fail. 

Previously, strict typings around the `Decimal` instantiation caused TypeScript compilation failures due to the `AcbuRate` union type containing `Date`. Additionally, `convertLocalToUsd` was improperly restricted to `number` inputs only.

To resolve this, the function signature was expanded to safely accept `number | string | Decimal` inputs, and internal casting safely bypasses the TypeScript `Date` union conflict.

## Changes Made
- Updated `convertLocalToUsd` signature to accept `string` and `Decimal` types.
- Fixed the internal `Decimal` instantiation cast to correctly satisfy the compiler without runtime impact.
- Added explicit golden tests in `currencyConverter.test.ts` for both `string` and `Decimal` inputs to guarantee that conversion correctness is explicitly verified.

## Verification
- Unit tests now verify that string inputs (`"100000.5"`) and `Decimal` object inputs successfully execute and output the expected precision results.

Closes #772


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Currency conversion now accepts amounts provided as numbers, text values, or high-precision decimal values.
  * Local currency amounts continue to be converted accurately to USD, including when using precise decimal inputs.
* **Tests**
  * Added coverage confirming consistent conversion results across supported amount formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->