### PR TITLE
fix(tsconfig): use tests glob instead of hand-listed test files (#607)

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,25 +29,10 @@
     "src/**/*",
     "prisma/**/*",
     "scripts/**/*",
-    "tests/setup.ts",
-    "tests/webhookService.test.ts",
-    "tests/walletActivationService.test.ts",
-    "tests/walletService.test.ts",
-    "tests/transferService.test.ts",
-    "tests/RebalancingEngine.test.ts",
-    "tests/recoveryService.test.ts",
-    "tests/centralBankClient.test.ts",
-    "tests/forexClient.test.ts",
-    "tests/notificationService.test.ts",
-    "tests/metricsService.test.ts",
-    "scripts/basketService.test.ts",
-    "scripts/contracts.test.ts",
-    "scripts/auditService.test.ts",
-    "tests/idempotencyStore.test.ts"
+    "tests/**/*"
   ],
   "exclude": [
     "node_modules",
-    "dist",
-    "tests"
+    "dist"
   ]
 }


### PR DESCRIPTION
## Summary
Fixes #607.

The base `tsconfig.json` `include` array enumerated ~15 individual test files while the `exclude` array excluded the whole `tests/` directory. Since `exclude` filters the set that `include` globs produce, most of the `tests/`-prefixed entries in `include` were silently cancelled by the `tests` exclude — and every newly added test file had to be hand-registered to be type-checked. That is the confusing maintenance overhead the issue describes.

## Change
- `include`: replaced the hand-maintained per-file test list with a single `tests/**/*` glob (alongside the existing `src`, `prisma`, `scripts` globs).
- `exclude`: removed the contradictory `tests` entry (kept `node_modules`, `dist`).

## Why it's safe
- `tsconfig.build.json` (used by `pnpm build`) extends this config but re-excludes `**/*.test.ts`, `**/*.spec.ts`, `**/__tests__/**`, so **emitted build output is unchanged** — tests are still kept out of `dist/`.
- No CI job runs a bare `tsc -p tsconfig.json`; this config is editor/type-check facing, so all test files are now consistently resolved with no per-file bookkeeping.
- Prettier (`src/**/*.ts`) and ESLint (`src --ext .ts`) don't touch `tsconfig.json`, so lint/format are unaffected.

Severity: LOW (config clarity / maintenance).