### PR TITLE
Fix: Wire bulkTransfer config

### DIFF
--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -117,6 +117,9 @@ const envSchema = z.object({
     .toLowerCase()
     .pipe(z.enum(["true", "false"]))
     .default("false"),
+
+  BULK_TRANSFER_CHUNK_SIZE: z.coerce.number().int().positive().default(100),
+  BULK_TRANSFER_MAX_FILE_SIZE_BYTES: z.coerce.number().int().positive().default(10485760),
 });
 
 const parsed = envSchema.safeParse(process.env);
@@ -634,5 +637,10 @@ export const config = {
     leakThresholdPct: env.MEMORY_LEAK_THRESHOLD_PCT,
     checkIntervalMs: env.MEMORY_CHECK_INTERVAL_MS,
     heapDumpDir: env.HEAP_DUMP_DIR,
+  },
+
+  bulkTransfer: {
+    chunkSize: env.BULK_TRANSFER_CHUNK_SIZE,
+    maxFileSizeBytes: env.BULK_TRANSFER_MAX_FILE_SIZE_BYTES,
   },
 };


### PR DESCRIPTION
## Description
This PR resolves issue #735 by exposing the missing `bulkTransfer` object in the exported `config` object.

### Changes Made:
1. Added `BULK_TRANSFER_CHUNK_SIZE` and `BULK_TRANSFER_MAX_FILE_SIZE_BYTES` to the environment variable schema in `src/config/env.ts` with defaults matching the `.env.example` file.
2. Wired up `config.bulkTransfer` so that `src/services/enterpriseService.ts` can correctly access `chunkSize` and `maxFileSizeBytes` without throwing a TypeScript error.

Fixes #735