### PR TITLE
Fixed dead import (TS6133) in src/utils/rabbitmq-validation.ts by removing unused QUEUES import from line 4.

### DIFF
--- a/src/utils/rabbitmq-validation.ts
+++ b/src/utils/rabbitmq-validation.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { v4 as uuidv4 } from 'uuid';
 import { logger } from '../config/logger';
-import { getRabbitMQChannel, QUEUES } from '../config/rabbitmq';
+import { getRabbitMQChannel } from '../config/rabbitmq';
 import { QUEUE_SCHEMAS, MessageEnvelopeSchema, MessageEnvelope } from '../types/rabbitmq-schemas';
 
 export class MessageValidationError extends Error {


### PR DESCRIPTION

 The file src/utils/rabbitmq-validation.ts imported two symbols from ../config/rabbitmq: getRabbitMQChannel and QUEUES. While getRabbitMQChannel is actively used throughout the file (in publishValidatedMessage and deadLetterMessage), QUEUES was never referenced in any function, class, or expression. This triggered a TypeScript warning (TS6133) and cluttered the import statements. The fix removes QUEUES from the destructured import, leaving only the actually-used getRabbitMQChannel. No behavioral changes — the module's API and logic remain identical.

Closes #752

