### PR TITLE
Fix: Import validateOperationsForTreasuryAccount

### DIFF
--- a/src/services/stellar/client.ts
+++ b/src/services/stellar/client.ts
@@ -9,6 +9,7 @@ import {
 import { config } from "../../config/env";
 import { logger } from "../../config/logger";
 import { CircuitBreaker } from "../../utils/circuitBreaker";
+import { validateOperationsForTreasuryAccount } from "./operationSecurity";
 
 const Server = Horizon.Server;
 
@@ -33,6 +34,7 @@ export class StellarClient {
   private network: "testnet" | "mainnet";
   private networkPassphrase: string;
   private keypair: Keypair | null = null;
+  private treasuryAccountId?: string;
   readonly horizonBreaker = new CircuitBreaker({ failureThreshold: 3, cooldownMs: 30_000, successThreshold: 2 });
 
   constructor(cfg?: Partial<StellarNetworkConfig>) {


### PR DESCRIPTION
## Description
This PR resolves issue #750 by importing the missing `validateOperationsForTreasuryAccount` treasury guard function and declaring the `treasuryAccountId` property in the `StellarClient` class.

### Changes Made:
1. Imported `validateOperationsForTreasuryAccount` from `./operationSecurity.ts` into `src/services/stellar/client.ts`.
2. Explicitly declared the `private treasuryAccountId?: string;` property in the `StellarClient` class.

Fixes #750