### PR TITLE
fix(auth): implement validateAdminKey middleware and admin route guard

### DIFF
--- a/src/middleware/auth.test.ts
+++ b/src/middleware/auth.test.ts
@@ -1,5 +1,6 @@
-import { validateApiKey, generateApiKey, hashApiKey } from "./auth";
-import { prisma } from "../config/database";
+import { validateApiKey, validateAdminKey, generateApiKey, hashApiKey } from "./auth";
+import { prisma as databasePrisma } from "../config/database";
+const prisma: any = databasePrisma;
 import bcrypt from "bcrypt";
 import jwt from "jsonwebtoken";
 import { AppError } from "./errorHandler";
@@ -42,7 +43,7 @@ const mockNext = jest.fn() as jest.MockedFunction<NextFunction>;
 describe("auth middleware", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    (prisma.apiKey.update as jest.Mock).mockResolvedValue({});
+    (prisma.apiKey.update as any).mockResolvedValue({});
   });
 
   describe("validateApiKey", () => {
@@ -54,11 +55,7 @@ describe("auth middleware", () => {
     });
 
     it("rejects malformed key format — 401 with message", async () => {
-      await validateApiKey(
-        makeReq({ headers: { "x-api-key": "bad_key" } }),
-        mockRes,
-        mockNext,
-      );
+      await validateApiKey(makeReq({ headers: { "x-api-key": "bad_key" } }), mockRes, mockNext);
       const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
       expect(err.statusCode).toBe(401);
       expect(err.message).toBe("Invalid API key format");
@@ -80,20 +77,16 @@ describe("auth middleware", () => {
       const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
       expect(err.statusCode).toBe(401);
       expect(err.message).toBe("Invalid credentials format");
-      expect(prisma.apiKey.findFirst).not.toHaveBeenCalled();
+      expect(prisma.apiKey.findFirst as any).not.toHaveBeenCalled();
     });
 
     it("rejects when lookup key not in DB — 401", async () => {
-      (prisma.apiKey.findFirst as jest.Mock).mockResolvedValue(null);
-      await validateApiKey(
-        makeReq({ headers: { "x-api-key": VALID_KEY } }),
-        mockRes,
-        mockNext,
-      );
+      (prisma.apiKey.findFirst as any).mockResolvedValue(null);
+      await validateApiKey(makeReq({ headers: { "x-api-key": VALID_KEY } }), mockRes, mockNext);
       const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
       expect(err.statusCode).toBe(401);
       expect(err.message).toBe("Invalid API key");
-      expect(prisma.apiKey.findFirst).toHaveBeenCalledWith(
+      expect(prisma.apiKey.findFirst as any).toHaveBeenCalledWith(
         expect.objectContaining({
           where: expect.objectContaining({
             AND: expect.arrayContaining([
@@ -110,33 +103,31 @@ describe("auth middleware", () => {
     });
 
     it("rejects when bcrypt compare fails — 401", async () => {
-      (prisma.apiKey.findFirst as jest.Mock).mockResolvedValue({
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
         id: "key-1",
         userId: "user-1",
         organizationId: null,
         permissions: [],
         rateLimit: 100,
         keyHash: "hashed",
+        keyType: "USER_KEY",
       });
       (bcrypt.compare as jest.Mock).mockResolvedValue(false);
-      await validateApiKey(
-        makeReq({ headers: { "x-api-key": VALID_KEY } }),
-        mockRes,
-        mockNext,
-      );
+      await validateApiKey(makeReq({ headers: { "x-api-key": VALID_KEY } }), mockRes, mockNext);
       const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
       expect(err.statusCode).toBe(401);
       expect(err.message).toBe("Invalid API key");
     });
 
     it("calls next() with no error and populates req.apiKey on valid key", async () => {
-      (prisma.apiKey.findFirst as jest.Mock).mockResolvedValue({
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
         id: "key-1",
         userId: "user-1",
         organizationId: null,
         permissions: ["p2p:read", "p2p:write"],
         rateLimit: 100,
         keyHash: "hashed",
+        keyType: "USER_KEY",
       });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
       const req = makeReq({ headers: { "x-api-key": VALID_KEY } });
@@ -152,13 +143,14 @@ describe("auth middleware", () => {
     });
 
     it("accepts Bearer token in Authorization header", async () => {
-      (prisma.apiKey.findFirst as jest.Mock).mockResolvedValue({
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
         id: "key-2",
         userId: "user-2",
         organizationId: null,
         permissions: [],
         rateLimit: 50,
         keyHash: "hashed2",
+        keyType: "USER_KEY",
       });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
       const req = makeReq({
@@ -170,13 +162,14 @@ describe("auth middleware", () => {
     });
 
     it("treats invalid permissions JSON as empty array", async () => {
-      (prisma.apiKey.findFirst as jest.Mock).mockResolvedValue({
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
         id: "key-3",
         userId: "user-3",
         organizationId: null,
         permissions: { invalid: true },
         rateLimit: 100,
         keyHash: "hashed",
+        keyType: "USER_KEY",
       });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
       const req = makeReq({ headers: { "x-api-key": VALID_KEY } });
@@ -185,25 +178,148 @@ describe("auth middleware", () => {
     });
 
     it("updates lastUsedAt asynchronously after valid auth", async () => {
-      (prisma.apiKey.findFirst as jest.Mock).mockResolvedValue({
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
         id: "key-1",
         userId: "user-1",
         organizationId: null,
         permissions: [],
         rateLimit: 100,
         keyHash: "hashed",
+        keyType: "USER_KEY",
       });
       (bcrypt.compare as jest.Mock).mockResolvedValue(true);
-      await validateApiKey(
-        makeReq({ headers: { "x-api-key": VALID_KEY } }),
+      await validateApiKey(makeReq({ headers: { "x-api-key": VALID_KEY } }), mockRes, mockNext);
+      // Allow async update to fire
+      await Promise.resolve();
+      expect(prisma.apiKey.update as any).toHaveBeenCalledWith(
+        expect.objectContaining({ where: { id: "key-1" } }),
+      );
+    });
+  });
+
+  describe("validateAdminKey", () => {
+    it("rejects request with no API key — 401", async () => {
+      await validateAdminKey(makeReq(), mockRes, mockNext);
+      const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(401);
+    });
+
+    it("rejects malformed key format — 401", async () => {
+      await validateAdminKey(
+        makeReq({ headers: { "x-api-key": "invalid_format" } }),
         mockRes,
         mockNext,
       );
-      // Allow async update to fire
-      await Promise.resolve();
-      expect(prisma.apiKey.update).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: "key-1" } }),
-      );
+      const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(401);
+    });
+
+    it("rejects non-admin key (USER_KEY) — 403", async () => {
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
+        id: "key-user",
+        userId: "user-1",
+        organizationId: null,
+        permissions: ["p2p:read"],
+        rateLimit: 100,
+        keyHash: "hashed",
+        keyType: "USER_KEY",
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const req = makeReq({ headers: { "x-api-key": VALID_KEY } });
+      await validateAdminKey(req, mockRes, mockNext);
+
+      const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(403);
+      expect(err.message).toBe("Admin key required for this operation");
+    });
+
+    it("accepts valid ADMIN_KEY — 200/next() and populates req.apiKey and req.adminId", async () => {
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
+        id: "key-admin",
+        userId: "admin-user-123",
+        organizationId: "org-1",
+        permissions: ["admin:write"],
+        rateLimit: 1000,
+        keyHash: "hashed",
+        keyType: "ADMIN_KEY",
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const req = makeReq({ headers: { "x-api-key": VALID_KEY } });
+      await validateAdminKey(req, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(req.apiKey).toBeDefined();
+      expect(req.apiKey?.keyType).toBe("ADMIN_KEY");
+      expect(req.adminId).toBe("admin-user-123");
+    });
+
+    it("accepts valid BREAK_GLASS_KEY — 200/next() and sets adminId", async () => {
+      (prisma.apiKey.findFirst as any).mockResolvedValue({
+        id: "key-bg",
+        userId: "emergency-user-456",
+        organizationId: "org-1",
+        permissions: ["admin:write"],
+        rateLimit: 1000,
+        keyHash: "hashed",
+        keyType: "BREAK_GLASS_KEY",
+        emergencyReason: "Production Incident",
+        emergencyExpiresAt: new Date(Date.now() + 3600000),
+      });
+      (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+      const req = makeReq({ headers: { authorization: `Bearer ${VALID_KEY}` } });
+      await validateAdminKey(req, mockRes, mockNext);
+
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(req.apiKey?.keyType).toBe("BREAK_GLASS_KEY");
+      expect(req.adminId).toBe("emergency-user-456");
+    });
+
+    it("handles pre-existing req.apiKey on request context", async () => {
+      const req = makeReq({
+        apiKey: {
+          id: "key-pre-existing",
+          userId: "admin-pre",
+          organizationId: null,
+          keyType: "ADMIN_KEY",
+          createdByUserId: null,
+          emergencyReason: null,
+          emergencyExpiresAt: null,
+          permissions: [],
+          rateLimit: 100,
+        },
+      });
+
+      await validateAdminKey(req, mockRes, mockNext);
+      expect(mockNext).toHaveBeenCalledWith();
+      expect(req.adminId).toBe("admin-pre");
+      expect(prisma.apiKey.findFirst as any).not.toHaveBeenCalled();
+    });
+
+    it("rejects pre-existing non-admin req.apiKey with 403", async () => {
+      const req = makeReq({
+        apiKey: {
+          id: "key-user-pre",
+          userId: "user-pre",
+          organizationId: null,
+          keyType: "USER_KEY",
+          createdByUserId: null,
+          emergencyReason: null,
+          emergencyExpiresAt: null,
+          permissions: [],
+          rateLimit: 100,
+        },
+      });
+
+      await validateAdminKey(req, mockRes, mockNext);
+      const err = (mockNext as jest.Mock).mock.calls[0][0] as AppError;
+      expect(err).toBeInstanceOf(AppError);
+      expect(err.statusCode).toBe(403);
     });
   });
 
@@ -219,10 +335,10 @@ describe("auth middleware", () => {
   describe("generateApiKey", () => {
     it("creates a DB record and returns key in acbu_<lookup>_<secret> format", async () => {
       (bcrypt.hash as jest.Mock).mockResolvedValue("$2b$10$hash");
-      (prisma.apiKey.create as jest.Mock).mockResolvedValue({});
+      (prisma.apiKey.create as any).mockResolvedValue({});
       const key = await generateApiKey("user-42", ["p2p:write"]);
       expect(key).toMatch(/^acbu_[a-f0-9]{12}_[a-f0-9]{64}$/);
-      expect(prisma.apiKey.create).toHaveBeenCalledWith(
+      expect(prisma.apiKey.create as any).toHaveBeenCalledWith(
         expect.objectContaining({
           data: expect.objectContaining({
             userId: "user-42",

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -30,6 +30,7 @@ export interface AuthRequest extends Request {
     permissions: PermissionScope[];
     rateLimit: number;
   };
+  adminId?: string;
   /** Set by audience-specific routes (e.g. /retail, /business, /government) for limits and behaviour. */
   audience?: Audience;
   /** Optional user tier populated by upstream middleware/services for authorization checks. */
@@ -65,9 +66,7 @@ function validatePermissions(permissions: unknown): PermissionScope[] {
   return valid;
 }
 
-function parseApiKey(
-  rawApiKey: string,
-): { lookupKey: string; secret: string } | null {
+function parseApiKey(rawApiKey: string): { lookupKey: string; secret: string } | null {
   const match = rawApiKey.trim().match(API_KEY_FORMAT);
   if (!match) {
     return null;
@@ -100,10 +99,7 @@ function rejectIfJwtToken(token: string): void {
         // Check if this is a challenge token (has 2fa_challenge audience)
         if (decoded.aud === "2fa_challenge" && decoded.iss === "acbu/auth") {
           logger.error("Attempted to use 2FA challenge token for API access");
-          throw new AppError(
-            "Challenge tokens cannot be used for API access",
-            401,
-          );
+          throw new AppError("Challenge tokens cannot be used for API access", 401);
         }
         // Reject any JWT-like token that isn't a standard API key
         logger.warn("Non-API-key JWT token rejected for API access");
@@ -125,9 +121,7 @@ export const validateApiKey = async (
   next: NextFunction,
 ): Promise<void> => {
   try {
-    const apiKey =
-      req.headers["x-api-key"] ||
-      req.headers["authorization"]?.replace("Bearer ", "");
+    const apiKey = req.headers["x-api-key"] || req.headers["authorization"]?.replace("Bearer ", "");
 
     if (!apiKey || typeof apiKey !== "string") {
       throw new AppError("API key is required", 401);
@@ -169,10 +163,7 @@ export const validateApiKey = async (
     }
 
     // Single bcrypt verification.
-    const isValid = await bcrypt.compare(
-      parsedApiKey.secret,
-      apiKeyRecord.keyHash,
-    );
+    const isValid = await bcrypt.compare(parsedApiKey.secret, apiKeyRecord.keyHash);
     if (!isValid) {
       throw new AppError("Invalid API key", 401);
     }
@@ -183,9 +174,7 @@ export const validateApiKey = async (
         where: { id: apiKeyRecord.id },
         data: { lastUsedAt: new Date() },
       })
-      .catch((e: any) =>
-        logger.error("Failed to update API key lastUsedAt", { e }),
-      );
+      .catch((e: any) => logger.error("Failed to update API key lastUsedAt", { e }));
 
     req.apiKey = {
       id: apiKeyRecord.id,
@@ -202,6 +191,47 @@ export const validateApiKey = async (
     if (apiKeyRecord.user?.tier) {
       req.userTier = apiKeyRecord.user.tier as UserTier;
     }
+
+    next();
+  } catch (error) {
+    next(error);
+  }
+};
+
+export const ADMIN_KEY_TYPES: ApiKeyType[] = ["ADMIN_KEY", "BREAK_GLASS_KEY"];
+
+/**
+ * Middleware to validate admin API key
+ * Requires a valid API key with ADMIN_KEY or BREAK_GLASS_KEY type.
+ * Sets req.adminId for downstream route handlers / audit trails.
+ */
+export const validateAdminKey = async (
+  req: AuthRequest,
+  res: Response,
+  next: NextFunction,
+): Promise<void> => {
+  try {
+    if (!req.apiKey) {
+      await new Promise<void>((resolve, reject) => {
+        validateApiKey(req, res, (err?: unknown) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
+
+    if (!req.apiKey) {
+      throw new AppError("API key is required", 401);
+    }
+
+    if (!ADMIN_KEY_TYPES.includes(req.apiKey.keyType)) {
+      throw new AppError("Admin key required for this operation", 403);
+    }
+
+    req.adminId = req.apiKey.userId ?? req.apiKey.createdByUserId ?? req.apiKey.id;
 
     next();
   } catch (error) {

--- a/src/middleware/rateLimiter.ts
+++ b/src/middleware/rateLimiter.ts
@@ -2,11 +2,7 @@ import { Request, Response, NextFunction } from "express";
 import rateLimit from "express-rate-limit";
 import { config } from "../config/env";
 import { getMongoDB } from "../config/mongodb";
-import type {
-  ClientRateLimitInfo,
-  Options as RateLimitOptions,
-  Store,
-} from "express-rate-limit";
+import type { ClientRateLimitInfo, Options as RateLimitOptions, Store } from "express-rate-limit";
 import { AuthRequest } from "./auth";
 import { cacheService, sanitizeKey } from "../utils/cache";
 import { logger } from "../config/logger";
@@ -47,10 +43,7 @@ const fallbackMetrics = {
   lastFailureAt: null as number | null,
 };
 
-const incrementFallback = (
-  key: string,
-  windowMs: number,
-): { count: number } => {
+const incrementFallback = (key: string, windowMs: number): { count: number } => {
   const now = Date.now();
   const existing = fallbackRateLimitStore.get(key);
   if (!existing || existing.expiresAt <= now) {
@@ -199,10 +192,13 @@ class MongoRateLimitStore implements Store {
         },
       );
     } catch (error) {
-      logger.warn("MongoRateLimitStore.decrement failed, skipping (in-memory fallback has no decrement)", {
-        namespace: this.prefix,
-        error: error instanceof Error ? error.message : String(error),
-      });
+      logger.warn(
+        "MongoRateLimitStore.decrement failed, skipping (in-memory fallback has no decrement)",
+        {
+          namespace: this.prefix,
+          error: error instanceof Error ? error.message : String(error),
+        },
+      );
     }
   }
 
@@ -332,12 +328,10 @@ export const apiKeyRateLimiter = async (
   try {
     // Atomic increment with cap — MongoDB only increments when count < max.
     // Returns null when the cap is reached, no separate count check needed.
-    const cached = await cacheService.increment<{ count: number }>(
-      cacheKey,
-      "count",
-      1,
-      { ttl: windowMs / 1000, max: maxRequests },
-    );
+    const cached = await cacheService.increment<{ count: number }>(cacheKey, "count", 1, {
+      ttl: windowMs / 1000,
+      max: maxRequests,
+    });
 
     // Success - record for circuit breaker
     circuitBreaker.recordSuccess();
@@ -394,6 +388,16 @@ export const authRateLimiter = createRateLimiter(
 );
 
 /**
+ * Rate limiter for admin endpoints
+ */
+export const adminRateLimiter = createRateLimiter(
+  config.rateLimitWindowMs,
+  config.rateLimitMaxRequests,
+  "ip",
+  "admin",
+);
+
+/**
  * Per-user/IP rate limiter for sensitive auth endpoints: 2FA verify, passcode reset.
  * Fixes #269 — brute-force of 2FA tokens and passcodes is possible at line speed
  * when only an IP-based limiter is applied.
@@ -409,11 +413,7 @@ export const authRateLimiter = createRateLimiter(
 const TWO_FA_WINDOW_MS = 15 * 60 * 1000; // 15 minutes
 const TWO_FA_MAX_REQUESTS = 5;
 
-export const twoFaRateLimiter = (
-  req: AuthRequest,
-  res: Response,
-  next: NextFunction,
-): void => {
+export const twoFaRateLimiter = (req: AuthRequest, res: Response, next: NextFunction): void => {
   // Extract a user-scoped identifier from the request body.
   // For /signin: body.identifier (username/email/phone)
   // For /signin/verify-2fa: body.challenge_token (contains userId in jti prefix)
@@ -421,8 +421,7 @@ export const twoFaRateLimiter = (
   const body = (req.body ?? {}) as Record<string, unknown>;
   const userHint =
     (typeof body.identifier === "string" && body.identifier.slice(0, 32)) ||
-    (typeof body.challenge_token === "string" &&
-      body.challenge_token.slice(-16)) ||
+    (typeof body.challenge_token === "string" && body.challenge_token.slice(-16)) ||
     (typeof body.email === "string" && body.email.slice(0, 32)) ||
     "anon";
 
@@ -445,8 +444,7 @@ export const twoFaRateLimiter = (
     res.status(429).json({
       error: {
         code: "RATE_LIMIT_EXCEEDED",
-        message:
-          "Too many authentication attempts. Please wait 15 minutes before trying again.",
+        message: "Too many authentication attempts. Please wait 15 minutes before trying again.",
       },
     });
     return;
@@ -458,11 +456,7 @@ export const twoFaRateLimiter = (
 /**
  * Middleware to inject fallback state into request context for downstream logging
  */
-export const injectFallbackState = (
-  req: AuthRequest,
-  _res: Response,
-  next: NextFunction,
-): void => {
+export const injectFallbackState = (req: AuthRequest, _res: Response, next: NextFunction): void => {
   (req as any).rateLimiterState = {
     circuitState: circuitBreaker.getState(),
     isFallback: !circuitBreaker.canExecute(),

--- a/tests/routes/weightDriftAuditRoutes.test.ts
+++ b/tests/routes/weightDriftAuditRoutes.test.ts
@@ -1,0 +1,141 @@
+import express, { Express } from "express";
+import request from "supertest";
+import bcrypt from "bcrypt";
+import weightDriftAuditRoutes from "../../src/routes/weightDriftAuditRoutes";
+import { errorHandler } from "../../src/middleware/errorHandler";
+import { prisma as databasePrisma } from "../../src/config/database";
+import { weightDriftAuditService } from "../../src/services/reserve/WeightDriftAuditService";
+
+const prisma: any = databasePrisma;
+
+jest.mock("../../src/config/database", () => ({
+  prisma: {
+    apiKey: {
+      findFirst: jest.fn(),
+      update: jest.fn().mockResolvedValue({}),
+    },
+  },
+}));
+
+jest.mock("../../src/config/logger", () => ({
+  logger: {
+    error: jest.fn(),
+    warn: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+jest.mock("bcrypt", () => ({
+  compare: jest.fn(),
+  hash: jest.fn(),
+}));
+
+jest.mock("../../src/services/reserve/WeightDriftAuditService", () => ({
+  weightDriftAuditService: {
+    listAudits: jest.fn(),
+    getAudit: jest.fn(),
+    createAudit: jest.fn(),
+    calculateDriftReport: jest.fn(),
+    approveAudit: jest.fn(),
+    rejectAudit: jest.fn(),
+  },
+}));
+
+const VALID_KEY = "acbu_" + "a".repeat(12) + "_" + "b".repeat(64);
+
+describe("Weight Drift Audit Routes - Admin Auth Protection", () => {
+  let app: Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (prisma.apiKey.update as any).mockResolvedValue({});
+
+    app = express();
+    app.use(express.json());
+    app.use("/v1/admin/weight-drift-audits", weightDriftAuditRoutes);
+    app.use(errorHandler);
+  });
+
+  it("returns 401 when unauthenticated request calls admin route", async () => {
+    const res = await request(app).get("/v1/admin/weight-drift-audits");
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBeDefined();
+  });
+
+  it("returns 401 when malformed API key is provided", async () => {
+    const res = await request(app)
+      .get("/v1/admin/weight-drift-audits")
+      .set("x-api-key", "invalid-key-format");
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when authenticated key has USER_KEY type", async () => {
+    (prisma.apiKey.findFirst as any).mockResolvedValue({
+      id: "key-user-1",
+      userId: "user-1",
+      organizationId: null,
+      permissions: ["p2p:read"],
+      rateLimit: 100,
+      keyHash: "hashed",
+      keyType: "USER_KEY",
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+
+    const res = await request(app).get("/v1/admin/weight-drift-audits").set("x-api-key", VALID_KEY);
+
+    expect(res.status).toBe(403);
+    expect(res.body.error?.message).toContain("Admin key required");
+  });
+
+  it("allows access and returns 200 when authenticated with ADMIN_KEY", async () => {
+    (prisma.apiKey.findFirst as any).mockResolvedValue({
+      id: "key-admin-1",
+      userId: "admin-user-1",
+      organizationId: "org-1",
+      permissions: ["admin:write"],
+      rateLimit: 1000,
+      keyHash: "hashed",
+      keyType: "ADMIN_KEY",
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    (weightDriftAuditService.listAudits as jest.Mock).mockResolvedValue({
+      audits: [],
+      total: 0,
+    });
+
+    const res = await request(app).get("/v1/admin/weight-drift-audits").set("x-api-key", VALID_KEY);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      audits: [],
+      pagination: { limit: 20, offset: 0, total: 0 },
+    });
+  });
+
+  it("allows access with Bearer header when authenticated with BREAK_GLASS_KEY", async () => {
+    (prisma.apiKey.findFirst as any).mockResolvedValue({
+      id: "key-bg-1",
+      userId: "emergency-admin-1",
+      organizationId: "org-1",
+      permissions: ["admin:write"],
+      rateLimit: 1000,
+      keyHash: "hashed",
+      keyType: "BREAK_GLASS_KEY",
+      emergencyReason: "Urgent fix",
+      emergencyExpiresAt: new Date(Date.now() + 3600000),
+    });
+    (bcrypt.compare as jest.Mock).mockResolvedValue(true);
+    (weightDriftAuditService.listAudits as jest.Mock).mockResolvedValue({
+      audits: [],
+      total: 0,
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/weight-drift-audits")
+      .set("Authorization", `Bearer ${VALID_KEY}`);
+
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
## Overview
Implements and exports the missing `validateAdminKey` middleware in `src/middleware/auth.ts` and `adminRateLimiter` in `src/middleware/rateLimiter.ts`, properly securing admin routes such as weight drift audit endpoints.

## Related Issue
Closes #801

## Changes
### backend/auth
* **[MODIFY]** `src/middleware/auth.ts`
  * Implemented and exported `validateAdminKey` middleware requiring `ADMIN_KEY` or `BREAK_GLASS_KEY` types
  * Added `adminId` to `AuthRequest` interface
* **[MODIFY]** `src/middleware/rateLimiter.ts`
  * Exported `adminRateLimiter` middleware
* **[MODIFY]** `src/middleware/auth.test.ts`
  * Added unit test coverage for `validateAdminKey` (401 on missing/malformed key, 403 on non-admin key, 200 on valid admin key)
* **[ADD]** `tests/routes/weightDriftAuditRoutes.test.ts`
  * Added route-level integration tests verifying admin authentication enforcement

## Verification Results
```text
PASS tests/adminAuth.test.ts
PASS tests/segmentGuard.test.ts
PASS src/middleware/auth.test.ts
PASS tests/routes/weightDriftAuditRoutes.test.ts

Test Suites: 4 passed, 4 total
Tests:       38 passed, 38 total
Snapshots:   0 total
```

| Acceptance Criteria | Status |
| :--- | :--- |
| Unauthenticated admin call returns 401 | ✅ Verified via unit and route tests |
| Missing \`validateAdminKey\` resolved | ✅ Implemented and exported |
| Admin endpoints secured | ✅ Enforced on weight drift audit routes |