### PR TITLE
fix: recovery_attempts migration + dead import cleanup

### DIFF
--- a/prisma/migrations/20260825000000_add_recovery_attempts/migration.sql
+++ b/prisma/migrations/20260825000000_add_recovery_attempts/migration.sql
@@ -1,0 +1,25 @@
+-- CreateTable
+CREATE TABLE "recovery_attempts" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "identifier" VARCHAR(255) NOT NULL,
+    "ip" VARCHAR(45),
+    "user_agent" VARCHAR(512),
+    "success" BOOLEAN NOT NULL DEFAULT false,
+    "reason" VARCHAR(255),
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "recovery_attempts_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "idx_recovery_attempt_user_id" ON "recovery_attempts"("user_id");
+
+-- CreateIndex
+CREATE INDEX "idx_recovery_attempt_identifier" ON "recovery_attempts"("identifier");
+
+-- CreateIndex
+CREATE INDEX "idx_recovery_attempt_created_at" ON "recovery_attempts"("created_at");
+
+-- CreateIndex
+CREATE INDEX "idx_recovery_attempt_success" ON "recovery_attempts"("success");

--- a/src/jobs/producers/BaseProducer.ts
+++ b/src/jobs/producers/BaseProducer.ts
@@ -1,4 +1,4 @@
-import { getRabbitMQChannel, assertQueueWithDLQ } from '../../config/rabbitmq';
+import { assertQueueWithDLQ } from '../../config/rabbitmq';
 import { logger } from '../../config/logger';
 import { publishValidatedMessage } from '../../utils/rabbitmq-validation';
 


### PR DESCRIPTION
Closes #742
Closes #727

## Summary

Two compiler errors fixed:

### High — TS2339 (9 errors in `rateLimitService.ts`)
`prisma.recoveryAttempt` was called throughout the rate-limiter but the `recovery_attempts` table had no migration — the model existed in `schema.prisma` but was never applied to the database, so Prisma Client never generated the accessor.

**Fix:** Added `prisma/migrations/20260825000000_add_recovery_attempts/migration.sql` creating the table with all columns and indexes matching the schema.

**After merge:** run `pnpm prisma:migrate:deploy && pnpm prisma:generate` to apply and regenerate the client.

### Low — TS6133 (dead import in `BaseProducer.ts`)
`getRabbitMQChannel` was imported but never used.

**Fix:** Removed it from the import statement.

## Testing
- `pnpm prisma:migrate:deploy` — applies migration cleanly
- `pnpm prisma:generate` — client includes `recoveryAttempt` accessor
- `pnpm build` / `tsc --noEmit` — both errors gone