### PR TITLE
fix: resolve Express route registration type error

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -229,6 +229,7 @@ app.use(
   webhookRoutes,
 );
 app.use(
+  "/",
   express.json({
     inflate: true,
     limit: MAX_REQUEST_BODY_SIZE,


### PR DESCRIPTION
Closes #721 
W2-B-011 — Fix Express Route Registration Type Error

Fixed the Express route registration issue in "src/index.ts:234" that caused TS2769 due to the middleware handler being passed in an incorrect argument position.

Updated the route registration to use the correct Express "app.(path, handler)" structure, ensuring the affected endpoint is registered and handled correctly.

Result: The TypeScript error is resolved and the endpoint can be reached successfully, returning HTTP 200 for the end-to-end request.