### PR TITLE
fix(fiatController): correct account_name copy-paste bug

### DIFF
--- a/src/controllers/fiatController.ts
+++ b/src/controllers/fiatController.ts
@@ -41,7 +41,7 @@ function serializeFiatAccount(acc: FiatAccountView) {
     usd_equivalent: acc.usd_equivalent,
     bank_name: acc.bank_name,
     account_number: acc.account_number,
-    account_name: acc.account_number,
+    account_name: acc.account_name,
     ledger_entries: acc.ledger_entries,
   };
 }


### PR DESCRIPTION
## Summary

Fixes a copy-paste bug in `serializeFiatAccount()` in `src/controllers/fiatController.ts`.

`account_name` was being set to `acc.account_number` instead of `acc.account_name`, causing the API to return the account number in both fields and never expose the actual account name.

**Change:**
```diff
- account_name: acc.account_number,
+ account_name: acc.account_name,
```

Closes #567