### PR TITLE
ci: configure dependabot and auto-merge for dependencies (#825)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,26 @@
 version: 2
 updates:
-  - package-ecosystem: "pnpm"
+  # Maintain dependencies for pnpm/npm
+  - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "monthly"
+      interval: "weekly"
+    labels:
+      - "dependencies"
     open-pull-requests-limit: 10
-    allow:
-      - dependency-type: "direct"
-      - dependency-type: "indirect"
+
+  # Maintain GitHub Actions in workflows
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "monthly"
-    open-pull-requests-limit: 5
+      interval: "weekly"
+    labels:
+      - "dependencies"
+
+  # Maintain Docker images
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,30 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    name: Auto-Approve & Merge
+    runs-on: ubuntu-latest
+    # Only run this job if the PR was opened by Dependabot
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+
+      - name: Approve and auto-merge
+        # We only auto-merge patch and minor updates to prevent breaking changes
+        if: steps.metadata.outputs.update-type == 'version-update:semver-patch' || steps.metadata.outputs.update-type == 'version-update:semver-minor'
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
## Summary
- Reconfigured `.github/dependabot.yml` to automatically track and update dependencies for `npm` (which handles pnpm), `github-actions`, and `docker` on a weekly schedule.
- Added a new GitHub Actions workflow (`.github/workflows/dependabot-auto-merge.yml`) to automatically approve and squash-merge Dependabot PRs if they are non-breaking (`patch` or `minor` updates).
- Resolves the issue of lingering CVEs by automating dependency hygiene and keeping environments up to date with zero manual intervention required for safe version bumps.

## Scope
- [ ] Backend API behavior
- [x] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`
*(Note: Validated locally by ensuring the YAML structure meets GitHub's native Dependabot syntax specifications).*

## Links
- Issue(s): Closes #825
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->