### PR TITLE
fix(webhooks): harden signature bypass and add event idempotency

### DIFF
--- a/prisma/migrations/20260826000000_add_webhook_event_id/migration.sql
+++ b/prisma/migrations/20260826000000_add_webhook_event_id/migration.sql
@@ -1,0 +1,5 @@
+ALTER TABLE "webhooks" ADD COLUMN "event_id" VARCHAR(255);
+
+CREATE UNIQUE INDEX "idx_webhooks_event_id_unique"
+  ON "webhooks"("event_id")
+  WHERE "event_id" IS NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -326,6 +326,7 @@ model AuditTrail {
 model Webhook {
   id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
   transactionId String?   @map("transaction_id") @db.Uuid
+  eventId       String?   @map("event_id") @db.VarChar(255)
   eventType     String    @map("event_type") @db.VarChar(50)
   payload       Json
   signature     String?   @db.VarChar(255)
@@ -338,6 +339,7 @@ model Webhook {
 
   @@index([transactionId], map: "idx_webhooks_transaction_id")
   @@index([status], map: "idx_webhooks_status")
+  @@index([eventId], map: "idx_webhooks_event_id")
   // #758: composite index for filtering pending/failed webhooks by event type (hot path in retry queue)
   @@index([eventType, status], map: "idx_webhooks_event_type_status")
   // #758: composite index for retry queue worker — find pending webhooks ordered by creation time

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -22,6 +22,7 @@ envFiles.forEach((file) => {
 
 const envSchema = z.object({
   NODE_ENV: z.string().default("development"),
+  WEBHOOK_SIGNATURE_BYPASS: z.string().optional(),
   PORT: z.coerce.number().int().positive().max(65535).default(5000),
   API_VERSION: z.string().default("v1"),
   DATABASE_URL: z.string().min(1),
@@ -135,6 +136,15 @@ if (!parsed.success) {
 const isJestTest =
   typeof (globalThis as any).jest !== "undefined" ||
   process.env.JEST_WORKER_ID !== undefined;
+
+if (
+  parsed.data.WEBHOOK_SIGNATURE_BYPASS !== undefined &&
+  !["development", "test"].includes(parsed.data.NODE_ENV)
+) {
+  throw new Error(
+    "WEBHOOK_SIGNATURE_BYPASS must be unset in staging and production environments",
+  );
+}
 
 if (parsed.data.NODE_ENV === "production" && !isJestTest && !parsed.data.PRISMA_ACCELERATE_URL) {
   throw new Error("Missing required environment variable: PRISMA_ACCELERATE_URL");

--- a/src/controllers/webhookController.test.ts
+++ b/src/controllers/webhookController.test.ts
@@ -687,6 +687,29 @@ describe("webhookController", () => {
       );
     });
 
+    it("persists event_id and acknowledges a database duplicate", async () => {
+      (prisma.webhook.create as jest.Mock)
+        .mockResolvedValueOnce({ id: "wh-1" })
+        .mockRejectedValueOnce({ code: "P2002" });
+      const payload = { event: "charge.success", event_id: "paystack-event-1", data: {} };
+      const firstRes = makeRes();
+      const secondRes = makeRes();
+
+      await handlePaystackWebhook({ headers: {}, body: payload } as Request, firstRes, makeNext());
+      await handlePaystackWebhook({ headers: {}, body: payload } as Request, secondRes, makeNext());
+
+      expect(prisma.webhook.create).toHaveBeenNthCalledWith(
+        1,
+        expect.objectContaining({
+          data: expect.objectContaining({ eventId: "paystack-event-1" }),
+        }),
+      );
+      expect(secondRes.status).toHaveBeenCalledWith(200);
+      expect(secondRes.json).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "ok", duplicate: true }),
+      );
+    });
+
     it("calls next(error) when DB write fails", async () => {
       (prisma.webhook.create as jest.Mock).mockRejectedValue(new Error("DB error"));
       const next = makeNext();
@@ -742,6 +765,24 @@ describe("webhookController", () => {
           data: expect.objectContaining({ eventType: "CARD_TRANSACTION" }),
         }),
       );
+    });
+
+    it("acknowledges duplicate event_id values without logging them again", async () => {
+      (prisma.webhook.create as jest.Mock).mockRejectedValue({ code: "P2002" });
+      const next = makeNext();
+      const res = makeRes();
+
+      await handleFlutterwaveWebhook(
+        { headers: {}, body: { event_id: "flutterwave-event-1", data: {} } } as Request,
+        res,
+        next,
+      );
+
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith(
+        expect.objectContaining({ status: "ok", duplicate: true }),
+      );
+      expect(next).not.toHaveBeenCalled();
     });
 
     it("calls next(error) when DB write fails", async () => {

--- a/src/controllers/webhookController.ts
+++ b/src/controllers/webhookController.ts
@@ -23,13 +23,11 @@ import { reconcileBillsWebhook } from "../services/bills";
 import type { FinancialEventStatus } from "../types/logging";
 
 // ── Dev/stage mock bypass ────────────────────────────────────────────────────
-// When WEBHOOK_SIGNATURE_BYPASS=true AND NODE_ENV is not production,
-// signature verification is skipped entirely. This allows local development
-// and CI environments to send test payloads without real secrets.
-// Never set this variable in production — the boot guard in env.ts will
-// reject a missing secret before this code is even reached.
-const isDev = config.nodeEnv !== "production";
-const bypassEnabled = isDev && process.env.WEBHOOK_SIGNATURE_BYPASS === "true";
+// The bypass is deliberately limited to local/test environments. env.ts also
+// rejects this setting during startup for staging-facing deployments.
+const bypassEnabled =
+  ["development", "test"].includes(config.nodeEnv) &&
+  process.env.WEBHOOK_SIGNATURE_BYPASS === "true";
 
 // Maximum allowed clock drift in seconds between the webhook timestamp and server time.
 // Rejects replayed webhooks that fall outside this window. Default: 300 s (±5 min).
@@ -67,8 +65,27 @@ function isContentTypeJson(req: Request): boolean {
 if (bypassEnabled) {
   logger.warn(
     "WEBHOOK_SIGNATURE_BYPASS is enabled — webhook signature verification " +
-      "is DISABLED. This must never be set in production.",
+      "is DISABLED for development/test only. Do not use this setting in a staging-facing deployment.",
   );
+}
+
+function getWebhookEventId(payload: Record<string, unknown>): string | undefined {
+  const eventId = payload.event_id;
+  return typeof eventId === "string" && eventId.trim() ? eventId.trim() : undefined;
+}
+
+function isWebhookEventIdConflict(error: unknown): boolean {
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "code" in error &&
+    (error as { code?: unknown }).code === "P2002"
+  );
+}
+
+function sendDuplicateWebhookResponse(res: Response): void {
+  setFiatWebhookDeprecationHeaders(res);
+  res.status(200).json({ status: "ok", duplicate: true, deprecated: true });
 }
 
 // ── Flutterwave Webhook ──────────────────────────────────────────────────────
@@ -271,6 +288,7 @@ export async function handlePaystackWebhook(
     };
     const eventType = payload.event ?? "unknown";
     const data = payload.data ?? {};
+    const eventId = getWebhookEventId(payload as Record<string, unknown>);
     logger.warn("Paystack webhook received (deprecated path)", {
       eventType,
       reference: data.reference,
@@ -288,6 +306,23 @@ export async function handlePaystackWebhook(
     const paystackCorrelationId =
       (req.headers["x-request-id"] as string | undefined) ?? crypto.randomUUID();
 
+    try {
+      await prisma.webhook.create({
+        data: {
+          eventId,
+          eventType: `paystack:${String(eventType)}`,
+          payload: payload as object,
+          status: "processed",
+        },
+      });
+    } catch (error) {
+      if (eventId && isWebhookEventIdConflict(error)) {
+        sendDuplicateWebhookResponse(res);
+        return;
+      }
+      throw error;
+    }
+
     logFinancialEvent({
       event: "webhook.received",
       provider: "paystack",
@@ -295,18 +330,10 @@ export async function handlePaystackWebhook(
       transactionId: data.reference ?? paystackCorrelationId,
       userId: paystackCorrelationId,
       accountId: paystackCorrelationId,
-      idempotencyKey: data.reference ?? paystackCorrelationId,
+      idempotencyKey: eventId ?? data.reference ?? paystackCorrelationId,
       correlationId: paystackCorrelationId,
       amount: data.amount ?? 0,
       currency: data.currency ?? "NGN",
-    });
-
-    await prisma.webhook.create({
-      data: {
-        eventType: `paystack:${String(eventType)}`,
-        payload: payload as object,
-        status: "processed",
-      },
     });
 
     if (eventType === "charge.success" && data.status === "success") {
@@ -350,6 +377,7 @@ export async function handleFlutterwaveWebhook(
     };
     const eventType = payload.event ?? payload.type ?? "unknown";
     const data = payload.data ?? {};
+    const eventId = getWebhookEventId(payload as Record<string, unknown>);
     logger.warn("Flutterwave webhook received (deprecated path)", {
       eventType,
       tx_ref: data.tx_ref,
@@ -367,6 +395,23 @@ export async function handleFlutterwaveWebhook(
     const flwCorrelationId =
       (req.headers["x-request-id"] as string | undefined) ?? crypto.randomUUID();
 
+    try {
+      await prisma.webhook.create({
+        data: {
+          eventId,
+          eventType: String(eventType),
+          payload: payload as object,
+          status: "processed",
+        },
+      });
+    } catch (error) {
+      if (eventId && isWebhookEventIdConflict(error)) {
+        sendDuplicateWebhookResponse(res);
+        return;
+      }
+      throw error;
+    }
+
     logFinancialEvent({
       event: "webhook.received",
       provider: "flutterwave",
@@ -374,19 +419,11 @@ export async function handleFlutterwaveWebhook(
       transactionId: data.tx_ref ?? flwCorrelationId,
       userId: flwCorrelationId,
       accountId: flwCorrelationId,
-      idempotencyKey: data.tx_ref ?? flwCorrelationId,
+      idempotencyKey: eventId ?? data.tx_ref ?? flwCorrelationId,
       correlationId: flwCorrelationId,
       amount: data.amount ?? 0,
       currency: data.currency ?? "NGN",
       providerRef: data.flw_ref,
-    });
-
-    await prisma.webhook.create({
-      data: {
-        eventType: String(eventType),
-        payload: payload as object,
-        status: "processed",
-      },
     });
 
     if (eventType === "charge.completed" || data.status === "successful") {


### PR DESCRIPTION
## Summary
- Restricted WEBHOOK_SIGNATURE_BYPASS to explicit true in development/test.
Startup now rejects the variable when set in staging or production.
Added startup warning when bypass is active.
Restricted WEBHOOK_SIGNATURE_BYPASS to explicit true in development/test.
Startup now rejects the variable when set in staging or production.
Added startup warning when bypass is active.

## Scope
- [ ] Backend API behavior
- [ ] Build/CI only
- [ ] Docs only
- [ ] Other

## Validation
- [ ] `pnpm run build`
- [ ] `pnpm test`
- [ ] `pnpm lint`

## Links
- closes #785 
- Related PR(s): #

