### PR TITLE
ci: replace hardcoded services with docker compose up (#821)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,20 +117,6 @@ jobs:
     # Migrations never touch shared/staging databases — GitHub destroys the
     # service container as soon as the job finishes, so every run starts
     # from an empty database and full isolation is guaranteed.
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: acbu_ci
-          POSTGRES_PASSWORD: acbu_ci_pw
-          POSTGRES_DB: acbu_ci
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U acbu_ci -d acbu_ci"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
 
     env:
       DATABASE_URL: postgresql://acbu_ci:acbu_ci_pw@localhost:5432/acbu_ci
@@ -141,6 +127,18 @@ jobs:
           # Fetch full history so the destructive-migration gate can diff
           # schema.prisma against the pull request base commit
           fetch-depth: 0
+
+      - name: Start local dev infrastructure
+        env:
+          POSTGRES_USER: acbu_ci
+          POSTGRES_PASSWORD: acbu_ci_pw
+          POSTGRES_DB: acbu_ci
+          MONGO_USER: acbu_ci
+          MONGO_PASSWORD: acbu_ci_pw
+          MONGO_DB: acbu_ci_cache
+          RABBITMQ_USER: acbu_ci
+          RABBITMQ_PASSWORD: acbu_ci_pw
+        run: docker compose up -d --wait
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/cross-repo-e2e-nightly.yml
+++ b/.github/workflows/cross-repo-e2e-nightly.yml
@@ -19,46 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
 
-    services:
-      postgres:
-        image: postgres:16-alpine
-        env:
-          POSTGRES_USER: acbu_e2e
-          POSTGRES_PASSWORD: acbu_e2e_pw
-          POSTGRES_DB: acbu_e2e
-        ports:
-          - 5432:5432
-        options: >-
-          --health-cmd "pg_isready -U acbu_e2e -d acbu_e2e"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-
-      mongodb:
-        image: mongo:7-alpine
-        ports:
-          - 27017:27017
-        options: >-
-          --health-cmd "mongosh --eval db.adminCommand('ping')"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-
-      rabbitmq:
-        image: rabbitmq:3.13-management-alpine
-        ports:
-          - 5672:5672
-          - 15672:15672
-        options: >-
-          --health-cmd "rabbitmq-diagnostics -q status"
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 10
-
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Start local dev infrastructure
+        env:
+          POSTGRES_USER: acbu_e2e
+          POSTGRES_PASSWORD: acbu_e2e_pw
+          POSTGRES_DB: acbu_e2e
+          MONGO_USER: acbu_e2e
+          MONGO_PASSWORD: acbu_e2e_pw
+          MONGO_DB: acbu_e2e_cache
+          RABBITMQ_USER: acbu_e2e
+          RABBITMQ_PASSWORD: acbu_e2e_pw
+        run: docker compose up -d --wait
 
       - uses: pnpm/action-setup@v4
         with:


### PR DESCRIPTION
## Summary
- Removed hardcoded GitHub Actions `services:` blocks for PostgreSQL, MongoDB, and RabbitMQ from `.github/workflows/ci.yml` and `.github/workflows/cross-repo-e2e-nightly.yml`.
- Replaced the hardcoded services with a step that runs `docker compose up -d --wait`, feeding the necessary credentials via environment variables to satisfy the secure defaults enforced in #604.
- Resolves Issue #821 by guaranteeing strict infrastructure parity between local development environments and the CI pipeline, eliminating configuration drift.

## Scope
- [ ] Backend API behavior
- [x] Build/CI only
- [ ] Docs only
- [ ] Other

Closes #821 

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`
*(Note: Validated locally via visual inspection of YAML syntax and indentation).*

## Links
- Issue(s): #821
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->