### PR TITLE
docs(index): clarify intentionally-unused _req in error handler (#722)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -238,6 +238,8 @@ app.use(
   }),
 );
 
+// Express requires a 4-arg signature to be recognized as an error handler;
+// `_req` is intentionally unused and prefixed to satisfy noUnusedParameters (#722).
 app.use(
   (
     err: Error & { type?: string },


### PR DESCRIPTION
The TS6133 unused-parameter error on the 4-arg Express error handler was already resolved by prefixing the param with an underscore (2aa5ce47). This adds a comment so the reason is clear to reviewers and it isn't accidentally 'fixed' by removing the required 4th-arity signature.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): closes #722 
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->
