### PR TITLE
ci: add Dockerfile and GHCR publish job (#811)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,7 @@ jobs:
           --health-timeout 5s
           --health-retries 10
 
+
     env:
       DATABASE_URL: postgresql://acbu_ci:acbu_ci_pw@localhost:5432/acbu_ci
 
@@ -187,3 +188,48 @@ jobs:
           --to-url "$DATABASE_URL"
           --shadow-database-url "postgresql://acbu_ci:acbu_ci_pw@localhost:5432/acbu_ci_shadow"
           --exit-code
+
+  docker-build-publish:
+    name: Build and Publish Docker Image
+    runs-on: ubuntu-latest
+    needs: build
+    # Only publish images on pushes to the main/dev branches, not on PRs
+    if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/develop')
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels)
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=ref,event=branch
+            type=sha
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Output image digest
+        run: echo "Image pushed with digest ${{ steps.build-and-push.outputs.digest }}"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+# Stage 1: Builder
+FROM node:22-alpine AS builder
+
+# Install build tools for native dependencies (e.g., bcrypt)
+RUN apk add --no-cache python3 make g++
+
+# Setup pnpm
+RUN corepack enable && corepack prepare pnpm@10.33.1 --activate
+
+WORKDIR /app
+
+# Install dependencies first (caching layer)
+COPY package.json pnpm-lock.yaml ./
+COPY prisma ./prisma/
+RUN pnpm install --frozen-lockfile
+
+# Copy source and build
+COPY . .
+RUN pnpm prisma:generate
+RUN pnpm build
+
+# Stage 2: Runner
+FROM node:22-alpine AS runner
+
+# Install build tools for native dependencies in prod
+RUN apk add --no-cache python3 make g++
+
+# Setup pnpm
+RUN corepack enable && corepack prepare pnpm@10.33.1 --activate
+
+WORKDIR /app
+ENV NODE_ENV=production
+
+# Install only production dependencies
+COPY package.json pnpm-lock.yaml ./
+COPY prisma ./prisma/
+RUN pnpm install --frozen-lockfile --prod
+RUN pnpm prisma:generate
+
+# Copy compiled dist from builder
+COPY --from=builder /app/dist ./dist
+
+EXPOSE 5000
+
+CMD ["pnpm", "start"]


### PR DESCRIPTION
## Summary
- Added a production-ready, multi-stage `Dockerfile` based on `node:22-alpine`, including the necessary build tools (`python3`, `make`, `g++`) to compile native dependencies like `bcrypt`.
- Appended a `docker-build-publish` job to `.github/workflows/ci.yml` to automatically build and push the Docker image to GitHub Container Registry (GHCR) when code is merged to `main`, `dev`, or `develop`.
- Implemented image tagging by branch and SHA digest, resolving Issue #811 where image builds were failing to surface before deployment time.

Closes #811 

## Scope
- [ ] Backend API behavior
- [x] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`
*(Note: Validated Dockerfile syntax and GitHub Actions workflow configuration locally).*

## Links
- Issue(s): #811
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->