### PR TITLE
Add missing refresh_tokens migration (#734)

### DIFF
--- a/prisma/migrations/20260827000000_add_refresh_tokens/migration.sql
+++ b/prisma/migrations/20260827000000_add_refresh_tokens/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE "refresh_tokens" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "user_id" UUID NOT NULL,
+    "token_family_id" UUID NOT NULL,
+    "token_hash" VARCHAR(255) NOT NULL,
+    "expires_at" TIMESTAMP(6) NOT NULL,
+    "revoked_at" TIMESTAMP(6),
+    "replaced_by_token" VARCHAR(255),
+    "created_at" TIMESTAMP(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "last_used_at" TIMESTAMP(6),
+
+    CONSTRAINT "refresh_tokens_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "refresh_tokens_token_hash_key" ON "refresh_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "idx_refresh_tokens_user_id" ON "refresh_tokens"("user_id");
+
+-- CreateIndex
+CREATE INDEX "idx_refresh_tokens_token_family_id" ON "refresh_tokens"("token_family_id");
+
+-- CreateIndex
+CREATE INDEX "idx_refresh_tokens_token_hash" ON "refresh_tokens"("token_hash");
+
+-- CreateIndex
+CREATE INDEX "idx_refresh_tokens_expires_at" ON "refresh_tokens"("expires_at");
+
+-- AddForeignKey
+ALTER TABLE "refresh_tokens" ADD CONSTRAINT "refresh_tokens_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/src/services/auth/refreshToken.test.ts
+++ b/src/services/auth/refreshToken.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for the refresh-token flow (issue #734).
+ *
+ * The RefreshToken Prisma model and these service functions already
+ * existed; the actual gap was that no migration had ever been written to
+ * create the `refresh_tokens` table (see
+ * prisma/migrations/20260827000000_add_refresh_tokens/migration.sql).
+ *
+ * These are unit tests against a mocked Prisma client - they verify the
+ * service logic (hashing, token-family rotation, audit logging) rather
+ * than exercising a real database. A real Postgres instance is required
+ * to validate the migration.sql itself applies cleanly; that should be
+ * covered by CI, which runs against an actual Postgres service.
+ */
+import {
+  issueRefreshToken,
+  refreshAccessToken,
+  revokeRefreshToken,
+} from "./authService";
+import { prisma } from "../../config/database";
+import { generateApiKey } from "../../middleware/auth";
+import { logAudit } from "../audit";
+
+jest.mock("../../config/database", () => ({
+  prisma: {
+    refreshToken: {
+      create: jest.fn(),
+      findFirst: jest.fn(),
+      updateMany: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../middleware/auth", () => ({
+  generateApiKey: jest.fn(),
+}));
+
+jest.mock("../audit", () => ({
+  logAudit: jest.fn().mockResolvedValue(undefined),
+}));
+
+// authService.ts imports config/rabbitmq at module scope (unrelated to the
+// refresh-token flow under test here). Mocking it avoids ts-jest compiling
+// the real file, which currently has a separate, already-tracked unused-
+// import bug (issue #715, PR #849 open) unrelated to this fix.
+jest.mock("../../config/rabbitmq", () => ({
+  getRabbitMQChannel: jest.fn(),
+  QUEUES: {
+    OTP_SEND: "otp_send",
+  },
+}));
+
+jest.mock("../../config/logger", () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    warn: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+describe("refresh token flow (#734)", () => {
+  const userId = "user-1";
+  const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("issueRefreshToken", () => {
+    it("creates a refresh token row and returns a token + expiry", async () => {
+      (prisma.refreshToken.create as jest.Mock).mockResolvedValue({});
+
+      const result = await issueRefreshToken({ userId });
+
+      expect(prisma.refreshToken.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            userId,
+            tokenHash: expect.stringMatching(SHA256_HEX),
+          }),
+        }),
+      );
+      expect(result.refresh_token).toEqual(expect.any(String));
+      expect(result.expires_at).toEqual(expect.any(String));
+      expect(logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: "refresh_token_issued",
+          performedBy: userId,
+        }),
+      );
+    });
+  });
+
+  describe("refreshAccessToken", () => {
+    const existingToken = {
+      id: "rt-1",
+      tokenFamilyId: "family-1",
+      user: { id: userId, actorType: "retail", organizationId: null },
+    };
+
+    it("rejects when no matching, unrevoked, unexpired token exists", async () => {
+      (prisma.refreshToken.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        refreshAccessToken({ refresh_token: "bogus" }),
+      ).rejects.toThrow("Invalid or expired refresh token");
+
+      expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
+      expect(generateApiKey).not.toHaveBeenCalled();
+    });
+
+    it("rotates the whole token family and issues a new token + api key", async () => {
+      (prisma.refreshToken.findFirst as jest.Mock).mockResolvedValue(
+        existingToken,
+      );
+      (prisma.refreshToken.updateMany as jest.Mock).mockResolvedValue({
+        count: 1,
+      });
+      (prisma.refreshToken.create as jest.Mock).mockResolvedValue({});
+      (generateApiKey as jest.Mock).mockResolvedValue("new-api-key");
+
+      const result = await refreshAccessToken({
+        refresh_token: "old-refresh-token",
+      });
+
+      // The old family must be fully revoked, not just the one token used.
+      expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tokenFamilyId: existingToken.tokenFamilyId,
+            revokedAt: null,
+          }),
+          data: expect.objectContaining({ revokedAt: expect.any(Date) }),
+        }),
+      );
+
+      // A brand new token in a brand new family is issued.
+      expect(prisma.refreshToken.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ userId }),
+        }),
+      );
+      const createCallFamilyId = (prisma.refreshToken.create as jest.Mock).mock
+        .calls[0][0].data.tokenFamilyId;
+      expect(createCallFamilyId).not.toEqual(existingToken.tokenFamilyId);
+
+      expect(result.api_key).toBe("new-api-key");
+      expect(result.user_id).toBe(userId);
+      expect(logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "refresh_token_rotated" }),
+      );
+    });
+  });
+
+  describe("revokeRefreshToken", () => {
+    it("rejects when the token is already revoked or unknown", async () => {
+      (prisma.refreshToken.findFirst as jest.Mock).mockResolvedValue(null);
+
+      await expect(
+        revokeRefreshToken({ refresh_token: "bogus" }),
+      ).rejects.toThrow("Invalid refresh token");
+
+      expect(prisma.refreshToken.updateMany).not.toHaveBeenCalled();
+    });
+
+    it("revokes every token in the family, not just the one presented", async () => {
+      (prisma.refreshToken.findFirst as jest.Mock).mockResolvedValue({
+        id: "rt-1",
+        tokenFamilyId: "family-1",
+        user: { id: userId, actorType: "retail", organizationId: null },
+      });
+      (prisma.refreshToken.updateMany as jest.Mock).mockResolvedValue({
+        count: 2,
+      });
+
+      const result = await revokeRefreshToken({
+        refresh_token: "some-token",
+      });
+
+      expect(result).toEqual({ ok: true });
+      expect(prisma.refreshToken.updateMany).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: expect.objectContaining({
+            tokenFamilyId: "family-1",
+            revokedAt: null,
+          }),
+        }),
+      );
+      expect(logAudit).toHaveBeenCalledWith(
+        expect.objectContaining({ action: "refresh_token_revoked" }),
+      );
+    });
+  });
+});


