### PR TITLE
fix(events): enforce schema validation at the producer boundary (W2-B…

### DIFF
--- a/src/jobs/producers/AuditLogProducer.ts
+++ b/src/jobs/producers/AuditLogProducer.ts
@@ -1,14 +1,9 @@
 import { BaseProducer } from './BaseProducer';
 import { QUEUES } from '../../config/rabbitmq';
-import { validateMessage } from '../../utils/rabbitmq-validation';
 import type { AuditLog } from '../../types/rabbitmq-schemas';
 
 export class AuditLogProducer extends BaseProducer<AuditLog> {
   protected queue = QUEUES.AUDIT_LOGS;
-
-  protected validate(payload: AuditLog): AuditLog {
-    return validateMessage<AuditLog>(this.queue, payload);
-  }
 }
 
 export const auditLogProducer = new AuditLogProducer();

--- a/src/jobs/producers/BaseProducer.test.ts
+++ b/src/jobs/producers/BaseProducer.test.ts
@@ -1,0 +1,57 @@
+import { BaseProducer } from './BaseProducer';
+import { auditLogProducer } from './AuditLogProducer';
+import { MessageValidationError } from '../../utils/rabbitmq-validation';
+import * as rabbitmq from '../../config/rabbitmq';
+
+jest.mock('../../config/rabbitmq', () => ({
+  getRabbitMQChannel: jest.fn(() => ({ sendToQueue: jest.fn() })),
+  assertQueueWithDLQ: jest.fn(async () => undefined),
+  QUEUES: { AUDIT_LOGS: 'audit_logs' },
+}));
+
+describe('BaseProducer (producer-boundary validation)', () => {
+  beforeEach(() => {
+    (rabbitmq.getRabbitMQChannel as jest.Mock).mockClear();
+    (rabbitmq.assertQueueWithDLQ as jest.Mock).mockClear();
+  });
+
+  it('enqueues a valid payload after schema validation', async () => {
+    await auditLogProducer.publish({ eventType: 'login', action: 'create' });
+
+    expect(rabbitmq.getRabbitMQChannel).toHaveBeenCalled();
+    const channel = (rabbitmq.getRabbitMQChannel as jest.Mock).mock.results[0].value;
+    expect(channel.sendToQueue).toHaveBeenCalledTimes(1);
+    expect(channel.sendToQueue.mock.calls[0][0]).toBe('audit_logs');
+  });
+
+  it('rejects a tampered payload (wrong field type) BEFORE enqueue', async () => {
+    await expect(
+      auditLogProducer.publish({ eventType: 123, action: 'create' } as never),
+    ).rejects.toBeInstanceOf(MessageValidationError);
+
+    expect(rabbitmq.getRabbitMQChannel).not.toHaveBeenCalled();
+  });
+
+  it('rejects a payload missing required fields BEFORE enqueue', async () => {
+    await expect(auditLogProducer.publish({ eventType: 'login' } as never)).rejects.toBeInstanceOf(
+      MessageValidationError,
+    );
+
+    expect(rabbitmq.getRabbitMQChannel).not.toHaveBeenCalled();
+  });
+
+  it('enforces validation even if a subclass bypasses validate()', async () => {
+    class BypassProducer extends BaseProducer<Record<string, unknown>> {
+      protected queue = 'audit_logs';
+      // Intentionally does NOT validate — the base boundary must still reject.
+      protected validate(payload: Record<string, unknown>) {
+        return payload;
+      }
+    }
+
+    const bypass = new BypassProducer();
+    await expect(bypass.publish({ eventType: 123 })).rejects.toBeInstanceOf(MessageValidationError);
+
+    expect(rabbitmq.getRabbitMQChannel).not.toHaveBeenCalled();
+  });
+});

--- a/src/jobs/producers/BaseProducer.ts
+++ b/src/jobs/producers/BaseProducer.ts
@@ -1,23 +1,37 @@
-import { getRabbitMQChannel, assertQueueWithDLQ } from '../../config/rabbitmq';
+import { assertQueueWithDLQ } from '../../config/rabbitmq';
 import { logger } from '../../config/logger';
-import { publishValidatedMessage } from '../../utils/rabbitmq-validation';
+import { publishValidatedMessage, validateMessage } from '../../utils/rabbitmq-validation';
 
 export abstract class BaseProducer<T> {
   protected abstract queue: string;
-  protected abstract validate(payload: T): T;
+
+  /**
+   * Optional subclass hook for additional, schema-specific checks or transforms.
+   * NOTE: schema validation at the producer boundary is ALWAYS performed by
+   * `publish()` below and can never be skipped by omitting this method.
+   */
+  protected validate?(payload: T): T | Promise<T>;
 
   async publish(payload: T, options?: { persistent?: boolean; priority?: number }): Promise<void> {
     try {
       // Ensure queue exists with DLQ
       await assertQueueWithDLQ(this.queue);
 
-      // Validate and publish
-      const validatedPayload = this.validate(payload);
-      await publishValidatedMessage(this.queue, validatedPayload, options);
+      // Producer-boundary validation: reject malformed or tampered payloads
+      // BEFORE they are enqueued. This guarantees the validation schemas in
+      // rabbitmq-schemas.ts are always honored, regardless of subclass behaviour.
+      const schemaValidated = validateMessage<T>(this.queue, payload);
+
+      // Optional subclass-specific post-schema checks/transforms.
+      const finalPayload = this.validate
+        ? await this.validate(schemaValidated)
+        : schemaValidated;
+
+      await publishValidatedMessage(this.queue, finalPayload, options);
 
       logger.debug('Message published successfully', {
         queue: this.queue,
-        payload: validatedPayload,
+        payload: finalPayload,
       });
     } catch (error) {
       logger.error('Failed to publish message', {

--- a/src/jobs/producers/EscrowEventProducer.ts
+++ b/src/jobs/producers/EscrowEventProducer.ts
@@ -1,14 +1,9 @@
 import { BaseProducer } from './BaseProducer';
 import { QUEUES } from '../../config/rabbitmq';
-import { validateMessage } from '../../utils/rabbitmq-validation';
 import type { EscrowEvent } from '../../types/rabbitmq-schemas';
 
 export class EscrowEventProducer extends BaseProducer<EscrowEvent> {
   protected queue = QUEUES.ACBU_ESCROW_EVENTS;
-
-  protected validate(payload: EscrowEvent): EscrowEvent {
-    return validateMessage<EscrowEvent>(this.queue, payload);
-  }
 }
 
 export const escrowEventProducer = new EscrowEventProducer();

--- a/src/jobs/producers/LendingPoolEventProducer.ts
+++ b/src/jobs/producers/LendingPoolEventProducer.ts
@@ -1,14 +1,9 @@
 import { BaseProducer } from './BaseProducer';
 import { QUEUES } from '../../config/rabbitmq';
-import { validateMessage } from '../../utils/rabbitmq-validation';
 import type { LendingPoolEvent } from '../../types/rabbitmq-schemas';
 
 export class LendingPoolEventProducer extends BaseProducer<LendingPoolEvent> {
   protected queue = QUEUES.ACBU_LENDING_POOL_EVENTS;
-
-  protected validate(payload: LendingPoolEvent): LendingPoolEvent {
-    return validateMessage<LendingPoolEvent>(this.queue, payload);
-  }
 }
 
 export const lendingPoolEventProducer = new LendingPoolEventProducer();

--- a/src/jobs/producers/SavingsVaultEventProducer.ts
+++ b/src/jobs/producers/SavingsVaultEventProducer.ts
@@ -1,14 +1,9 @@
 import { BaseProducer } from './BaseProducer';
 import { QUEUES } from '../../config/rabbitmq';
-import { validateMessage } from '../../utils/rabbitmq-validation';
 import type { SavingsVaultEvent } from '../../types/rabbitmq-schemas';
 
 export class SavingsVaultEventProducer extends BaseProducer<SavingsVaultEvent> {
   protected queue = QUEUES.ACBU_SAVINGS_VAULT_EVENTS;
-
-  protected validate(payload: SavingsVaultEvent): SavingsVaultEvent {
-    return validateMessage<SavingsVaultEvent>(this.queue, payload);
-  }
 }
 
 export const savingsVaultEventProducer = new SavingsVaultEventProducer();


### PR DESCRIPTION
Closes #793 

…-041)

- BaseProducer.publish now ALWAYS validates the payload against the queue's schema from rabbitmq-schemas.ts before enqueuing, so the validation schemas cannot be bypassed by a faulty/forgotten subclass override. Subclass validate() is kept only as an optional post-schema hook.
- Removed the now-redundant per-subclass validateMessage calls in the four concrete producers (AuditLog, Escrow, LendingPool, SavingsVault); validation is centralized in the base boundary.
- Added BaseProducer.test.ts proving the acceptance criterion: a tampered or malformed payload is rejected (MessageValidationError) and channel.sendToQueue is never called (i.e. rejected BEFORE enqueue). Also proves a subclass cannot skip validation.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
