### PR TITLE
fix: type ledger transaction client

### DIFF
--- a/src/services/ledger/ledgerService.ts
+++ b/src/services/ledger/ledgerService.ts
@@ -84,7 +84,8 @@ export async function createLedgerEntries(
 
     try {
       const { count } = await prisma.$transaction(
-        (tx) => tx.transaction.createMany({ data: chunk }),
+        (tx: Prisma.TransactionClient) =>
+          tx.transaction.createMany({ data: chunk }),
         {
           timeout: LEDGER_TX_TIMEOUT_MS,
           maxWait: LEDGER_TX_MAX_WAIT_MS,


### PR DESCRIPTION
## Summary

Fixes the implicit `any` TypeScript error for `tx` in `ledgerService`.

## Changes

* Typed `tx` with Prisma `TransactionClient`
* Removed the implicit `any` from the ledger transaction flow
* Improved type safety in the ledger money path

## Testing

* Ran TypeScript compilation with strict mode
* Confirmed the TS7006 implicit `any` error is resolved

Closes #738
