### PR TITLE
fix(migrations): repair tx-hash dedup that blocked prisma migrate deploy

### DIFF
--- a/prisma/migrations/20260423000000_unique_transactions_blockchain_tx_hash/migration.sql
+++ b/prisma/migrations/20260423000000_unique_transactions_blockchain_tx_hash/migration.sql
@@ -1,11 +1,23 @@
 -- B-074: prevent replay submissions with the same blockchain tx hash for burn transactions.
 -- Deduplicate pre-existing rows before enforcing the constraint.
--- For each (type, blockchain_tx_hash) pair with duplicates, keep the oldest and delete newer rows.
+-- For each (type, blockchain_tx_hash) pair with duplicates, keep the oldest
+-- (by created_at) and delete newer rows. Rows with NULL type or hash are never
+-- duplicates and are preserved.
+-- NOTE: transactions.id is a UUID, so MIN(id)/MAX(id) do not exist in Postgres;
+-- ordering by created_at (then id as tiebreaker) instead.
 DELETE FROM "transactions" t
-WHERE id NOT IN (
-  SELECT MIN(id) FROM "transactions"
-  WHERE "type" IS NOT NULL AND "blockchain_tx_hash" IS NOT NULL
-  GROUP BY "type", "blockchain_tx_hash"
+WHERE t.id IN (
+  SELECT id FROM (
+    SELECT
+      id,
+      ROW_NUMBER() OVER (
+        PARTITION BY "type", "blockchain_tx_hash"
+        ORDER BY "created_at" ASC, "id" ASC
+      ) AS rn
+    FROM "transactions"
+    WHERE "type" IS NOT NULL AND "blockchain_tx_hash" IS NOT NULL
+  ) ranked
+  WHERE rn > 1
 );
 
 -- Postgres UNIQUE allows multiple NULLs, so this enforces uniqueness only when present.

--- a/scripts/ci/check-migration-sql.js
+++ b/scripts/ci/check-migration-sql.js
@@ -1,0 +1,185 @@
+"use strict";
+
+/**
+ * Static guard against known-broken SQL patterns in Prisma migrations.
+ *
+ * Current checks (#755):
+ * 1. AGGREGATE_ON_UUID — MIN/MAX/SUM/AVG called directly on a UUID column.
+ *    PostgreSQL has no min(uuid)/max(uuid) aggregate (SQLSTATE 42883, P3018),
+ *    so e.g. `SELECT MIN(id) FROM "transactions"` makes `prisma migrate deploy`
+ *    fail and blocks every migration after it. Cast to text first
+ *    (`MIN(id::text)`) or rewrite with a window function.
+ * 2. USERS_STELLAR_ADDRESS_SNAKE_CASE — `stellar_address` referenced against the
+ *    `users` table. The column is `"stellarAddress"` (camelCase); `users` has no
+ *    snake_case column. (on_ramp_swaps.stellar_address is a different, valid
+ *    column and is not flagged.)
+ */
+
+const fs = require("node:fs");
+const path = require("node:path");
+
+const MIGRATIONS_ROOT = path.join(__dirname, "..", "..", "prisma", "migrations");
+const SCHEMA_PATH = path.join(__dirname, "..", "..", "prisma", "schema.prisma");
+const MAX_STATEMENT_LENGTH = 220;
+
+// MIN/MAX/SUM/AVG over a (possibly quoted / table-qualified) bare column reference.
+// Casts like MIN(id::text) do NOT match because the argument continues past the column name.
+const AGGREGATE_RE =
+  /\b(MIN|MAX|SUM|AVG)\s*\(\s*(?:"?[A-Za-z_]\w*"?\s*\.\s*)?"?([A-Za-z_]\w*)"?\s*\)/gi;
+
+const STELLAR_ADDRESS_SNAKE_RE = /\bstellar_address\b/i;
+
+// Table-reference contexts that indicate `users` is the target table.
+const USERS_TABLE_RE = /\b(?:FROM|INTO|UPDATE|TABLE)\s+"?users"?\b/i;
+
+function truncateStatement(statement) {
+  const compact = statement.replace(/\s+/g, " ").trim();
+  if (compact.length <= MAX_STATEMENT_LENGTH) {
+    return compact;
+  }
+  return `${compact.slice(0, MAX_STATEMENT_LENGTH - 3)}...`;
+}
+
+function splitSqlStatements(sql) {
+  return sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+    .map((statement) => (statement.endsWith(";") ? statement : `${statement};`));
+}
+
+/**
+ * Remove SQL comments (dash-dash line comments and slash-star ... star-slash
+ * blocks) so the guards analyze executable statements only, not explanatory
+ * text.
+ */
+function stripSqlComments(sql) {
+  return sql.replace(/\/\*[\s\S]*?\*\//g, "").replace(/--[^\n]*/g, "");
+}
+
+/**
+ * Collect every identifier that maps to a UUID column in schema.prisma:
+ * the Prisma field name and its @map("...") column name (when present).
+ */
+function getUuidIdentifiers(schemaSql) {
+  const identifiers = new Set();
+  for (const line of schemaSql.split("\n")) {
+    if (!/@db\.Uuid/.test(line)) {
+      continue;
+    }
+    const fieldMatch = /^\s*([A-Za-z_]\w*)/.exec(line);
+    if (fieldMatch) {
+      identifiers.add(fieldMatch[1]);
+    }
+    const mapMatch = /@map\("([^"]+)"\)/.exec(line);
+    if (mapMatch) {
+      identifiers.add(mapMatch[1]);
+    }
+  }
+  return identifiers;
+}
+
+function findUuidAggregates(sql, uuidIdentifiers) {
+  const findings = [];
+  let match;
+  while ((match = AGGREGATE_RE.exec(sql)) !== null) {
+    const column = match[2];
+    if (uuidIdentifiers.has(column)) {
+      findings.push({
+        kind: "AGGREGATE_ON_UUID",
+        aggregate: match[1].toUpperCase(),
+        column,
+        statement: truncateStatement(match[0]),
+      });
+    }
+  }
+  return findings;
+}
+
+function findUsersStellarAddressSnakeCase(sql) {
+  const findings = [];
+  for (const statement of splitSqlStatements(sql)) {
+    if (!USERS_TABLE_RE.test(statement)) {
+      continue;
+    }
+    if (STELLAR_ADDRESS_SNAKE_RE.test(statement)) {
+      findings.push({
+        kind: "USERS_STELLAR_ADDRESS_SNAKE_CASE",
+        column: "stellar_address",
+        statement: truncateStatement(statement),
+      });
+    }
+  }
+  return findings;
+}
+
+function collectFindings(migrationSql) {
+  const uuidIdentifiers = getUuidIdentifiers(fs.readFileSync(SCHEMA_PATH, "utf8"));
+  const executableSql = stripSqlComments(migrationSql);
+  return [
+    ...findUuidAggregates(executableSql, uuidIdentifiers),
+    ...findUsersStellarAddressSnakeCase(executableSql),
+  ];
+}
+
+function getAllMigrationFiles(root = MIGRATIONS_ROOT) {
+  if (!fs.existsSync(root)) {
+    return [];
+  }
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.isDirectory()) {
+      files.push(...getAllMigrationFiles(path.join(root, entry.name)));
+    } else if (entry.name.endsWith(".sql")) {
+      files.push(path.join(root, entry.name));
+    }
+  }
+  return files;
+}
+
+function scanMigrations(root = MIGRATIONS_ROOT) {
+  const findings = [];
+  for (const file of getAllMigrationFiles(root)) {
+    const sql = fs.readFileSync(file, "utf8");
+    const fileFindings = collectFindings(sql);
+    for (const finding of fileFindings) {
+      findings.push({
+        source: path.relative(path.join(root, "..", ".."), file),
+        ...finding,
+      });
+    }
+  }
+  return findings;
+}
+
+function formatFinding(finding) {
+  return `- [${finding.source}] ${finding.kind} (${finding.aggregate ?? ""}${finding.aggregate ? "(" : ""}${finding.column}${finding.aggregate ? ")" : ""}): ${finding.statement}`;
+}
+
+function main() {
+  const findings = scanMigrations();
+  if (findings.length === 0) {
+    console.log("No broken migration SQL patterns detected.");
+    return;
+  }
+  console.error("Broken migration SQL patterns detected:");
+  for (const finding of findings) {
+    console.error(formatFinding(finding));
+  }
+  process.exit(1);
+}
+
+if (require.main === module) {
+  main();
+}
+
+module.exports = {
+  getUuidIdentifiers,
+  findUuidAggregates,
+  findUsersStellarAddressSnakeCase,
+  stripSqlComments,
+  collectFindings,
+  getAllMigrationFiles,
+  scanMigrations,
+  splitSqlStatements,
+};

