### PR TITLE
ci: enforce pnpm audit gate for high severity vulnerabilities (#783)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   lint-and-format:
-    name: Lint & Format
+    name: Lint, Format & Security Audit
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,6 +24,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Run security audit
+        run: pnpm audit --audit-level high
 
       - name: Run ESLint
         run: pnpm lint


### PR DESCRIPTION
## Summary
- Added a `pnpm audit --audit-level high` step to the `lint-and-format` job in `.github/workflows/ci.yml`.
- This ensures the CI pipeline acts as a strict security gate, failing automatically if any `high` or `critical` severity vulnerabilities are detected in the dependency tree.

## Scope
- [ ] Backend API behavior
- [x] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`
*(Note: Validated locally via `pnpm audit --audit-level high`. It successfully caught an existing high-severity vulnerability in a nested Prisma dependency, confirming the gate functions as intended).*

## Links
- Issue(s): 
Closes #783
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->