### PR TITLE
fix(compliance): remove unused imports in complianceController

### DIFF
--- a/src/controllers/complianceController.ts
+++ b/src/controllers/complianceController.ts
@@ -1,9 +1,6 @@
 import { Response, NextFunction } from "express";
-import type { Prisma } from "@prisma/client";
 import { AuthRequest } from "../middleware/auth";
-import { prisma } from "../config/database";
 import { AppError } from "../middleware/errorHandler";
-import { logger } from "../config/logger";
 import { getAuditExports } from "../services/reports/reportService";
 import { tombstoneDeleteUser } from "../services/user";
 


### PR DESCRIPTION
closes #718  



Prisma, prisma, and logger were imported but never referenced after a prior refactor. Removing them resolves TS6133 errors and keeps the module clean.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