--- a/tests/migrationSqlGuard.test.ts
+++ b/tests/migrationSqlGuard.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Migration SQL guard tests (#755).
+ *
+ * Guards against the two known-broken migration patterns that blocked
+ * `prisma migrate deploy` on a clean database:
+ * 1. MIN/MAX/SUM/AVG aggregates applied directly to UUID columns
+ *    (Postgres has no min(uuid) — SQLSTATE 42883 / P3018).
+ * 2. `stellar_address` referenced against the `users` table (the real
+ *    column is "stellarAddress").
+ */
+const {
+  getUuidIdentifiers,
+  findUuidAggregates,
+  findUsersStellarAddressSnakeCase,
+  collectFindings,
+  scanMigrations,
+} = require("../scripts/ci/check-migration-sql");
+
+describe("getUuidIdentifiers", () => {
+  it("collects plain and @map-ed uuid fields from schema.prisma", () => {
+    const ids = getUuidIdentifiers(`
+      model User {
+        id       String   @id @default(uuid()) @db.Uuid
+        userId   String   @map("user_id") @db.Uuid
+        currency String   @db.VarChar(3)
+        stars    Int      @db.Integer
+      }
+    `);
+
+    expect(ids.has("id")).toBe(true);
+    expect(ids.has("userId")).toBe(true);
+    expect(ids.has("user_id")).toBe(true);
+    expect(ids.has("currency")).toBe(false);
+    expect(ids.has("stars")).toBe(false);
+  });
+});
+
+describe("findUuidAggregates", () => {
+  const uuidIdentifiers = getUuidIdentifiers(`
+    model Transaction {
+      id       String   @id @default(uuid()) @db.Uuid
+      userId   String   @map("user_id") @db.Uuid
+      amount   Decimal  @db.Decimal(20, 8)
+    }
+  `);
+
+  it("flags MIN/MAX/SUM/AVG on a plain uuid column", () => {
+    const findings = findUuidAggregates(
+      'DELETE FROM "transactions" t WHERE id NOT IN (SELECT MIN(id) FROM "transactions");',
+      uuidIdentifiers,
+    );
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        kind: "AGGREGATE_ON_UUID",
+        aggregate: "MIN",
+        column: "id",
+      }),
+    ]);
+  });
+
+  it("flags aggregates on quoted and table-qualified uuid columns", () => {
+    const findings = findUuidAggregates(
+      'SELECT MAX("user_id") FROM t; SELECT SUM(t.userId) FROM t; SELECT AVG(t."audit_id") FROM t;',
+      uuidIdentifiers,
+    );
+
+    expect(findings.map((f: { column: string }) => f.column)).toEqual(["user_id", "userId"]);
+  });
+
+  it("ignores aggregates on non-uuid columns and COUNT", () => {
+    const findings = findUuidAggregates(
+      "SELECT MIN(amount) FROM t; SELECT MAX(created_at) FROM t; SELECT COUNT(id) FROM t;",
+      uuidIdentifiers,
+    );
+
+    expect(findings).toEqual([]);
+  });
+
+  it("ignores aggregates with an explicit cast (safe form)", () => {
+    const findings = findUuidAggregates(
+      'SELECT MIN(id::text) FROM "transactions";',
+      uuidIdentifiers,
+    );
+
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("findUsersStellarAddressSnakeCase", () => {
+  it("flags stellar_address used against the users table", () => {
+    const findings = findUsersStellarAddressSnakeCase(`
+      SELECT COUNT(*) FROM users
+      WHERE stellar_address IS NOT NULL AND LENGTH(stellar_address) != 56;
+    `);
+
+    expect(findings).toEqual([
+      expect.objectContaining({
+        kind: "USERS_STELLAR_ADDRESS_SNAKE_CASE",
+        column: "stellar_address",
+      }),
+    ]);
+  });
+
+  it("does not flag the valid on_ramp_swaps.stellar_address column", () => {
+    const findings = findUsersStellarAddressSnakeCase(`
+      CREATE TABLE "on_ramp_swaps" (
+        "id" UUID NOT NULL,
+        "stellar_address" VARCHAR(56) NOT NULL
+      );
+    `);
+
+    expect(findings).toEqual([]);
+  });
+
+  it("does not flag the correct camelCase users column", () => {
+    const findings = findUsersStellarAddressSnakeCase(`
+      ALTER TABLE users
+      ADD CONSTRAINT chk_valid_stellar_address
+      CHECK ("stellarAddress" IS NULL OR LENGTH("stellarAddress") = 56);
+    `);
+
+    expect(findings).toEqual([]);
+  });
+});
+
+describe("collectFindings", () => {
+  it("detects both broken patterns in one migration file", () => {
+    const findings = collectFindings(`
+      DELETE FROM "transactions" t WHERE id NOT IN (
+        SELECT MIN(id) FROM "transactions"
+      );
+      ALTER TABLE users ADD CONSTRAINT c CHECK (
+        "stellarAddress" IS NULL OR LENGTH(stellar_address) = 56
+      );
+    `);
+
+    expect(findings.map((f: { kind: string }) => f.kind)).toEqual([
+      "AGGREGATE_ON_UUID",
+      "USERS_STELLAR_ADDRESS_SNAKE_CASE",
+    ]);
+  });
+});
+
+describe("scanMigrations (real repo files)", () => {
+  it("finds no broken patterns in the current migration history", () => {
+    const findings = scanMigrations();
+
+    expect(findings).toEqual([]);
+  });
+});


### PR DESCRIPTION
Closes #755

## Summary

`prisma migrate deploy` on a clean database now reaches the latest migration. The acceptance criterion is verified end-to-end against a fresh Postgres 16 instance (all 25 migrations apply, and `prisma migrate diff --from-migrations` reports "No difference detected").

## What changed

- **`prisma/migrations/20260423000000_unique_transactions_blockchain_tx_hash/migration.sql`** — replaced the broken dedup `DELETE ... WHERE id NOT IN (SELECT MIN(id) ...)` (Postgres has no `min(uuid)` aggregate → P3018 / SQLSTATE 42883, which blocked every migration after it) with a `ROW_NUMBER() OVER (PARTITION BY type, blockchain_tx_hash ORDER BY created_at, id)` rewrite that keeps the oldest row and preserves rows with NULL type/hash.
- **`scripts/ci/check-migration-sql.js`** (new) — static guard that flags (1) `MIN/MAX/SUM/AVG` aggregates over UUID columns declared in `schema.prisma`, and (2) `users.stellar_address` (the column is `"stellarAddress"`), so neither bug can be reintroduced.
- **`tests/migrationSqlGuard.test.ts`** (new) — unit tests mirroring the repo's `destructiveMigrationGate` pattern: success paths, each failure pattern, edge cases (quoted/table-qualified columns, safe casts, `COUNT`, `on_ramp_swaps.stellar_address` false-positive), plus a scan of the real migration history asserting zero findings.

## Key design decisions

- **Edited the migration in place instead of squash/rebase.** The migration has never applied to any database (deploy stops at it with P3018 and never records it in `_prisma_migrations`), so editing it is safe and keeps history readable.
- **Guard reads `schema.prisma` for `@db.Uuid` columns** (field names and `@map`ed column names) so it catches `MIN(user_id)`-style bugs too, not just `id`.
- **Comments are stripped before analysis** so explanatory text doesn't false-positive the guard.

## Step C note (issue/code mismatch, stated plainly)

The issue's evidence points at `20260426000000_add_stellar_address_validation/migration.sql` using `users.stellar_address`. On the current `dev`, that migration was **already fixed** by commit `7ad2dc4` (it now uses `"stellarAddress"` and applies cleanly — the `chk_valid_stellar_address` constraint and its index are verified present in the deployed DB). The **actual current blocker** for the acceptance criterion was a different migration: `20260423000000_unique_transactions_blockchain_tx_hash`, broken by commit `9efca66` (added `MIN(id)` on a UUID column). That is what this PR repairs.

## Acceptance criteria

- [x] `prisma migrate deploy` on a clean database reaches the latest migration — verified: `All migrations have been successfully applied` (25/25) on fresh Postgres 16
- [x] Migration history stays self-consistent — `prisma migrate diff --from-migrations ... --exit-code` → `No difference detected`
- [x] `chk_valid_stellar_address` constraint and `idx_users_stellar_address_not_null` exist after deploy (the #755-named migration works)
- [x] Regression guard + tests pass — 10/10 in `tests/migrationSqlGuard.test.ts`, and the real-history scan is clean

## Test output

```
Test Suites: 1 passed, 1 total
Tests:       10 passed, 10 total   (tests/migrationSqlGuard.test.ts)
```

Coverage note: the changed code paths are the migration SQL (executed by Postgres, not Jest) and the guard script (plain JS). Jest's configured coverage threshold applies only to `./src/services/transfer/`; the guard's logic is exercised by the 10 unit tests above.

## Honest follow-ups

- The repo still carries ~47 pre-existing strict tsc errors in unrelated files (`authController`, `stellar/client`, `weightDriftAuditJob`, etc.) — not touched by this PR.
- Wiring `check-migration-sql.js` into CI (like `check-destructive-migrations.js`) would make the guard run on every PR; for now it's enforced by the unit test scanning the real migration history.

## Security note

No credentials or secrets involved. The dedup rewrite changes data-destruction semantics for the better: the previous SQL would have deleted every row with a NULL `type` or `blockchain_tx_hash`; the new one preserves them. No production database ever applied the broken migration, so there is no data to remediate.
