### PR TITLE
fix(reserve): import logAudit instead of nonexistent auditService.log…

### DIFF
--- a/src/services/reserve/WeightDriftAuditService.ts
+++ b/src/services/reserve/WeightDriftAuditService.ts
@@ -13,7 +13,7 @@ import { prisma } from "../../config/database";
 import { logger } from "../../config/logger";
 import { basketService } from "../basket";
 import { reserveTracker } from "../reserve/ReserveTracker";
-import { auditService } from "../audit";
+import { logAudit } from "../audit";
 import { Decimal } from "@prisma/client/runtime/library";
 
 const DRIFT_THRESHOLD_PCT = 2; // Trigger audit if drift exceeds 2%
@@ -148,7 +148,7 @@ export class WeightDriftAuditService {
       }
 
       // Emit audit log for audit creation
-      await auditService.logAuditEntry({
+      await logAudit({
         eventType: "WEIGHT_DRIFT_AUDIT_CREATED",
         entityType: "WeightDriftAudit",
         entityId: auditRecord.id,
@@ -208,7 +208,7 @@ export class WeightDriftAuditService {
       });
 
       // Emit audit log for approval
-      await auditService.logAuditEntry({
+      await logAudit({
         eventType: "WEIGHT_DRIFT_AUDIT_APPROVED",
         entityType: "WeightDriftAudit",
         entityId: auditId,
@@ -258,7 +258,7 @@ export class WeightDriftAuditService {
       });
 
       // Emit audit log for rejection
-      await auditService.logAuditEntry({
+      await logAudit({
         eventType: "WEIGHT_DRIFT_AUDIT_REJECTED",
         entityType: "WeightDriftAudit",
         entityId: auditId,


### PR DESCRIPTION

Closes #743 
## Summary
`WeightDriftAuditService.ts` imported a named export `auditService` from `../audit` that was never defined there — only `logAudit()` and the `AuditEntry` type are exported from that module (see `src/services/audit/index.ts`). This caused a TS2305 compile error and meant weight-drift audit entries could never actually be written.

Every other service in the codebase (bills, auth, mint/burn controllers) logs audit entries by calling `logAudit({...})` directly — `WeightDriftAuditService.ts` was the only file written against a nonexistent `auditService.logAuditEntry()` API.

Fix: updated the import to pull in `logAudit` instead of the nonexistent `auditService`, and updated all three call sites (`createAudit`, `approveAudit`, `rejectAudit`) to call `logAudit(...)` directly, matching the established pattern.

## Scope
- [x] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [x] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #743 
- Related PR(s):