### PR TITLE
fix(logger): alert and quarantine invalid financial events instead of dropping them

### DIFF
--- a/src/config/logger.ts
+++ b/src/config/logger.ts
@@ -103,6 +103,27 @@ export const logger = winston.createLogger({
 
 // Structured Financial Logging
 
+// Audit dead-letter queue (DLQ) for financial events that fail validation.
+// Records are appended as newline-delimited JSON so they can be replayed,
+// alerted on, or reconciled later instead of vanishing from the audit trail.
+const FINANCIAL_EVENT_DLQ_FILENAME = "financial-events-dlq.log";
+
+export function getFinancialEventDlqFilePath(): string {
+  return path.join(logDir, FINANCIAL_EVENT_DLQ_FILENAME);
+}
+
+function writeFinancialEventDlq(record: Record<string, unknown>): void {
+  try {
+    fs.appendFileSync(getFinancialEventDlqFilePath(), `${JSON.stringify(record)}\n`, "utf8");
+  } catch (err) {
+    // Never let DLQ persistence failures propagate to callers; the error-level
+    // alert emitted alongside still surfaces the rejected event.
+    logger.error("Failed to persist invalid financial event to audit DLQ", {
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+}
+
 const REQUIRED_FIELDS: (keyof FinancialLogPayload)[] = [
   "event",
   "amount",
@@ -136,7 +157,20 @@ export function logFinancialEvent(payload: Omit<FinancialLogPayload, "timestamp"
     (f) => entry[f] === undefined || entry[f] === null || entry[f] === "",
   );
   if (missing.length > 0) {
-    logger.warn("logFinancialEvent: missing required fields", { missing, partial: entry });
+    // Error-level alert: a malformed financial event must never disappear
+    // from the audit trail silently (#791).
+    logger.error("logFinancialEvent: missing required fields — event quarantined to audit DLQ", {
+      missing,
+      partial: entry,
+    });
+    // Preserve the redacted partial record in the audit DLQ for replay and
+    // reconciliation instead of dropping it.
+    writeFinancialEventDlq({
+      reason: "missing_required_fields",
+      missing,
+      dlqTimestamp: new Date().toISOString(),
+      event: entry,
+    });
     return;
   }
 

--- a/tests/logger.financialEvent.test.ts
+++ b/tests/logger.financialEvent.test.ts
@@ -1,0 +1,112 @@
+import fs from "fs";
+import os from "os";
+import path from "path";
+
+describe("logFinancialEvent — invalid payload handling (#791)", () => {
+  let tmpDir: string;
+
+  const loadModule = () => {
+    // Reset the module registry so config/env and logger re-read LOG_FILE.
+    jest.resetModules();
+    process.env.LOG_FILE = path.join(tmpDir, "app.log");
+    return require("../src/config/logger") as typeof import("../src/config/logger");
+  };
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "acbu-dlq-"));
+  });
+
+  afterEach(() => {
+    delete process.env.LOG_FILE;
+    jest.restoreAllMocks();
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  const validPayload = {
+    event: "transfer.initiated",
+    amount: 1000,
+    currency: "NGN",
+    userId: "user-1",
+    accountId: "acct-1",
+    idempotencyKey: "idem-1",
+    transactionId: "tx-1",
+    status: "pending" as const,
+    correlationId: "corr-1",
+  };
+
+  it("raises an error-level alert when required fields are missing", () => {
+    const { logger, logFinancialEvent } = loadModule();
+    const errorSpy = jest.spyOn(logger, "error");
+    const warnSpy = jest.spyOn(logger, "warn");
+
+    logFinancialEvent({ ...validPayload, userId: undefined } as never);
+
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [message] = errorSpy.mock.calls[0];
+    expect(message).toContain("missing required fields");
+    // The old behaviour logged a mere warn — it must not be used anymore.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it("persists the partial record in the audit DLQ instead of dropping it", () => {
+    const { logger, logFinancialEvent, getFinancialEventDlqFilePath } = loadModule();
+    jest.spyOn(logger, "error");
+
+    logFinancialEvent({
+      ...validPayload,
+      transactionId: "",
+      currency: undefined,
+    } as never);
+
+    const dlqPath = getFinancialEventDlqFilePath();
+    expect(fs.existsSync(dlqPath)).toBe(true);
+
+    const lines = fs.readFileSync(dlqPath, "utf8").trim().split("\n");
+    expect(lines).toHaveLength(1);
+
+    const record = JSON.parse(lines[0]);
+    expect(record.reason).toBe("missing_required_fields");
+    expect(record.missing).toEqual(expect.arrayContaining(["currency", "transactionId"]));
+    expect(record.event.event).toBe("transfer.initiated");
+    expect(record.event.userId).toBe("user-1");
+    expect(typeof record.dlqTimestamp).toBe("string");
+  });
+
+  it("appends each invalid event as its own DLQ record", () => {
+    const { logger, logFinancialEvent, getFinancialEventDlqFilePath } = loadModule();
+    jest.spyOn(logger, "error");
+
+    logFinancialEvent({ ...validPayload, amount: undefined } as never);
+    logFinancialEvent({ ...validPayload, status: "" } as never);
+
+    const lines = fs.readFileSync(getFinancialEventDlqFilePath(), "utf8").trim().split("\n");
+    expect(lines).toHaveLength(2);
+    expect(JSON.parse(lines[0]).missing).toEqual(["amount"]);
+    expect(JSON.parse(lines[1]).missing).toEqual(["status"]);
+  });
+
+  it("redacts PII in the partial record written to the DLQ", () => {
+    const { logger, logFinancialEvent, getFinancialEventDlqFilePath } = loadModule();
+    jest.spyOn(logger, "error");
+
+    logFinancialEvent({
+      ...validPayload,
+      provider: "card 4111111111111111 charged",
+      errorCode: undefined,
+    } as never);
+
+    const raw = fs.readFileSync(getFinancialEventDlqFilePath(), "utf8");
+    expect(raw).not.toContain("4111111111111111");
+    expect(JSON.parse(raw.trim()).event.provider).toContain("[REDACTED]");
+  });
+
+  it("does not write to the DLQ for valid events", () => {
+    const { logger, logFinancialEvent, getFinancialEventDlqFilePath } = loadModule();
+    const infoSpy = jest.spyOn(logger, "info");
+
+    logFinancialEvent(validPayload);
+
+    expect(infoSpy).toHaveBeenCalledWith("financial_event", expect.objectContaining({ event: "transfer.initiated" }));
+    expect(fs.existsSync(getFinancialEventDlqFilePath())).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #791

## Problem
`logFinancialEvent` logged only a `warn` when a payload failed the required-field check and then returned, so malformed financial events silently vanished from the audit trail.

## Fix
- Emit an **error-level alert** ("missing required fields — event quarantined to audit DLQ") that includes the missing fields and the partial record, so monitoring can page on it.
- Persist the redacted partial record to an **audit dead-letter queue** (`financial-events-dlq.log`, newline-delimited JSON in the log directory) with the rejection reason, missing-field list, and a DLQ timestamp — enabling replay and reconciliation instead of silent loss.
- DLQ write failures never propagate to callers; they are surfaced via their own error-level log.

## Testing
- New suite `tests/logger.financialEvent.test.ts` covers: error-level alert raised on missing fields, partial record persisted to the DLQ, one record per invalid event, PII redaction inside the DLQ record, and no DLQ writes for valid events.

## Acceptance criteria (from the issue)
✅ Missing-field event raises an error-level alert.
✅ Partial record preserved in an audit DLQ instead of being dropped.