### PR TITLE
fix(ci): set explicit timeout-minutes on every workflow job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,7 @@ jobs:
   lint-and-format:
     name: Lint & Format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 
@@ -34,6 +35,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       # Minimal env vars so Jest can load modules without connecting to real infra.
       # All external calls are mocked in tests.
@@ -71,6 +73,7 @@ jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     needs: [lint-and-format, test]
     steps:
       - uses: actions/checkout@v4
@@ -103,6 +106,7 @@ jobs:
   validate-migrations:
     name: Validate Migrations
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     needs: build
     # Only run on pull requests — push to main/dev triggers deploy, not re-validation
     if: github.event_name == 'pull_request'

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -12,6 +12,7 @@ on:
 jobs:
   snyk-scan:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     env:
       SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 

--- a/.github/workflows/verify-wasm-integrity.yml
+++ b/.github/workflows/verify-wasm-integrity.yml
@@ -22,6 +22,7 @@ jobs:
   verify-wasm-integrity:
     name: Verify WASM Checksums
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Closes #808 
All workflows previously omitted timeout-minutes, allowing hung jobs to consume runner minutes indefinitely. Add explicit timeouts per job:

- ci.yml: lint-and-format (10), test (20), build (20), validate-migrations (10)
- snyk.yml: snyk-scan (20)
- verify-wasm-integrity.yml: verify-wasm-integrity (10)

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
