### PR TITLE
fix(W2-B-065): fix swapRace and burn idempotency test failures

### DIFF
--- a/src/config/rabbitmq.ts
+++ b/src/config/rabbitmq.ts
@@ -1,4 +1,4 @@
-import amqp, { Channel, ChannelModel, ConfirmChannel } from "amqplib";
+import amqp, { ChannelModel, ConfirmChannel } from "amqplib";
 import { config } from "./env";
 import { logger } from "./logger";
 

--- a/tests/swapRace.test.ts
+++ b/tests/swapRace.test.ts
@@ -1,7 +1,7 @@
 process.env.DATABASE_URL = "postgresql://test:test@localhost/test";
 process.env.MONGODB_URI = "mongodb://localhost/test";
 process.env.RABBITMQ_URL = "amqp://localhost";
-process.env.JWT_SECRET = "test-secret";
+process.env.JWT_SECRET = "test-secret-min-32-characters-long";
 
 jest.mock("../src/config/database", () => ({
   prisma: {


### PR DESCRIPTION
- Remove unused Channel import from src/config/rabbitmq.ts (TS6133) which caused swapRace.test.ts suite to fail at compile time
- Extend JWT_SECRET in swapRace.test.ts to meet the 32-char minimum required by the env validator (was 'test-secret', now 34 chars)
- burn.idempotency.test.ts already passes; no source changes needed

Acceptance: both test suites pass deterministically (7/7 tests)

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
closes #775