### PR TITLE
fix: remove unused Channel import from RabbitMQ config (#715)

### DIFF
--- a/src/config/rabbitmq.ts
+++ b/src/config/rabbitmq.ts
@@ -1,4 +1,4 @@
-import amqp, { Channel, ChannelModel, ConfirmChannel } from "amqplib";
+import amqp, { ChannelModel, ConfirmChannel } from "amqplib";
 import { config } from "./env";
 import { logger } from "./logger";
 


### PR DESCRIPTION
Closes  #715
This PR removes the unused `Channel` import from `src/config/rabbitmq.ts` to fix the TS6133 error.

**Before:**
import amqp, { Channel, ChannelModel, ConfirmChannel } from "amqplib";

**After:**
import amqp, { ChannelModel, ConfirmChannel } from "amqplib";

✅ TypeScript compiles clean for this file
✅ No other changes made
✅  resolved