### PR TITLE
fix(rates): use Decimal methods instead of .toNumber() in convertLocalToUsdWithPrecision

### DIFF
--- a/src/services/rates/currencyConverter.ts
+++ b/src/services/rates/currencyConverter.ts
@@ -170,7 +170,7 @@ export async function convertLocalToUsdWithPrecision(
   // Retrieve the local-to-ACBU rate
   const localToAcbuRate = latestRate[rateFieldName as keyof typeof latestRate];
 
-  if (!localToAcbuRate || localToAcbuRate.toNumber() <= 0) {
+  if (!localToAcbuRate || new Decimal(localToAcbuRate).isNegative() || new Decimal(localToAcbuRate).isZero()) {
     throw new AppError(
       `Exchange rate for ${currency} is not available or invalid. Cannot process deposit at this time.`,
       503,
@@ -187,7 +187,7 @@ export async function convertLocalToUsdWithPrecision(
   // Get USD rate per ACBU
   const acbuUsdRate = new Decimal(latestRate.acbuUsd);
 
-  if (acbuUsdRate.toNumber() <= 0) {
+  if (acbuUsdRate.isNegative() || acbuUsdRate.isZero()) {
     throw new AppError(
       "USD conversion rate is invalid. Cannot process deposit at this time.",
       503,


### PR DESCRIPTION
## Summary

Fixes TS2339 compilation errors in convertLocalToUsdWithPrecision where .toNumber() was called directly on a rate field value with Prisma union type string | Date | Decimal.

## Changes

- **src/services/rates/currencyConverter.ts**: Replaced .toNumber() <= 0 calls with 
ew Decimal().isNegative() / .isZero() in convertLocalToUsdWithPrecision, consistent with the fix already applied to convertLocalToUsd.

## Issues

- Closes #739
- Closes #736 (InvestmentStrategy model already exists in schema and migration — confirmed resolved)

## Verification

The fix ensures:
1. Rate values are properly wrapped in Decimal before comparison, avoiding TS2339 errors
2. Consistent Decimal math across both conversion functions
3. No runtime behavior change — identical comparison semantics