### PR TITLE
fix(#449): validate Content-Length against actual body size

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import { requestMetricsMiddleware } from "./middleware/metrics";
 import { errorHandler, AppError } from "./middleware/errorHandler";
 import { standardRateLimiter } from "./middleware/rateLimiter";
 import { userAgentFilter } from "./middleware/userAgentFilter";
+import { verifyContentLength } from "./middleware/bodyParser";
 import { swaggerSpec } from "./config/swagger";
 import routes from "./routes";
 import webhookRoutes from "./routes/webhookRoutes";
@@ -225,7 +226,8 @@ app.use(
     inflate: true,
     limit: MAX_REQUEST_BODY_SIZE,
     type: "application/json",
-    verify: (req: express.Request, _res: express.Response, buf: Buffer) => {
+    verify: (req: express.Request, res: express.Response, buf: Buffer, encoding: string) => {
+      verifyContentLength(req, res, buf, encoding);
       (req as unknown as { rawBody?: Buffer }).rawBody = Buffer.from(buf);
     },
   }),
@@ -236,7 +238,8 @@ app.use(
   express.json({
     inflate: true,
     limit: MAX_REQUEST_BODY_SIZE,
-    verify: (req: express.Request, _res: express.Response, buf: Buffer) => {
+    verify: (req: express.Request, res: express.Response, buf: Buffer, encoding: string) => {
+      verifyContentLength(req, res, buf, encoding);
       (req as unknown as { rawBody?: Buffer }).rawBody = Buffer.from(buf);
     },
   }),
@@ -265,6 +268,24 @@ app.use(
         error: {
           code: "UNSUPPORTED_CONTENT_ENCODING",
           message: "Unsupported request body encoding",
+        },
+      });
+      return;
+    }
+    if (err?.type === "content_length.mismatch") {
+      res.status(400).json({
+        error: {
+          code: "CONTENT_LENGTH_MISMATCH",
+          message: err.message,
+        },
+      });
+      return;
+    }
+    if (err?.type === "content_length.invalid") {
+      res.status(400).json({
+        error: {
+          code: "INVALID_CONTENT_LENGTH",
+          message: "Invalid Content-Length header",
         },
       });
       return;

--- a/src/middleware/bodyParser.ts
+++ b/src/middleware/bodyParser.ts
@@ -1,56 +1,69 @@
-import type { NextFunction, Request, Response } from "express";
+import type { Request, Response } from "express";
 
 /**
- * Validates that the Content-Length header, when present, matches the actual
- * received body size. A mismatch indicates a truncated or padded payload and
- * is rejected before it reaches the JSON/urlencoded parsers.
+ * A `verify` callback compatible with express `body-parser` options
+ * (e.g. `express.json({ verify: verifyContentLength })`).
+ *
+ * The body-parser library invokes this function after reading the full raw
+ * request body into `buf`, so we have the actual byte count and can compare
+ * it against the declared `Content-Length` header before any JSON parsing
+ * begins.
+ *
+ * Why here rather than a standalone middleware?
+ * -------------------------------------------------
+ * Express body-parser (used internally by `express.json`) consumes the
+ * request stream.  A standalone middleware registered *before* the parser
+ * would have to re-read the stream itself, causing the stream to be consumed
+ * twice.  A standalone middleware registered *after* the parser only sees the
+ * already-parsed body, not the raw bytes.  The `verify` hook is the only
+ * safe place to inspect raw bytes AND short-circuit before parsing commits.
+ *
+ * Behaviour:
+ * - If `Content-Length` is absent or cannot be parsed as a non-negative
+ *   integer the request passes through unchanged (trusting the underlying
+ *   body-parser size limit configured via `limit`).
+ * - If the actual byte count does NOT match the declared value, throws an
+ *   error with `status: 400` so express-body-parser converts it into a
+ *   400 response before the route handler is reached.
  *
  * Fixes #449.
  */
-export function validateContentLength(req: Request, res: Response, next: NextFunction): void {
+export function verifyContentLength(
+  req: Request,
+  _res: Response,
+  buf: Buffer,
+  _encoding: string,
+): void {
   const declared = req.headers["content-length"];
 
-  // No header — nothing to validate; downstream parsers handle it.
+  // No header — nothing to validate.
   if (declared === undefined) {
-    next();
     return;
   }
 
   const declaredBytes = parseInt(declared, 10);
+
+  // Malformed or negative value — reject early.
   if (isNaN(declaredBytes) || declaredBytes < 0) {
-    res.status(400).json({
-      error: { code: "INVALID_CONTENT_LENGTH", message: "Invalid Content-Length header" },
+    const err = Object.assign(new Error("Invalid Content-Length header"), {
+      status: 400,
+      type: "content_length.invalid",
     });
-    return;
+    throw err;
   }
 
-  let received = 0;
-  req.on("data", (chunk: Buffer) => {
-    received += chunk.length;
-    // Early abort if body already exceeds declared size.
-    if (received > declaredBytes) {
-      res.status(400).json({
-        error: {
-          code: "CONTENT_LENGTH_MISMATCH",
-          message: "Request body exceeds declared Content-Length",
-        },
-      });
-      req.destroy();
-    }
-  });
+  const actualBytes = buf.length;
 
-  req.on("end", () => {
-    if (!res.headersSent && received !== declaredBytes) {
-      res.status(400).json({
-        error: {
-          code: "CONTENT_LENGTH_MISMATCH",
-          message: "Request body size does not match Content-Length",
-        },
-      });
-      return;
-    }
-    if (!res.headersSent) {
-      next();
-    }
-  });
+  if (actualBytes !== declaredBytes) {
+    const err = Object.assign(
+      new Error(
+        `Content-Length mismatch: declared ${declaredBytes} bytes but received ${actualBytes} bytes`,
+      ),
+      {
+        status: 400,
+        type: "content_length.mismatch",
+      },
+    );
+    throw err;
+  }
 }

--- a/tests/bodyParser.test.ts
+++ b/tests/bodyParser.test.ts
@@ -1,0 +1,129 @@
+import type { Request, Response } from "express";
+import { verifyContentLength } from "../src/middleware/bodyParser";
+
+/**
+ * Build a minimal mock Request with optional headers.
+ */
+function makeReq(headers: Record<string, string> = {}): Request {
+  return { headers } as unknown as Request;
+}
+
+const mockRes = {} as Response;
+
+describe("verifyContentLength", () => {
+  describe("when Content-Length header is absent", () => {
+    it("does not throw", () => {
+      const req = makeReq({});
+      const buf = Buffer.from('{"foo":"bar"}');
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).not.toThrow();
+    });
+  });
+
+  describe("when Content-Length matches actual body size", () => {
+    it("does not throw", () => {
+      const body = '{"amount":100}';
+      const buf = Buffer.from(body);
+      const req = makeReq({ "content-length": String(buf.length) });
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).not.toThrow();
+    });
+
+    it("handles an empty body with Content-Length: 0", () => {
+      const buf = Buffer.alloc(0);
+      const req = makeReq({ "content-length": "0" });
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).not.toThrow();
+    });
+  });
+
+  describe("when Content-Length is smaller than actual body (padding attack)", () => {
+    it("throws with status 400 and type content_length.mismatch", () => {
+      const buf = Buffer.from('{"amount":100,"extra":"padding"}');
+      const req = makeReq({ "content-length": "5" }); // claims only 5 bytes
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).toThrow(
+        expect.objectContaining({
+          status: 400,
+          type: "content_length.mismatch",
+        }),
+      );
+    });
+  });
+
+  describe("when Content-Length is larger than actual body (truncation / smuggling)", () => {
+    it("throws with status 400 and type content_length.mismatch", () => {
+      const buf = Buffer.from('{"x":1}');
+      const req = makeReq({ "content-length": "9999" }); // inflated value
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).toThrow(
+        expect.objectContaining({
+          status: 400,
+          type: "content_length.mismatch",
+        }),
+      );
+    });
+
+    it("error message contains declared and actual byte counts", () => {
+      const buf = Buffer.from("hello");
+      const req = makeReq({ "content-length": "100" });
+      let errorMessage = "";
+      try {
+        verifyContentLength(req, mockRes, buf, "utf-8");
+      } catch (err: unknown) {
+        errorMessage = (err as Error).message;
+      }
+      expect(errorMessage).toMatch(/100/);
+      expect(errorMessage).toMatch(/5/);
+    });
+  });
+
+  describe("when Content-Length header is malformed", () => {
+    it("throws with status 400 and type content_length.invalid for non-numeric value", () => {
+      const buf = Buffer.from('{"x":1}');
+      const req = makeReq({ "content-length": "abc" });
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).toThrow(
+        expect.objectContaining({
+          status: 400,
+          type: "content_length.invalid",
+        }),
+      );
+    });
+
+    it("throws with status 400 and type content_length.invalid for negative value", () => {
+      const buf = Buffer.from('{"x":1}');
+      const req = makeReq({ "content-length": "-1" });
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).toThrow(
+        expect.objectContaining({
+          status: 400,
+          type: "content_length.invalid",
+        }),
+      );
+    });
+
+    it("throws for an empty string value", () => {
+      const buf = Buffer.from("data");
+      const req = makeReq({ "content-length": "" });
+      expect(() => verifyContentLength(req, mockRes, buf, "utf-8")).toThrow(
+        expect.objectContaining({
+          status: 400,
+          type: "content_length.invalid",
+        }),
+      );
+    });
+  });
+
+  describe("multi-byte UTF-8 content", () => {
+    it("compares raw byte length, not character count", () => {
+      // "€" (U+20AC) is 1 character but 3 UTF-8 bytes
+      const str = "€€"; // 2 chars, 6 bytes
+      const buf = Buffer.from(str, "utf-8");
+      expect(buf.length).toBe(6);
+
+      // Correct byte count should pass
+      const reqOk = makeReq({ "content-length": "6" });
+      expect(() => verifyContentLength(reqOk, mockRes, buf, "utf-8")).not.toThrow();
+
+      // Character count (2) should fail
+      const reqBad = makeReq({ "content-length": "2" });
+      expect(() => verifyContentLength(reqBad, mockRes, buf, "utf-8")).toThrow(
+        expect.objectContaining({ type: "content_length.mismatch" }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
The previous bodyParser.ts exported validateContentLength as a stream-reading middleware, but the request stream is consumed by express.json before that middleware could read it — a race condition that made the check unreachable.

This fix:
- Rewrites verifyContentLength as a body-parser verify callback so it receives the raw Buffer directly from express.json, after the full body has been read and before any parsing begins.
- Wires the callback into both express.json registrations (webhook and general) in index.ts, composing it with the existing rawBody capture.
- Adds two new error cases to the body-parser error handler: content_length.mismatch → 400 CONTENT_LENGTH_MISMATCH content_length.invalid  → 400 INVALID_CONTENT_LENGTH
- Adds 10 unit tests covering absent header (pass-through), exact match, inflated/deflated declared size, malformed header values, and multi-byte UTF-8 byte counting.

## Summary
- Describe the change and why it is needed.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- Issue(s): #
- Related PR(s): #

<!--
Use relative references (`#123`) for issues/PRs.
Avoid hardcoded repository-owner URLs like:
https://github.com/<owner>/<repo>/pull/<id>
This prevents stale links if org/user ownership changes.
-->

Closes #449 