### PR DESCRIPTION
Closes #734
Closes #730

Dug into this one and the actual gap was narrower than the issue title suggests. The RefreshToken Prisma model already exists in schema.prisma, and issueRefreshToken/refreshAccessToken/revokeRefreshToken (the functions from W2-B-006) already exist in authService.ts, fully implemented. What was actually missing was the migration itself - checked every file in prisma/migrations, none of them ever created the refresh_tokens table, so the model existed on paper but the table never got created in the database.

Added the migration, matching the schema fields and following the same conventions as the other migrations in this repo (naming, FK style, indexes).

Also added tests for the refresh flow since there weren't any - issuing a token, rejecting invalid/expired ones, rotating the whole token family on refresh (not just the one token used), and revoking the whole family on logout.

Couldn't spin up a real Postgres in my environment to apply the migration against a live database, so these are unit tests against a mocked Prisma client rather than a true integration test - that part should get exercised by CI if it runs against a real database.

Ran the existing authService.test.ts alongside these to make sure nothing regressed, all green.

Separately, unrelated to this PR: found two bugs in src/config/env.ts on main that crash the whole app/test suite on boot right now (isPlaceholderKey is called but never defined, and TESTNET_CUSTODIAL_BOOTSTRAP is accessed without being in the validation schema, so it's always undefined). Not touching that here since it's a different area entirely, but flagging it since it looks like it'd currently block CI for everyone.